### PR TITLE
fix(web): logo upload

### DIFF
--- a/services/web/pkg/theme/service.go
+++ b/services/web/pkg/theme/service.go
@@ -144,9 +144,8 @@ func (s Service) LogoUpload(w http.ResponseWriter, r *http.Request) {
 	}
 
 	err = UpdateKV(s.themeFS, filepathx.JailJoin(_brandingRoot, _themeFileName), KV{
-		"common.logo":                      filepathx.JailJoin("themes", fp),
-		"clients.web.defaults.logo.topbar": filepathx.JailJoin("themes", fp),
-		"clients.web.defaults.logo.login":  filepathx.JailJoin("themes", fp),
+		"common.logo":               filepathx.JailJoin("themes", fp),
+		"clients.web.defaults.logo": filepathx.JailJoin("themes", fp),
 	})
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
@@ -184,9 +183,8 @@ func (s Service) LogoReset(w http.ResponseWriter, r *http.Request) {
 	}
 
 	err = UpdateKV(s.themeFS, filepathx.JailJoin(_brandingRoot, _themeFileName), KV{
-		"common.logo":                      nil,
-		"clients.web.defaults.logo.topbar": nil,
-		"clients.web.defaults.logo.login":  nil,
+		"common.logo":               nil,
+		"clients.web.defaults.logo": nil,
 	})
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
## Description
Logo upload broke when we changed the theme scheme, see https://github.com/opencloud-eu/opencloud/pull/165 and https://github.com/opencloud-eu/web/pull/40
Just needed to update some keys for making the logo upload and reset work again.

## Related Issue
- Fixes https://github.com/opencloud-eu/opencloud/issues/203

## How Has This Been Tested?
- ✋ 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)
