### PR TITLE
chore(idp): pin pnpm version in package.json

### DIFF
--- a/services/idp/package.json
+++ b/services/idp/package.json
@@ -154,6 +154,7 @@
     "webpack-manifest-plugin": "5.0.0",
     "workbox-webpack-plugin": "7.1.0"
   },
+  "packageManager": "pnpm@9.15.4",
   "pnpm": {
     "overrides": {
       "kpop>cldr": ""


### PR DESCRIPTION
This prevents corepack from altering the `package.json` file on install and has the added benefit of keeping things up to date in combination with renovate.
