### PR TITLE
drop project reference in testsuite headers, copyright and license re…

### DIFF
--- a/tests/acceptance/TestHelpers/Asserts/WebDav.php
+++ b/tests/acceptance/TestHelpers/Asserts/WebDav.php
@@ -1,7 +1,5 @@
 <?php declare(strict_types=1);
 /**
- * ownCloud
- *
  * @author Artur Neumann <artur@jankaritech.com>
  * @copyright Copyright (c) 2018 Artur Neumann artur@jankaritech.com
  *

--- a/tests/acceptance/TestHelpers/AuthAppHelper.php
+++ b/tests/acceptance/TestHelpers/AuthAppHelper.php
@@ -1,7 +1,5 @@
 <?php declare(strict_types=1);
 /**
- * ownCloud
- *
  * @author Niraj Acharya <niraj@jankaritech.com>
  * @copyright Copyright (c) 2024 Niraj Acharya niraj@jankaritech.com
  *

--- a/tests/acceptance/TestHelpers/BehatHelper.php
+++ b/tests/acceptance/TestHelpers/BehatHelper.php
@@ -1,7 +1,5 @@
 <?php declare(strict_types=1);
 /**
- * ownCloud
- *
  * @author Sajan Gurung <sajan@jankaritech.com>
  * @copyright Copyright (c) 2017 Artur Neumann artur@jankaritech.com
  *

--- a/tests/acceptance/TestHelpers/CliHelper.php
+++ b/tests/acceptance/TestHelpers/CliHelper.php
@@ -1,7 +1,5 @@
 <?php declare(strict_types=1);
 /**
- * ownCloud
- *
  * @author Sajan Gurung <sajan@jankaritech.com>
  * @copyright Copyright (c) 2024 Sajan Gurung sajan@jankaritech.com
  *

--- a/tests/acceptance/TestHelpers/CollaborationHelper.php
+++ b/tests/acceptance/TestHelpers/CollaborationHelper.php
@@ -1,7 +1,5 @@
 <?php declare(strict_types=1);
 /**
- * ownCloud
- *
  * @author Amrita Shrestha <amrita@jankaritech.com>
  * @copyright Copyright (c) 2024 Amrita Shrestha amrita@jankaritech.com
  *

--- a/tests/acceptance/TestHelpers/EmailHelper.php
+++ b/tests/acceptance/TestHelpers/EmailHelper.php
@@ -1,7 +1,5 @@
 <?php declare(strict_types=1);
 /**
- * ownCloud
- *
  * @author Prajwol Amatya <prajwol@jankaritech.com>
  * @copyright Copyright (c) 2023 Prajwol Amatya prajwol@jankaritech.com
  *

--- a/tests/acceptance/TestHelpers/GraphHelper.php
+++ b/tests/acceptance/TestHelpers/GraphHelper.php
@@ -1,7 +1,5 @@
 <?php declare(strict_types=1);
 /**
- * ownCloud
- *
  * @author Kiran Parajuli <kiran@jankaritech.com>
  * @copyright Copyright (c) 2022 Kiran Parajuli kiran@jankaritech.com
  *

--- a/tests/acceptance/TestHelpers/HttpLogger.php
+++ b/tests/acceptance/TestHelpers/HttpLogger.php
@@ -1,7 +1,5 @@
 <?php declare(strict_types=1);
 /**
- * ownCloud
- *
  * @author Sajan Gurung <sajan@jankaritech.com>
  * @copyright Copyright (c) 2023, ownCloud GmbH
  *

--- a/tests/acceptance/TestHelpers/HttpRequestHelper.php
+++ b/tests/acceptance/TestHelpers/HttpRequestHelper.php
@@ -1,7 +1,5 @@
 <?php declare(strict_types=1);
 /**
- * ownCloud
- *
  * @author Artur Neumann <artur@jankaritech.com>
  * @copyright Copyright (c) 2017 Artur Neumann artur@jankaritech.com
  *

--- a/tests/acceptance/TestHelpers/OcConfigHelper.php
+++ b/tests/acceptance/TestHelpers/OcConfigHelper.php
@@ -1,7 +1,5 @@
 <?php declare(strict_types=1);
 /**
- * ownCloud
- *
  * @author Sajan Gurung <sajan@jankaritech.com>
  * @copyright Copyright (c) 2023 Sajan Gurung sajan@jankaritech.com
  *

--- a/tests/acceptance/TestHelpers/OcHelper.php
+++ b/tests/acceptance/TestHelpers/OcHelper.php
@@ -1,7 +1,5 @@
 <?php declare(strict_types=1);
 /**
- * ownCloud
- *
  * @author    Artur Neumann <artur@jankaritech.com>
  * @copyright Copyright (c) 2020 Artur Neumann artur@jankaritech.com
  *

--- a/tests/acceptance/TestHelpers/OcmHelper.php
+++ b/tests/acceptance/TestHelpers/OcmHelper.php
@@ -1,7 +1,5 @@
 <?php declare(strict_types=1);
 /**
- * ownCloud
- *
  * @author Viktor Scharf <scharf.vi@gmail.com>
  * @copyright Copyright (c) 2024 Viktor Scharf <scharf.vi@gmail.com>
  *

--- a/tests/acceptance/TestHelpers/OcsApiHelper.php
+++ b/tests/acceptance/TestHelpers/OcsApiHelper.php
@@ -1,7 +1,5 @@
 <?php declare(strict_types=1);
 /**
- * ownCloud
- *
  * @author Artur Neumann <artur@jankaritech.com>
  * @copyright Copyright (c) 2017 Artur Neumann artur@jankaritech.com
  *

--- a/tests/acceptance/TestHelpers/SettingsHelper.php
+++ b/tests/acceptance/TestHelpers/SettingsHelper.php
@@ -1,7 +1,5 @@
 <?php declare(strict_types=1);
 /**
- * ownCloud
- *
  * @author Sajan Gurung <sajan@jankaritech.com>
  * @copyright Copyright (c) 2024 Sajan Gurung sajan@jankaritech.com
  *

--- a/tests/acceptance/TestHelpers/SetupHelper.php
+++ b/tests/acceptance/TestHelpers/SetupHelper.php
@@ -1,7 +1,5 @@
 <?php declare(strict_types=1);
 /**
- * ownCloud
- *
  * @author Artur Neumann <artur@jankaritech.com>
  * @copyright Copyright (c) 2017 Artur Neumann artur@jankaritech.com
  *

--- a/tests/acceptance/TestHelpers/SharingHelper.php
+++ b/tests/acceptance/TestHelpers/SharingHelper.php
@@ -1,7 +1,5 @@
 <?php declare(strict_types=1);
 /**
- * ownCloud
- *
  * @author Artur Neumann <artur@jankaritech.com>
  * @copyright Copyright (c) 2017 Artur Neumann artur@jankaritech.com
  *

--- a/tests/acceptance/TestHelpers/TranslationHelper.php
+++ b/tests/acceptance/TestHelpers/TranslationHelper.php
@@ -1,7 +1,5 @@
 <?php declare(strict_types=1);
 /**
- * ownCloud
- *
  * @author Talank Baral <talank@jankaritech.com>
  * @copyright Copyright (c) 2021 Talank Baral talank@jankaritech.com
  *

--- a/tests/acceptance/TestHelpers/UploadHelper.php
+++ b/tests/acceptance/TestHelpers/UploadHelper.php
@@ -1,7 +1,5 @@
 <?php declare(strict_types=1);
 /**
- * ownCloud
- *
  * @author Artur Neumann <artur@jankaritech.com>
  * @copyright Copyright (c) 2017 Artur Neumann artur@jankaritech.com
  *

--- a/tests/acceptance/TestHelpers/UserHelper.php
+++ b/tests/acceptance/TestHelpers/UserHelper.php
@@ -1,7 +1,5 @@
 <?php declare(strict_types=1);
 /**
- * ownCloud
- *
  * @author Artur Neumann <artur@jankaritech.com>
  * @copyright Copyright (c) 2017 Artur Neumann artur@jankaritech.com
  *

--- a/tests/acceptance/TestHelpers/WebDavHelper.php
+++ b/tests/acceptance/TestHelpers/WebDavHelper.php
@@ -1,7 +1,5 @@
 <?php declare(strict_types=1);
 /**
- * ownCloud
- *
  * @author Artur Neumann <artur@jankaritech.com>
  * @copyright Copyright (c) 2017 Artur Neumann artur@jankaritech.com
  *

--- a/tests/acceptance/bootstrap/ArchiverContext.php
+++ b/tests/acceptance/bootstrap/ArchiverContext.php
@@ -1,7 +1,5 @@
 <?php declare(strict_types=1);
 /**
- * ownCloud
- *
  * @author Artur Neumann <artur@jankaritech.com>
  * @copyright Copyright (c) 2021 Artur Neumann artur@jankaritech.com
  *

--- a/tests/acceptance/bootstrap/AuthAppContext.php
+++ b/tests/acceptance/bootstrap/AuthAppContext.php
@@ -1,7 +1,5 @@
 <?php declare(strict_types=1);
 /**
- * ownCloud
- *
  * @author Niraj Acharya <niraj@jankaritech.com>
  * @copyright Copyright (c) 2024 Niraj Acharya niraj@jankaritech.com
  *

--- a/tests/acceptance/bootstrap/CapabilitiesContext.php
+++ b/tests/acceptance/bootstrap/CapabilitiesContext.php
@@ -1,7 +1,5 @@
 <?php declare(strict_types=1);
 /**
- * ownCloud
- *
  * @author Joas Schilling <coding@schilljs.com>
  * @author Sergio Bertolin <sbertolin@owncloud.com>
  * @author Phillip Davis <phil@jankaritech.com>

--- a/tests/acceptance/bootstrap/CliContext.php
+++ b/tests/acceptance/bootstrap/CliContext.php
@@ -1,7 +1,5 @@
 <?php declare(strict_types=1);
 /**
- * ownCloud
- *
  * @author Sajan Gurung <sajan@jankaritech.com>
  * @copyright Copyright (c) 2024 Sajan Gurung sajan@jankaritech.com
  *

--- a/tests/acceptance/bootstrap/CollaborationContext.php
+++ b/tests/acceptance/bootstrap/CollaborationContext.php
@@ -1,7 +1,5 @@
 <?php declare(strict_types=1);
 /**
- * ownCloud
- *
  * @author Amrita Shrestha <amrita@jankaritech.com>
  * @copyright Copyright (c) 2024 Amrita Shrestha <amrita@jankaritech.com>
  *

--- a/tests/acceptance/bootstrap/FavoritesContext.php
+++ b/tests/acceptance/bootstrap/FavoritesContext.php
@@ -1,7 +1,5 @@
 <?php declare(strict_types=1);
 /**
- * ownCloud
- *
  * @author Artur Neumann <artur@jankaritech.com>
  * @copyright Copyright (c) 2018 Artur Neumann artur@jankaritech.com
  *

--- a/tests/acceptance/bootstrap/FeatureContext.php
+++ b/tests/acceptance/bootstrap/FeatureContext.php
@@ -1,8 +1,6 @@
 <?php declare(strict_types=1);
 
 /**
- * ownCloud
- *
  * @author Sergio Bertolin <sbertolin@owncloud.com>
  * @author Phillip Davis <phil@jankaritech.com>
  * @copyright Copyright (c) 2018, ownCloud GmbH

--- a/tests/acceptance/bootstrap/FilesVersionsContext.php
+++ b/tests/acceptance/bootstrap/FilesVersionsContext.php
@@ -1,7 +1,5 @@
 <?php declare(strict_types=1);
 /**
- * ownCloud
- *
  * @author Artur Neumann <artur@jankaritech.com>
  * @copyright Copyright (c) 2018, ownCloud GmbH
  *

--- a/tests/acceptance/bootstrap/GraphContext.php
+++ b/tests/acceptance/bootstrap/GraphContext.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 /**
- * ownCloud
- *
  * @author Kiran Parajuli <kiran@jankaritech.com>
  * @copyright Copyright (c) 2021 Kiran Parajuli kiran@jankaritech.com
  */

--- a/tests/acceptance/bootstrap/NotificationContext.php
+++ b/tests/acceptance/bootstrap/NotificationContext.php
@@ -1,7 +1,5 @@
 <?php declare(strict_types=1);
 /**
- * ownCloud
- *
  * @author Viktor Scharf <vscharf@owncloud.com>
  * @copyright Copyright (c) 2023 Viktor Scharf vscharf@owncloud.com
  */

--- a/tests/acceptance/bootstrap/OCSContext.php
+++ b/tests/acceptance/bootstrap/OCSContext.php
@@ -1,7 +1,5 @@
 <?php declare(strict_types=1);
 /**
- * ownCloud
- *
  * @author Artur Neumann <artur@jankaritech.com>
  * @copyright Copyright (c) 2019, ownCloud GmbH
  *

--- a/tests/acceptance/bootstrap/OcConfigContext.php
+++ b/tests/acceptance/bootstrap/OcConfigContext.php
@@ -1,7 +1,5 @@
 <?php declare(strict_types=1);
 /**
- * ownCloud
- *
  * @author Sajan Gurung <sajan@jankaritech.com>
  * @copyright Copyright (c) 2023 Sajan Gurung sajan@jankaritech.com
  *

--- a/tests/acceptance/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/bootstrap/PublicWebDavContext.php
@@ -1,7 +1,5 @@
 <?php declare(strict_types=1);
 /**
- * ownCloud
- *
  * @author Artur Neumann <artur@jankaritech.com>
  * @copyright Copyright (c) 2018, ownCloud GmbH
  *

--- a/tests/acceptance/bootstrap/SearchContext.php
+++ b/tests/acceptance/bootstrap/SearchContext.php
@@ -1,7 +1,5 @@
 <?php declare(strict_types=1);
 /**
- * ownCloud
- *
  * @author Artur Neumann <artur@jankaritech.com>
  * @copyright Copyright (c) 2018 Artur Neumann artur@jankaritech.com
  *

--- a/tests/acceptance/bootstrap/SettingsContext.php
+++ b/tests/acceptance/bootstrap/SettingsContext.php
@@ -3,8 +3,6 @@
 declare(strict_types=1);
 
 /**
- * ownCloud
- *
  * @author Viktor Scharf <v.scharf@owncloud.com>
  * @copyright Copyright (c) 2022 Viktor Scharf v.scharf@owncloud.com
  */

--- a/tests/acceptance/bootstrap/ShareesContext.php
+++ b/tests/acceptance/bootstrap/ShareesContext.php
@@ -1,7 +1,5 @@
 <?php declare(strict_types=1);
 /**
- * ownCloud
- *
  * @author Joas Schilling <coding@schilljs.com>
  * @author Sergio Bertolin <sbertolin@owncloud.com>
  * @author Phillip Davis <phil@jankaritech.com>

--- a/tests/acceptance/bootstrap/Sharing.php
+++ b/tests/acceptance/bootstrap/Sharing.php
@@ -1,7 +1,5 @@
 <?php declare(strict_types=1);
 /**
- * ownCloud
- *
  * @author Joas Schilling <coding@schilljs.com>
  * @author Sergio Bertolin <sbertolin@owncloud.com>
  * @author Phillip Davis <phil@jankaritech.com>

--- a/tests/acceptance/bootstrap/SpacesContext.php
+++ b/tests/acceptance/bootstrap/SpacesContext.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 /**
- * ownCloud
- *
  * @author Michael Barz <mbarz@owncloud.com>
  * @copyright Copyright (c) 2021 Michael Barz mbarz@owncloud.com
  *

--- a/tests/acceptance/bootstrap/SpacesTUSContext.php
+++ b/tests/acceptance/bootstrap/SpacesTUSContext.php
@@ -3,8 +3,6 @@
 declare(strict_types=1);
 
 /**
- * ownCloud
- *
  * @author Viktor Scharf <v.scharf@owncloud.com>
  * @copyright Copyright (c) 2022 Viktor Scharf v.scharf@owncloud.com
  */

--- a/tests/acceptance/bootstrap/WebDavLockingContext.php
+++ b/tests/acceptance/bootstrap/WebDavLockingContext.php
@@ -1,7 +1,5 @@
 <?php declare(strict_types=1);
 /**
- * ownCloud
- *
  * @author Artur Neumann <artur@jankaritech.com>
  * @copyright Copyright (c) 2018 Artur Neumann artur@jankaritech.com
  *

--- a/tests/acceptance/bootstrap/WebDavPropertiesContext.php
+++ b/tests/acceptance/bootstrap/WebDavPropertiesContext.php
@@ -1,7 +1,5 @@
 <?php declare(strict_types=1);
 /**
- * ownCloud
- *
  * @author Artur Neumann <artur@jankaritech.com>
  * @copyright Copyright (c) 2019, ownCloud GmbH
  *

--- a/tests/acceptance/bootstrap/bootstrap.php
+++ b/tests/acceptance/bootstrap/bootstrap.php
@@ -1,8 +1,6 @@
 <?php declare(strict_types=1);
 
 /**
- * ownCloud
- *
  * @author Phil Davis <phil@jankaritech.com>
  * @copyright Copyright (c) 2020 Phil Davis phil@jankaritech.com
  *


### PR DESCRIPTION
As discussed, we will drop the old name in the testsuite file headers.

Sidenote: some files in the testsuite are actually AGPL. I vote for moving to REUSE and properly rewrite the headers.