### PR TITLE
static binary issue

### DIFF
--- a/.make/go.mk
+++ b/.make/go.mk
@@ -42,12 +42,6 @@ DEBUG_LDFLAGS += -X google.golang.org/protobuf/reflect/protoregistry.conflictPol
 DOCKER_LDFLAGS += -X "$(OC_REPO)/pkg/config/defaults.BaseDataPathType=path" -X "$(OC_REPO)/pkg/config/defaults.BaseDataPathValue=/var/lib/opencloud"
 DOCKER_LDFLAGS += -X "$(OC_REPO)/pkg/config/defaults.BaseConfigPathType=path" -X "$(OC_REPO)/pkg/config/defaults.BaseConfigPathValue=/etc/opencloud"
 
-# We can't link statically when vips is enabled but we still
-# prefer static linking where possible
-ifndef ENABLE_VIPS
-	DOCKER_LDFLAGS += -extldflags "-static"
-endif
-
 GCFLAGS += all=-N -l
 
 .PHONY: all

--- a/.make/go.mk
+++ b/.make/go.mk
@@ -107,7 +107,7 @@ build: $(BIN)/$(EXECUTABLE)
 build-debug: $(BIN)/$(EXECUTABLE)-debug
 
 $(BIN)/$(EXECUTABLE): $(SOURCES)
-	$(GOBUILD) -v -tags '$(TAGS)' -ldflags '$(LDFLAGS) $(DOCKER_LDFLAGS)' -o $@ ./cmd/$(NAME)
+	$(GOBUILD) -v -tags '$(TAGS)' -ldflags '$(LDFLAGS)' -o $@ ./cmd/$(NAME)
 
 $(BIN)/$(EXECUTABLE)-debug: $(SOURCES)
 	$(GOBUILD) -v -tags '$(TAGS)' -ldflags '$(DEBUG_LDFLAGS)' -gcflags '$(GCFLAGS)' -o $@ ./cmd/$(NAME)

--- a/opencloud/docker/Dockerfile.linux.multiarch
+++ b/opencloud/docker/Dockerfile.linux.multiarch
@@ -7,11 +7,13 @@ RUN apk add bash make git curl gcc musl-dev libc-dev binutils-gold inotify-tools
 COPY ./ /opencloud/
 
 WORKDIR /opencloud/opencloud
-RUN GOOS="${TARGETOS:-linux}" GOARCH="${TARGETARCH:-amd64}" make ci-go-generate build ENABLE_VIPS=true
+RUN GOOS="${TARGETOS:-linux}" GOARCH="${TARGETARCH:-amd64}" make ci-go-generate release-linux-docker-${TARGETARCH} ENABLE_VIPS=true
 
 FROM alpine:3.20
 ARG VERSION
 ARG REVISION
+ARG TARGETOS
+ARG TARGETARCH
 
 RUN apk add --no-cache attr bash ca-certificates curl inotify-tools libc6-compat mailcap tree vips patch && \
 	echo 'hosts: files dns' >| /etc/nsswitch.conf
@@ -48,4 +50,4 @@ EXPOSE 9200/tcp
 ENTRYPOINT ["/usr/bin/opencloud"]
 CMD ["server"]
 
-COPY --from=build /opencloud/opencloud/bin/opencloud /usr/bin/opencloud
+COPY --from=build /opencloud/opencloud/dist/binaries/opencloud-linux-${TARGETARCH} /usr/bin/opencloud


### PR DESCRIPTION
related: https://github.com/opencloud-eu/opencloud/pull/229/commits/7c1acbcd48793e2785a47ae52f885297cb7d77cf

while `opencloud` build I got this error: 

```
make -C opencloud build              
go build -v -tags 'disable_crypt' -ldflags '-X google.golang.org/protobuf/reflect/protoregistry.conflictPolicy=warn -s -w -X "github.com/opencloud-eu/opencloud/pkg/version.String=" -X "github.com/opencloud-eu/opencloud/pkg/version.Tag=1.0.0" -X "github.com/opencloud-eu/opencloud/pkg/version.Date=20250226" -X "github.com/opencloud-eu/opencloud/pkg/config/defaults.BaseDataPathType=path" -X "github.com/opencloud-eu/opencloud/pkg/config/defaults.BaseDataPathValue=/var/lib/opencloud" -X "github.com/opencloud-eu/opencloud/pkg/config/defaults.BaseConfigPathType=path" -X "github.com/opencloud-eu/opencloud/pkg/config/defaults.BaseConfigPathValue=/etc/opencloud" -extldflags "-static" -X "github.com/opencloud-eu/opencloud/pkg/config/defaults.BaseDataPathType=path" -X "github.com/opencloud-eu/opencloud/pkg/config/defaults.BaseDataPathValue=/var/lib/opencloud" -X "github.com/opencloud-eu/opencloud/pkg/config/defaults.BaseConfigPathType=path" -X "github.com/opencloud-eu/opencloud/pkg/config/defaults.BaseConfigPathValue=/etc/opencloud" -extldflags "-static"' -o bin/opencloud ./cmd/opencloud
# github.com/opencloud-eu/opencloud/opencloud/cmd/opencloud
/opt/homebrew/Cellar/go/1.23.4/libexec/pkg/tool/darwin_arm64/link: running cc failed: exit status 1
/usr/bin/cc -arch arm64 -Wl,-S -Wl,-x -o $WORK/b001/exe/a.out -Qunused-arguments /var/folders/sv/vfckb_2n4b3_10t324tjr8700000gn/T/go-link-3504277551/go.o /var/folders/sv/vfckb_2n4b3_10t324tjr8700000gn/T/go-link-3504277551/000000.o /var/folders/sv/vfckb_2n4b3_10t324tjr8700000gn/T/go-link-3504277551/000001.o /var/folders/sv/vfckb_2n4b3_10t324tjr8700000gn/T/go-link-3504277551/000002.o /var/folders/sv/vfckb_2n4b3_10t324tjr8700000gn/T/go-link-3504277551/000003.o /var/folders/sv/vfckb_2n4b3_10t324tjr8700000gn/T/go-link-3504277551/000004.o /var/folders/sv/vfckb_2n4b3_10t324tjr8700000gn/T/go-link-3504277551/000005.o /var/folders/sv/vfckb_2n4b3_10t324tjr8700000gn/T/go-link-3504277551/000006.o /var/folders/sv/vfckb_2n4b3_10t324tjr8700000gn/T/go-link-3504277551/000007.o /var/folders/sv/vfckb_2n4b3_10t324tjr8700000gn/T/go-link-3504277551/000008.o /var/folders/sv/vfckb_2n4b3_10t324tjr8700000gn/T/go-link-3504277551/000009.o /var/folders/sv/vfckb_2n4b3_10t324tjr8700000gn/T/go-link-3504277551/000010.o /var/folders/sv/vfckb_2n4b3_10t324tjr8700000gn/T/go-link-3504277551/000011.o /var/folders/sv/vfckb_2n4b3_10t324tjr8700000gn/T/go-link-3504277551/000012.o /var/folders/sv/vfckb_2n4b3_10t324tjr8700000gn/T/go-link-3504277551/000013.o /var/folders/sv/vfckb_2n4b3_10t324tjr8700000gn/T/go-link-3504277551/000014.o /var/folders/sv/vfckb_2n4b3_10t324tjr8700000gn/T/go-link-3504277551/000015.o /var/folders/sv/vfckb_2n4b3_10t324tjr8700000gn/T/go-link-3504277551/000016.o /var/folders/sv/vfckb_2n4b3_10t324tjr8700000gn/T/go-link-3504277551/000017.o /var/folders/sv/vfckb_2n4b3_10t324tjr8700000gn/T/go-link-3504277551/000018.o /var/folders/sv/vfckb_2n4b3_10t324tjr8700000gn/T/go-link-3504277551/000019.o /var/folders/sv/vfckb_2n4b3_10t324tjr8700000gn/T/go-link-3504277551/000020.o /var/folders/sv/vfckb_2n4b3_10t324tjr8700000gn/T/go-link-3504277551/000021.o /var/folders/sv/vfckb_2n4b3_10t324tjr8700000gn/T/go-link-3504277551/000022.o /var/folders/sv/vfckb_2n4b3_10t324tjr8700000gn/T/go-link-3504277551/000023.o /var/folders/sv/vfckb_2n4b3_10t324tjr8700000gn/T/go-link-3504277551/000024.o /var/folders/sv/vfckb_2n4b3_10t324tjr8700000gn/T/go-link-3504277551/000025.o -lresolv -framework CoreFoundation -framework Security -O2 -g -O2 -g -framework CoreFoundation -O2 -g -static
ld: library not found for -lcrt0.o
clang: error: linker command failed with exit code 1 (use -v to see invocation)

make: *** [bin/opencloud] Error 1
```

cc @fschade 