### PR TITLE
Remove 'ocisConfig' struct tag leftovers

### DIFF
--- a/services/eventhistory/pkg/config/config.go
+++ b/services/eventhistory/pkg/config/config.go
@@ -30,8 +30,8 @@ type Config struct {
 
 // GRPCConfig defines the available grpc configuration.
 type GRPCConfig struct {
-	Addr      string                 `ocisConfig:"addr" env:"EVENTHISTORY_GRPC_ADDR" desc:"The bind address of the GRPC service." introductionVersion:"pre5.0"`
-	Namespace string                 `ocisConfig:"-" yaml:"-"`
+	Addr      string                 `yaml:"addr" env:"EVENTHISTORY_GRPC_ADDR" desc:"The bind address of the GRPC service." introductionVersion:"pre5.0"`
+	Namespace string                 `yaml:"-"`
 	TLS       *shared.GRPCServiceTLS `yaml:"tls"`
 }
 

--- a/services/ocm/pkg/config/config.go
+++ b/services/ocm/pkg/config/config.go
@@ -76,8 +76,8 @@ type CORS struct {
 
 // GRPCConfig defines the available grpc configuration.
 type GRPCConfig struct {
-	Addr      string                 `ocisConfig:"addr" env:"OCM_GRPC_ADDR" desc:"The bind address of the GRPC service." introductionVersion:"5.0"`
-	Namespace string                 `ocisConfig:"-" yaml:"-"`
+	Addr      string                 `yaml:"addr" env:"OCM_GRPC_ADDR" desc:"The bind address of the GRPC service." introductionVersion:"5.0"`
+	Namespace string                 `yaml:"-"`
 	TLS       *shared.GRPCServiceTLS `yaml:"tls"`
 	Protocol  string                 `yaml:"protocol" env:"OC_GRPC_PROTOCOL;OCM_GRPC_PROTOCOL" desc:"The transport protocol of the GRPC service." introductionVersion:"5.0"`
 }

--- a/services/policies/pkg/config/config.go
+++ b/services/policies/pkg/config/config.go
@@ -29,8 +29,8 @@ type Service struct {
 
 // GRPC defines the available grpc configuration.
 type GRPC struct {
-	Addr      string                 `ocisConfig:"addr" env:"POLICIES_GRPC_ADDR" desc:"The bind address of the GRPC service." introductionVersion:"pre5.0"`
-	Namespace string                 `ocisConfig:"-" yaml:"-"`
+	Addr      string                 `yaml:"addr" env:"POLICIES_GRPC_ADDR" desc:"The bind address of the GRPC service." introductionVersion:"pre5.0"`
+	Namespace string                 `yaml:"-"`
 	TLS       *shared.GRPCServiceTLS `yaml:"tls"`
 }
 

--- a/services/search/pkg/config/debug.go
+++ b/services/search/pkg/config/debug.go
@@ -2,8 +2,8 @@ package config
 
 // Debug defines the available debug configuration.
 type Debug struct {
-	Addr   string `ocisConfig:"addr" env:"SEARCH_DEBUG_ADDR" desc:"Bind address of the debug server, where metrics, health, config and debug endpoints will be exposed." introductionVersion:"pre5.0"`
-	Token  string `ocisConfig:"token" env:"SEARCH_DEBUG_TOKEN" desc:"Token to secure the metrics endpoint." introductionVersion:"pre5.0"`
-	Pprof  bool   `ocisConfig:"pprof" env:"SEARCH_DEBUG_PPROF" desc:"Enables pprof, which can be used for profiling." introductionVersion:"pre5.0"`
-	Zpages bool   `ocisConfig:"zpages" env:"SEARCH_DEBUG_ZPAGES" desc:"Enables zpages, which can be used for collecting and viewing in-memory traces." introductionVersion:"pre5.0"`
+	Addr   string `yaml:"addr" env:"SEARCH_DEBUG_ADDR" desc:"Bind address of the debug server, where metrics, health, config and debug endpoints will be exposed." introductionVersion:"pre5.0"`
+	Token  string `yaml:"token" env:"SEARCH_DEBUG_TOKEN" desc:"Token to secure the metrics endpoint." introductionVersion:"pre5.0"`
+	Pprof  bool   `yaml:"pprof" env:"SEARCH_DEBUG_PPROF" desc:"Enables pprof, which can be used for profiling." introductionVersion:"pre5.0"`
+	Zpages bool   `yaml:"zpages" env:"SEARCH_DEBUG_ZPAGES" desc:"Enables zpages, which can be used for collecting and viewing in-memory traces." introductionVersion:"pre5.0"`
 }

--- a/services/search/pkg/config/grpc.go
+++ b/services/search/pkg/config/grpc.go
@@ -4,7 +4,7 @@ import "github.com/opencloud-eu/opencloud/pkg/shared"
 
 // GRPCConfig defines the available grpc configuration.
 type GRPCConfig struct {
-	Addr      string                 `ocisConfig:"addr" env:"SEARCH_GRPC_ADDR" desc:"The bind address of the GRPC service." introductionVersion:"pre5.0"`
-	Namespace string                 `ocisConfig:"-" yaml:"-"`
+	Addr      string                 `yaml:"addr" env:"SEARCH_GRPC_ADDR" desc:"The bind address of the GRPC service." introductionVersion:"pre5.0"`
+	Namespace string                 `yaml:"-"`
 	TLS       *shared.GRPCServiceTLS `yaml:"tls"`
 }

--- a/services/search/pkg/config/service.go
+++ b/services/search/pkg/config/service.go
@@ -2,5 +2,5 @@ package config
 
 // Service defines the available service configuration.
 type Service struct {
-	Name string `ocisConfig:"-" yaml:"-"`
+	Name string `yaml:"-"`
 }

--- a/services/search/pkg/config/tracing.go
+++ b/services/search/pkg/config/tracing.go
@@ -4,10 +4,10 @@ import "github.com/opencloud-eu/opencloud/pkg/tracing"
 
 // Tracing defines the available tracing configuration.
 type Tracing struct {
-	Enabled   bool   `ocisConfig:"enabled" env:"OC_TRACING_ENABLED;SEARCH_TRACING_ENABLED" desc:"Activates tracing." introductionVersion:"pre5.0"`
-	Type      string `ocisConfig:"type" env:"OC_TRACING_TYPE;SEARCH_TRACING_TYPE" desc:"The type of tracing. Defaults to '', which is the same as 'jaeger'. Allowed tracing types are 'jaeger' and '' as of now." introductionVersion:"pre5.0"`
-	Endpoint  string `ocisConfig:"endpoint" env:"OC_TRACING_ENDPOINT;SEARCH_TRACING_ENDPOINT" desc:"The endpoint of the tracing agent." introductionVersion:"pre5.0"`
-	Collector string `ocisConfig:"collector" env:"OC_TRACING_COLLECTOR;SEARCH_TRACING_COLLECTOR" desc:"The HTTP endpoint for sending spans directly to a collector, i.e. http://jaeger-collector:14268/api/traces. Only used if the tracing endpoint is unset." introductionVersion:"pre5.0"`
+	Enabled   bool   `yaml:"enabled" env:"OC_TRACING_ENABLED;SEARCH_TRACING_ENABLED" desc:"Activates tracing." introductionVersion:"pre5.0"`
+	Type      string `yaml:"type" env:"OC_TRACING_TYPE;SEARCH_TRACING_TYPE" desc:"The type of tracing. Defaults to '', which is the same as 'jaeger'. Allowed tracing types are 'jaeger' and '' as of now." introductionVersion:"pre5.0"`
+	Endpoint  string `yaml:"endpoint" env:"OC_TRACING_ENDPOINT;SEARCH_TRACING_ENDPOINT" desc:"The endpoint of the tracing agent." introductionVersion:"pre5.0"`
+	Collector string `yaml:"collector" env:"OC_TRACING_COLLECTOR;SEARCH_TRACING_COLLECTOR" desc:"The HTTP endpoint for sending spans directly to a collector, i.e. http://jaeger-collector:14268/api/traces. Only used if the tracing endpoint is unset." introductionVersion:"pre5.0"`
 }
 
 // Convert Tracing to the tracing package's Config struct.


### PR DESCRIPTION
Support the 'ocisConfig' tag was removed long time ago with commit 1232f26fe4d50174cce99a0cc64e30debb9f1f6e

