### PR TITLE
Rebrand default IDP clients

### DIFF
--- a/services/idp/pkg/config/defaults/defaultconfig.go
+++ b/services/idp/pkg/config/defaults/defaultconfig.go
@@ -107,7 +107,7 @@ func DefaultConfig() *config.Config {
 				Name:            "OpenCloud iOS app",
 				ApplicationType: "native",
 				RedirectURIs: []string{
-					"oc://ios.opencloud.com",
+					"oc://ios.opencloud.eu",
 				},
 			},
 		},


### PR DESCRIPTION
Change default client ids and remove secrets. Desktop is a public client now. Let's assume we'll turn Android and IOS into public clients as well for now.