### PR TITLE
Fix pnpm.lock

### DIFF
--- a/services/idp/pnpm-lock.yaml
+++ b/services/idp/pnpm-lock.yaml
@@ -2458,9 +2458,6 @@ packages:
   core-js@3.40.0:
     resolution: {integrity: sha512-7vsMc/Lty6AGnn7uFpYT56QesI5D2Y/UkgKounk87OP9Z2H9Z8kj6jzcSGAxFmUtDOS0ntK6lbQz+Nsa0Jj6mQ==}
 
-  core-js@3.40.0:
-    resolution: {integrity: sha512-7vsMc/Lty6AGnn7uFpYT56QesI5D2Y/UkgKounk87OP9Z2H9Z8kj6jzcSGAxFmUtDOS0ntK6lbQz+Nsa0Jj6mQ==}
-
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
@@ -9400,8 +9397,6 @@ snapshots:
       browserslist: 4.23.2
 
   core-js-pure@3.37.1: {}
-
-  core-js@3.40.0: {}
 
   core-js@3.40.0: {}
 


### PR DESCRIPTION
A recent merge (https://github.com/opencloud-eu/opencloud/commit/82fa07c003f49399b489c2470f94ab543845603d#diff-23452924f82708e68e91b0de245f2203aedfa241985651855565d0e69dbb4b84R76) seem to have broke something. I am getting this:

```
# make -C services/idp generate
make: Entering directory '/work/opencloud/services/idp'
pnpm install
 WARN  Ignoring broken lockfile at /work/opencloud/services/idp: The lockfile at "/work/opencloud/services/idp/pnpm-lock.yaml" is broken: duplicated mapping key (2461:3)

 2458 |   core-js@3.40.0:
 2459 |     resolution: {integrity: sha5 ...
 2460 | 
 2461 |   core-js@3.40.0:
----------^
 2462 |     resolution: {integrity: sha5 ...
 2463 | 

```
