### PR TITLE
allow running api tests with posix

### DIFF
--- a/tests/acceptance/docker/Makefile
+++ b/tests/acceptance/docker/Makefile
@@ -48,6 +48,13 @@ else
 	SEARCH_EXTRACTOR_TYPE := basic
 endif
 
+# default to decomposedfs
+STORAGE_DRIVER ?= decomposed
+ifeq ($(STORAGE_DRIVER),posix)
+	# posix requires a additional driver config
+	COMPOSE_FILE := $(COMPOSE_FILE):src/posix.yml
+endif
+
 # static
 DIVIDE_INTO_NUM_PARTS := 10
 PARTS = 1 2 3 4 5 6 7 8 9 10
@@ -296,7 +303,7 @@ start-server: $(OC_WRAPPER) ## build and start server
 	OC_IMAGE_TAG=dev \
 	WITH_WRAPPER=$(WITH_WRAPPER) \
 	TEST_SOURCE=opencloud \
-	STORAGE_DRIVER=decomposed \
+	STORAGE_DRIVER=$(STORAGE_DRIVER) \
 	OC_ASYNC_UPLOADS=true \
 	SEARCH_EXTRACTOR_TYPE=tika \
 	OC_ADD_RUN_SERVICES=notifications \

--- a/tests/acceptance/docker/src/opencloud.Dockerfile
+++ b/tests/acceptance/docker/src/opencloud.Dockerfile
@@ -2,7 +2,7 @@
 # mounting 'ocwrapper' binary doesn't work with image 'amd64/alpine:3.17' (busybox based)
 
 ARG OC_IMAGE_TAG
-FROM opencloud-eu/opencloud:${OC_IMAGE_TAG} AS opencloud
+FROM opencloudeu/opencloud:${OC_IMAGE_TAG} AS opencloud
 
 FROM ubuntu:22.04
 COPY --from=opencloud /usr/bin/opencloud /usr/bin/opencloud

--- a/tests/acceptance/docker/src/posix.yml
+++ b/tests/acceptance/docker/src/posix.yml
@@ -1,0 +1,8 @@
+---
+services:
+  opencloud-server:
+    environment:
+      # activate posix storage driver for users
+      STORAGE_USERS_DRIVER: posix
+      # posix requires a shared cache store
+      STORAGE_USERS_ID_CACHE_STORE: "nats-js-kv"


### PR DESCRIPTION
this allows running
```
❯ make -C opencloud dev-docker
❯ STORAGE_DRIVER=posix LOCAL_TEST=true ./tests/acceptance/run_api_tests.sh
make: Verzeichnis „/home/jfd/Repositories/opencloud/tests/acceptance/docker“ wird betreten
Build and start server...
COMPOSE_FILE=src/opencloud-base.yml:src/tika.yml:src/email.yml:src/posix.yml \
COMPOSE_PROJECT_NAME=opencloud-acceptance-tests \
OC_IMAGE_TAG=dev \
WITH_WRAPPER=true \
TEST_SOURCE=opencloud \
STORAGE_DRIVER=posix \
OC_ASYNC_UPLOADS=true \
SEARCH_EXTRACTOR_TYPE=tika \
OC_ADD_RUN_SERVICES=notifications \
docker compose up -d --build --force-recreate
WARN[0000] The "POSTPROCESSING_STEPS" variable is not set. Defaulting to a blank string. 
Compose now can delegate build to bake for better performances
Just set COMPOSE_BAKE=true
[+] Building 0.9s (13/13) FINISHED                                         docker:default
 => [opencloud-server internal] load build definition from opencloud.Dockerfile      0.0s
 => => transferring dockerfile: 477B                                                 0.0s
 => WARN: InvalidDefaultArgInFrom: Default value for ARG opencloud-eu/opencloud:${O  0.0s
 => [opencloud-server internal] load metadata for docker.io/library/ubuntu:22.04     0.9s
 => [opencloud-server internal] load metadata for docker.io/opencloud-eu/opencloud:  0.0s
 => [opencloud-server auth] library/ubuntu:pull token for registry-1.docker.io       0.0s
 => [opencloud-server internal] load .dockerignore                                   0.0s
 => => transferring context: 2B                                                      0.0s
 => [opencloud-server opencloud 1/1] FROM docker.io/opencloud-eu/opencloud:dev       0.0s
 => [opencloud-server stage-1 1/4] FROM docker.io/library/ubuntu:22.04@sha256:ed154  0.0s
 => [opencloud-server internal] load build context                                   0.0s
 => => transferring context: 40B                                                     0.0s
 => CACHED [opencloud-server stage-1 2/4] COPY --from=opencloud /usr/bin/opencloud   0.0s
 => CACHED [opencloud-server stage-1 3/4] COPY [./serve-opencloud.sh, /usr/bin/serv  0.0s
 => CACHED [opencloud-server stage-1 4/4] RUN chmod +x /usr/bin/serve-opencloud      0.0s
 => [opencloud-server] exporting to image                                            0.0s
 => => exporting layers                                                              0.0s
 => => writing image sha256:eea32207a0117a0282f530da3af8d3546e8f5348b9166cb55c5dfe4  0.0s
 => => naming to docker.io/library/opencloud-acceptance-tests-opencloud-server       0.0s
 => [opencloud-server] resolving provenance for metadata file                        0.0s
[+] Running 7/7
 ✔ opencloud-server                                         Bu...                    0.0s 
 ✔ Network opencloud-acceptance-tests_default               Created                  0.3s 
 ✔ Container opencloud-acceptance-tests-tika-1              Started                  0.2s 
 ✔ Container opencloud-acceptance-tests-email-1             Started                  0.2s 
 ✔ Container opencloud-acceptance-tests-opencloud-server-1  Started                  0.3s 
 ✔ Container opencloud-acceptance-tests-tika-service-1      Started                  0.4s 
 ✔ Container opencloud-acceptance-tests-start_email-1       Started                  0.4s 
make: Verzeichnis „/home/jfd/Repositories/opencloud/tests/acceptance/docker“ wird verlassen
Waiting for server to start...
Attempt 1: Received response code 000
Attempt 2: Received response code 000
Attempt 3: Received response code 401
Attempt 4: Received response code 200
✅ Server is up and running!
==============================================
Running suite: apiArchiver
==============================================
❌ Suite apiArchiver failed. Check log: ./suite-logs/apiArchiver.log
==============================================
Running suite: apiContract
==============================================
❌ Suite apiContract failed. Check log: ./suite-logs/apiContract.log
==============================================
Running suite: apiCors
==============================================
❌ Suite apiCors failed. Check log: ./suite-logs/apiCors.log
==============================================
Running suite: apiAsyncUpload
==============================================
❌ Suite apiAsyncUpload failed. Check log: ./suite-logs/apiAsyncUpload.log
==============================================
Running suite: apiDownloads
==============================================
✅ Suite apiDownloads completed successfully.
==============================================
Running suite: apiDepthInfinity
==============================================
❌ Suite apiDepthInfinity failed. Check log: ./suite-logs/apiDepthInfinity.log
==============================================
Running suite: apiLocks
==============================================
❌ Suite apiLocks failed. Check log: ./suite-logs/apiLocks.log
==============================================
Running suite: apiActivities
==============================================
❌ Suite apiActivities failed. Check log: ./suite-logs/apiActivities.log
==============================================
Running suite: apiSettings
==============================================
✅ Suite apiSettings completed successfully.
==============================================
Running suite: apiGraph
==============================================
❌ Suite apiGraph failed. Check log: ./suite-logs/apiGraph.log
==============================================
Running suite: apiServiceAvailability
==============================================
❌ Suite apiServiceAvailability failed. Check log: ./suite-logs/apiServiceAvailability.log
==============================================
Running suite: apiGraphUserGroup
==============================================
❌ Suite apiGraphUserGroup failed. Check log: ./suite-logs/apiGraphUserGroup.log
==============================================
Running suite: apiSpaces
==============================================
❌ Suite apiSpaces failed. Check log: ./suite-logs/apiSpaces.log
==============================================
Running suite: apiSpacesShares
==============================================
❌ Suite apiSpacesShares failed. Check log: ./suite-logs/apiSpacesShares.log
==============================================
Running suite: apiSpacesDavOperation
==============================================
❌ Suite apiSpacesDavOperation failed. Check log: ./suite-logs/apiSpacesDavOperation.log
==============================================
Running suite: apiSearch1
==============================================
❌ Suite apiSearch1 failed. Check log: ./suite-logs/apiSearch1.log
==============================================
Running suite: apiSearch2
==============================================
❌ Suite apiSearch2 failed. Check log: ./suite-logs/apiSearch2.log
==============================================
Running suite: apiReshare
==============================================
❌ Suite apiReshare failed. Check log: ./suite-logs/apiReshare.log
==============================================
Running suite: apiSharingNg1
==============================================
❌ Suite apiSharingNg1 failed. Check log: ./suite-logs/apiSharingNg1.log
==============================================
Running suite: apiSharingNg2
==============================================
❌ Suite apiSharingNg2 failed. Check log: ./suite-logs/apiSharingNg2.log
==============================================
Running suite: apiSharingNgShareInvitation
==============================================
❌ Suite apiSharingNgShareInvitation failed. Check log: ./suite-logs/apiSharingNgShareInvitation.log
==============================================
Running suite: apiSharingNgLinkSharePermission
==============================================
❌ Suite apiSharingNgLinkSharePermission failed. Check log: ./suite-logs/apiSharingNgLinkSharePermission.log
==============================================
Running suite: apiSharingNgLinkShareRoot
==============================================
❌ Suite apiSharingNgLinkShareRoot failed. Check log: ./suite-logs/apiSharingNgLinkShareRoot.log
==============================================
Running suite: apiAccountsHashDifficulty
==============================================
❌ Suite apiAccountsHashDifficulty failed. Check log: ./suite-logs/apiAccountsHashDifficulty.log
==============================================
Running suite: apiSearchContent
==============================================
❌ Suite apiSearchContent failed. Check log: ./suite-logs/apiSearchContent.log
==============================================
Running suite: apiNotification
==============================================
❌ Suite apiNotification failed. Check log: ./suite-logs/apiNotification.log
==============================================
Running suite: coreApiAuth
==============================================
❌ Suite coreApiAuth failed. Check log: ./suite-logs/coreApiAuth.log
==============================================
Running suite: coreApiCapabilities
==============================================
✅ Suite coreApiCapabilities completed successfully.
==============================================
Running suite: coreApiFavorites
==============================================
❌ Suite coreApiFavorites failed. Check log: ./suite-logs/coreApiFavorites.log
==============================================
Running suite: coreApiMain
==============================================
❌ Suite coreApiMain failed. Check log: ./suite-logs/coreApiMain.log
==============================================
Running suite: coreApiShareCreateSpecialToShares1
==============================================
❌ Suite coreApiShareCreateSpecialToShares1 failed. Check log: ./suite-logs/coreApiShareCreateSpecialToShares1.log
==============================================
Running suite: coreApiShareCreateSpecialToShares2
==============================================
❌ Suite coreApiShareCreateSpecialToShares2 failed. Check log: ./suite-logs/coreApiShareCreateSpecialToShares2.log
==============================================
Running suite: coreApiSharees
==============================================
✅ Suite coreApiSharees completed successfully.
==============================================
Running suite: coreApiShareManagementBasicToShares
==============================================
❌ Suite coreApiShareManagementBasicToShares failed. Check log: ./suite-logs/coreApiShareManagementBasicToShares.log
==============================================
Running suite: coreApiShareManagementToShares
==============================================
❌ Suite coreApiShareManagementToShares failed. Check log: ./suite-logs/coreApiShareManagementToShares.log
==============================================
Running suite: coreApiShareOperationsToShares1
==============================================
❌ Suite coreApiShareOperationsToShares1 failed. Check log: ./suite-logs/coreApiShareOperationsToShares1.log
==============================================
Running suite: coreApiShareOperationsToShares2
==============================================
❌ Suite coreApiShareOperationsToShares2 failed. Check log: ./suite-logs/coreApiShareOperationsToShares2.log
==============================================
Running suite: coreApiSharePublicLink1
==============================================
❌ Suite coreApiSharePublicLink1 failed. Check log: ./suite-logs/coreApiSharePublicLink1.log
==============================================
Running suite: coreApiSharePublicLink2
==============================================
❌ Suite coreApiSharePublicLink2 failed. Check log: ./suite-logs/coreApiSharePublicLink2.log
==============================================
Running suite: coreApiShareUpdateToShares
==============================================
❌ Suite coreApiShareUpdateToShares failed. Check log: ./suite-logs/coreApiShareUpdateToShares.log
==============================================
Running suite: coreApiTrashbin
==============================================
❌ Suite coreApiTrashbin failed. Check log: ./suite-logs/coreApiTrashbin.log
==============================================
Running suite: coreApiTrashbinRestore
==============================================
❌ Suite coreApiTrashbinRestore failed. Check log: ./suite-logs/coreApiTrashbinRestore.log
==============================================
Running suite: coreApiVersions
==============================================
❌ Suite coreApiVersions failed. Check log: ./suite-logs/coreApiVersions.log
==============================================
Running suite: coreApiWebdavDelete
==============================================
❌ Suite coreApiWebdavDelete failed. Check log: ./suite-logs/coreApiWebdavDelete.log
==============================================
Running suite: coreApiWebdavEtagPropagation1
==============================================
❌ Suite coreApiWebdavEtagPropagation1 failed. Check log: ./suite-logs/coreApiWebdavEtagPropagation1.log
==============================================
Running suite: coreApiWebdavEtagPropagation2
==============================================
❌ Suite coreApiWebdavEtagPropagation2 failed. Check log: ./suite-logs/coreApiWebdavEtagPropagation2.log
==============================================
Running suite: coreApiWebdavMove1
==============================================
❌ Suite coreApiWebdavMove1 failed. Check log: ./suite-logs/coreApiWebdavMove1.log
==============================================
Running suite: coreApiWebdavMove2
==============================================
❌ Suite coreApiWebdavMove2 failed. Check log: ./suite-logs/coreApiWebdavMove2.log
==============================================
Running suite: coreApiWebdavOperations
==============================================
❌ Suite coreApiWebdavOperations failed. Check log: ./suite-logs/coreApiWebdavOperations.log
==============================================
Running suite: coreApiWebdavPreviews
==============================================
❌ Suite coreApiWebdavPreviews failed. Check log: ./suite-logs/coreApiWebdavPreviews.log
==============================================
Running suite: coreApiWebdavProperties
==============================================
❌ Suite coreApiWebdavProperties failed. Check log: ./suite-logs/coreApiWebdavProperties.log
==============================================
Running suite: coreApiWebdavUpload
==============================================
❌ Suite coreApiWebdavUpload failed. Check log: ./suite-logs/coreApiWebdavUpload.log
==============================================
Running suite: coreApiWebdavUploadTUS
==============================================
❌ Suite coreApiWebdavUploadTUS failed. Check log: ./suite-logs/coreApiWebdavUploadTUS.log
==============================================
Test Summary:
✅ Successful suites: 4
❌ Failed suites: 49
Logs saved in: ./suite-logs
==============================================
```