### PR TITLE
use opencloud rolling image in the full example

### DIFF
--- a/deployments/examples/opencloud_full/.env
+++ b/deployments/examples/opencloud_full/.env
@@ -39,7 +39,7 @@ OPENCLOUD=:opencloud.yml
 # For production releases: "opencloudeu/opencloud"
 # For rolling releases:    "opencloudeu/opencloud-rolling"
 # Defaults to production if not set otherwise
-OC_DOCKER_IMAGE=opencloudeu/opencloud
+OC_DOCKER_IMAGE=opencloudeu/opencloud-rolling
 # The openCloud container version.
 # Defaults to "latest" and points to the latest stable tag.
 OC_DOCKER_TAG=

--- a/deployments/examples/opencloud_full/collabora.yml
+++ b/deployments/examples/opencloud_full/collabora.yml
@@ -13,7 +13,7 @@ services:
       GRAPH_AVAILABLE_ROLES: "b1e2218d-eef8-4d4c-b82d-0f1a1b48f3b5,a8d5fe5e-96e3-418d-825b-534dbdf22b99,fb6c3e19-e378-47e5-b277-9732f9de6e21,58c63c02-1d89-4572-916a-870abc5a1b7d,2d00ce52-1fc2-4dbc-8b95-a73b73395f5a,1c996275-f1c9-4e71-abdf-a42f6495e960,312c0871-5ef7-4b3a-85b6-0e4074c64049,aa97fe03-7980-45ac-9e50-b325749fd7e6"
 
   collaboration:
-    image: ${OC_DOCKER_IMAGE:-opencloudeu/opencloud}:${OC_DOCKER_TAG:-latest}
+    image: ${OC_DOCKER_IMAGE:-opencloudeu/opencloud-rolling}:${OC_DOCKER_TAG:-latest}
     networks:
       opencloud-net:
     depends_on:
@@ -53,7 +53,7 @@ services:
     restart: always
 
   collabora:
-    image: collabora/code:24.04.11.1.1
+    image: collabora/code:24.04.12.2.1
     # release notes: https://www.collaboraonline.com/release-notes/
     networks:
       opencloud-net:

--- a/deployments/examples/opencloud_full/onlyoffice.yml
+++ b/deployments/examples/opencloud_full/onlyoffice.yml
@@ -8,7 +8,7 @@ services:
           - ${WOPISERVER_ONLYOFFICE_DOMAIN:-wopiserver-oo.opencloud.test}
 
   collaboration-oo:
-    image: ${OC_DOCKER_IMAGE:-opencloudeu/opencloud}:${OC_DOCKER_TAG:-latest}
+    image: ${OC_DOCKER_IMAGE:-opencloudeu/opencloud-rolling}:${OC_DOCKER_TAG:-latest}
     networks:
       opencloud-net:
     depends_on:

--- a/deployments/examples/opencloud_full/opencloud.yml
+++ b/deployments/examples/opencloud_full/opencloud.yml
@@ -6,7 +6,7 @@ services:
         aliases:
           - ${OC_DOMAIN:-cloud.opencloud.test}
   opencloud:
-    image: ${OC_DOCKER_IMAGE:-opencloudeu/opencloud}:${OC_DOCKER_TAG:-latest}
+    image: ${OC_DOCKER_IMAGE:-opencloudeu/opencloud-rolling}:${OC_DOCKER_TAG:-latest}
     # changelog: https://github.com/opencloud-eu/opencloud/tree/main/changelog
     # release notes: https://docs.opencloud.eu/opencloud_release_notes.html
     networks:


### PR DESCRIPTION
related: https://github.com/opencloud-eu/opencloud/issues/257

We can't run `opencloud full` if we don't have `opencloudeu/opencloud:latest` https://hub.docker.com/r/opencloudeu/opencloud

 ```
% docker compose up -d  
[+] Running 2/2
 ✘ collaboration Error context canceled                                                                                               1.0s 
 ✘ opencloud Error     failed to resolve reference "docker.io/opencloudeu/opencloud:latest": docker.io/opencloude...                  1.0s 
Error response from daemon: failed to resolve reference "docker.io/opencloudeu/opencloud:latest": docker.io/opencloudeu/opencloud:latest: not found
```

using opencloudeu/opencloud-rolling:latest instead