### PR TITLE
fix: docker image names

### DIFF
--- a/deployments/continuous-deployment-config/opencloud_full/master.yml
+++ b/deployments/continuous-deployment-config/opencloud_full/master.yml
@@ -28,7 +28,7 @@
           INSECURE: "false"
           TRAEFIK_ACME_MAIL: devops@opencloud.eu
           OC_DOCKER_TAG: main
-          OC_DOCKER_IMAGE: opencloud-eu/opencloud-rolling:main
+          OC_DOCKER_IMAGE: opencloudeu/opencloud-rolling:latest
           OC_DOMAIN: cloud.main.opencloud.rocks
           COMPANION_DOMAIN: companion.main.opencloud.rocks
           COMPANION_IMAGE: transloadit/companion:5.5.0

--- a/deployments/examples/opencloud_full/.env
+++ b/deployments/examples/opencloud_full/.env
@@ -36,13 +36,13 @@ TRAEFIK_ACME_CASERVER=
 # Note: the leading colon is required to enable the service.
 OPENCLOUD=:opencloud.yml
 # The opencloud container image.
-# For production releases: "opencloud-eu/opencloud"
-# For rolling releases:    "opencloud-eu/opencloud-rolling"
+# For production releases: "opencloudeu/opencloud"
+# For rolling releases:    "opencloudeu/opencloud-rolling"
 # Defaults to production if not set otherwise
-OC_DOCKER_IMAGE=opencloud-eu/opencloud
+OC_DOCKER_IMAGE=opencloudeu/opencloud
 # The openCloud container version.
 # Defaults to "latest" and points to the latest stable tag.
-OC_DOCKER_TAG=dev
+OC_DOCKER_TAG=
 # Domain of openCloud, where you can find the frontend.
 # Defaults to "cloud.opencloud.test"
 OC_DOMAIN=

--- a/deployments/examples/opencloud_full/collabora.yml
+++ b/deployments/examples/opencloud_full/collabora.yml
@@ -13,7 +13,7 @@ services:
       GRAPH_AVAILABLE_ROLES: "b1e2218d-eef8-4d4c-b82d-0f1a1b48f3b5,a8d5fe5e-96e3-418d-825b-534dbdf22b99,fb6c3e19-e378-47e5-b277-9732f9de6e21,58c63c02-1d89-4572-916a-870abc5a1b7d,2d00ce52-1fc2-4dbc-8b95-a73b73395f5a,1c996275-f1c9-4e71-abdf-a42f6495e960,312c0871-5ef7-4b3a-85b6-0e4074c64049,aa97fe03-7980-45ac-9e50-b325749fd7e6"
 
   collaboration:
-    image: ${OC_DOCKER_IMAGE:-opencloud-eu/opencloud}:${OC_DOCKER_TAG:-latest}
+    image: ${OC_DOCKER_IMAGE:-opencloudeu/opencloud}:${OC_DOCKER_TAG:-latest}
     networks:
       opencloud-net:
     depends_on:

--- a/deployments/examples/opencloud_full/onlyoffice.yml
+++ b/deployments/examples/opencloud_full/onlyoffice.yml
@@ -8,7 +8,7 @@ services:
           - ${WOPISERVER_ONLYOFFICE_DOMAIN:-wopiserver-oo.opencloud.test}
 
   collaboration-oo:
-    image: ${OC_DOCKER_IMAGE:-opencloud-eu/opencloud}:${OC_DOCKER_TAG:-latest}
+    image: ${OC_DOCKER_IMAGE:-opencloudeu/opencloud}:${OC_DOCKER_TAG:-latest}
     networks:
       opencloud-net:
     depends_on:

--- a/deployments/examples/opencloud_full/opencloud.yml
+++ b/deployments/examples/opencloud_full/opencloud.yml
@@ -6,7 +6,7 @@ services:
         aliases:
           - ${OC_DOMAIN:-cloud.opencloud.test}
   opencloud:
-    image: ${OC_DOCKER_IMAGE:-opencloud-eu/opencloud}:${OC_DOCKER_TAG:-latest}
+    image: ${OC_DOCKER_IMAGE:-opencloudeu/opencloud}:${OC_DOCKER_TAG:-latest}
     # changelog: https://github.com/opencloud-eu/opencloud/tree/main/changelog
     # release notes: https://docs.opencloud.eu/opencloud_release_notes.html
     networks:

--- a/opencloud/Makefile
+++ b/opencloud/Makefile
@@ -33,7 +33,7 @@ docs-generate: config-docs-generate
 .PHONY: dev-docker
 dev-docker:
 	$(MAKE) --no-print-directory release-linux-docker-$(GOARCH)
-	docker build -f docker/Dockerfile.linux.$(GOARCH) -t opencloud-eu/opencloud:dev .
+	docker build -f docker/Dockerfile.linux.$(GOARCH) -t opencloudeu/opencloud:dev .
 
 ########### multiarch-docker ###########
 .PHONY: dev-docker-multiarch

--- a/opencloud/docker/manifest-latest.tmpl
+++ b/opencloud/docker/manifest-latest.tmpl
@@ -1,10 +1,10 @@
-image: opencloud-eu/opencloud-rolling:latest
+image: opencloudeu/opencloud-rolling:latest
 manifests:
-  - image: opencloud-eu/opencloud-rolling:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}linux-amd64
+  - image: opencloudeu/opencloud-rolling:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}linux-amd64
     platform:
       architecture: amd64
       os: linux
-  - image: opencloud-eu/opencloud-rolling:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}linux-arm64
+  - image: opencloudeu/opencloud-rolling:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}linux-arm64
     platform:
       architecture: arm64
       variant: v8

--- a/opencloud/docker/manifest.production-latest.tmpl
+++ b/opencloud/docker/manifest.production-latest.tmpl
@@ -1,10 +1,10 @@
-image: opencloud-eu/opencloud:latest
+image: opencloudeu/opencloud:latest
 manifests:
-  - image: opencloud-eu/opencloud:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}linux-amd64
+  - image: opencloudeu/opencloud:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}linux-amd64
     platform:
       architecture: amd64
       os: linux
-  - image: opencloud-eu/opencloud:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}linux-arm64
+  - image: opencloudeu/opencloud:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}linux-arm64
     platform:
       architecture: arm64
       variant: v8

--- a/opencloud/docker/manifest.production.tmpl
+++ b/opencloud/docker/manifest.production.tmpl
@@ -1,4 +1,4 @@
-image: opencloud-eu/opencloud:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}master{{/if}}
+image: opencloudeu/opencloud:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}master{{/if}}
 {{#if build.tags}}
 tags:
 {{#each build.tags}}
@@ -6,11 +6,11 @@ tags:
 {{/each}}
 {{/if}}
 manifests:
-  - image: opencloud-eu/opencloud:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}linux-amd64
+  - image: opencloudeu/opencloud:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}linux-amd64
     platform:
       architecture: amd64
       os: linux
-  - image: opencloud-eu/opencloud:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}linux-arm64
+  - image: opencloudeu/opencloud:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}linux-arm64
     platform:
       architecture: arm64
       variant: v8

--- a/opencloud/docker/manifest.tmpl
+++ b/opencloud/docker/manifest.tmpl
@@ -1,4 +1,4 @@
-image: opencloud-eu/opencloud-rolling:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}master{{/if}}
+image: opencloudeu/opencloud-rolling:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}master{{/if}}
 {{#if build.tags}}
 tags:
 {{#each build.tags}}
@@ -6,11 +6,11 @@ tags:
 {{/each}}
 {{/if}}
 manifests:
-  - image: opencloud-eu/opencloud-rolling:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}linux-amd64
+  - image: opencloudeu/opencloud-rolling:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}linux-amd64
     platform:
       architecture: amd64
       os: linux
-  - image: opencloud-eu/opencloud-rolling:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}linux-arm64
+  - image: opencloudeu/opencloud-rolling:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}linux-arm64
     platform:
       architecture: arm64
       variant: v8


### PR DESCRIPTION
## Description
Docker images live in the org namespace `opencloudeu` since `-` is not an allowed char on docker hub. Hope I found all the occurrences.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)
