### PR TITLE
use vanilla version of LICENCE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,8 +187,8 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2020 ownCloud GmbH
-   
+   Copyright [yyyy] [name of copyright owner]
+
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at


### PR DESCRIPTION
This replaces the LICENSE with the vanilla https://www.apache.org/licenses/LICENSE-2.0.txt license file.