### PR TITLE
fix test with password banned list. add run test with posixfs

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -19,7 +19,7 @@ Basically we have two sources for feature tests and test suites:
 
 At the moment, both can be applied to OpenCloud.
 
-As a storage backend, we support the OpenCloud native storage, also called `decomposed`. This stores files directly on disk. Along with that we also provide `decomposeds3` storage driver.
+As a storage backend, we support the OpenCloud native storage, also called `decomposed`. This stores files directly on disk. Along with that we also provide `decomposeds3`, `posix`  storage drivers.
 
 You can invoke two types of test suite runs:
 
@@ -30,7 +30,7 @@ You can invoke two types of test suite runs:
 
 #### Local OpenCloud Tests (prefix `api`)
 
-The names of the full test suite make targets have the same naming as in the CI pipeline. See the available local OpenCloud specific test suites [here](https://github.com/opencloud-eu/opencloud/tree/main/tests/acceptance/features). They can be run with `decomposed` storage and `decomposeds3` storage.
+The names of the full test suite make targets have the same naming as in the CI pipeline. See the available local OpenCloud specific test suites [here](https://github.com/opencloud-eu/opencloud/tree/main/tests/acceptance/features). They can be run with `decomposed` storage, `decomposeds3` storage and `posix` storage
 
 For example, command:
 
@@ -40,13 +40,21 @@ make -C tests/acceptance/docker localApiTests-apiGraph-decomposed
 
 runs the same tests as the `localApiTests-apiGraph-decomposed` CI pipeline, which runs the OpenCloud test suite "apiGraph" against the OpenCloud server with `decomposed` storage.
 
-And command:
+command:
 
 ```bash
 make -C tests/acceptance/docker localApiTests-apiGraph-decomposeds3
 ```
 
 runs the OpenCloud test suite `apiGraph` against the OpenCloud server with `decomposeds3` storage.
+
+And command:
+
+```bash
+make -C tests/acceptance/docker localApiTests-apiGraph-posix
+```
+
+runs the OpenCloud test suite `apiGraph` against the OpenCloud server with `posix` storage.
 
 Note:
 While running the tests, OpenCloud server is started with [ocwrapper](https://github.com/opencloud-eu/opencloud/blob/main/tests/ocwrapper/README.md) (i.e. `WITH_WRAPPER=true`) by default. In order to run the tests without ocwrapper, provide `WITH_WRAPPER=false` when running the tests. For example:

--- a/tests/acceptance/bootstrap/OcConfigContext.php
+++ b/tests/acceptance/bootstrap/OcConfigContext.php
@@ -154,7 +154,12 @@ class OcConfigContext implements Context {
 	 * @throws GuzzleException
 	 */
 	public function theConfigHasBeenSetPathTo(string $configVariable, string $path): void {
-		$path = \realpath(\dirname(__FILE__) . "/../../" . $path);
+		if (\getenv('TEST_ROOT_PATH')) {
+			$path = \getenv('TEST_ROOT_PATH') . "/" . $path;
+		} else {
+			$path = \realpath(\dirname(__FILE__) . "/../../" . $path);
+		}
+		
 		$response =  OcConfigHelper::reConfigureOc(
 			[
 				$configVariable => $path

--- a/tests/acceptance/docker/Makefile
+++ b/tests/acceptance/docker/Makefile
@@ -148,6 +148,13 @@ test-opencloud-feature-decomposeds3-storage: ## test a OpenCloud feature with de
 	START_CEPH=1 \
 	$(MAKE) --no-print-directory testSuite
 
+.PHONY: test-opencloud-feature-posix-storage
+test-opencloud-feature-posix-storage: ## test a OpenCloud feature with posix storage, usage: make ... BEHAT_FEATURE='tests/acceptance/features/apiAccountsHashDifficulty/addUser.feature:10'
+	@TEST_SOURCE=opencloud \
+	STORAGE_DRIVER=posix \
+	BEHAT_FEATURE=$(BEHAT_FEATURE) \
+	$(MAKE) --no-print-directory testSuite
+
 .PHONY: test-core-feature-decomposed-storage
 test-core-feature-decomposed-storage: ## test a core feature with decomposed storage, usage: make ... BEHAT_FEATURE='tests/acceptance/features/coreApiAuth/webDavAuth.feature'
 	@TEST_SOURCE=core \
@@ -161,6 +168,13 @@ test-core-feature-decomposeds3-storage: ## test a core feature with decomposeds3
 	STORAGE_DRIVER=decomposeds3 \
 	BEHAT_FEATURE=$(BEHAT_FEATURE) \
 	START_CEPH=1 \
+	$(MAKE) --no-print-directory testSuite
+
+.PHONY: test-opencloud-feature-posix-storage
+test-core-opencloud-feature-posix-storage: ## test a core feature with posix storage, usage: make ... BEHAT_FEATURE='tests/acceptance/features/apiAccountsHashDifficulty/addUser.feature:10'
+	@TEST_SOURCE=core \
+	STORAGE_DRIVER=posix \
+	BEHAT_FEATURE=$(BEHAT_FEATURE) \
 	$(MAKE) --no-print-directory testSuite
 
 localSuiteOpencloud = $(addprefix localApiTests-, $(addsuffix -decomposed,${LOCAL_API_SUITES}))
@@ -178,6 +192,15 @@ $(localSuiteDecomposedS3): ## run local api test suite with s3 storage
 	@$(eval BEHAT_SUITE=$(shell echo "$@" | cut -d'-' -f2))
 	@TEST_SOURCE=opencloud \
 	STORAGE_DRIVER=decomposeds3 \
+	BEHAT_SUITE=$(BEHAT_SUITE) \
+	$(MAKE) --no-print-directory testSuite
+
+localSuitePosix = $(addprefix localApiTests-, $(addsuffix -posix,${LOCAL_API_SUITES}))
+.PHONY: $(localSuitePosix)
+$(localSuitePosix): ## run local api test suite with posix storage
+	@$(eval BEHAT_SUITE=$(shell echo "$@" | cut -d'-' -f2))
+	@TEST_SOURCE=opencloud \
+	STORAGE_DRIVER=posix \
 	BEHAT_SUITE=$(BEHAT_SUITE) \
 	$(MAKE) --no-print-directory testSuite
 

--- a/tests/acceptance/docker/src/run-tests.sh
+++ b/tests/acceptance/docker/src/run-tests.sh
@@ -30,6 +30,9 @@ elif [ "$TEST_SOURCE" = "opencloud" ]; then
     elif [ "$STORAGE_DRIVER" = "decomposeds3" ]; then
         export BEHAT_FILTER_TAGS='~@skip&&~@skipOnOpencloud-decomposeds3-Storage'
         export OC_REVA_DATA_ROOT=''
+    elif [ "$STORAGE_DRIVER" = "posix" ]; then
+        export BEHAT_FILTER_TAGS='~@skip&&~@skipOnOpencloud-posix-Storage'
+        export OC_REVA_DATA_ROOT=''
     else
         echo "non existing storage selected"
         exit 1

--- a/tests/acceptance/features/apiSharingNgLinkSharePermission/createLinkShare.feature
+++ b/tests/acceptance/features/apiSharingNgLinkSharePermission/createLinkShare.feature
@@ -500,7 +500,7 @@ Feature: Create a link share for a resource
       """
     And the public should be able to download file "textfile1.txt" from the last link share with password "%public%" and the content should be "other data"
 
-  @skip-local-run
+
   Scenario Outline: create a file's link share with a password that is listed in the Banned-Password-List using permissions endpoint
     Given the config "OC_PASSWORD_POLICY_BANNED_PASSWORDS_LIST" has been set to path "config/drone/banned-password-list.txt"
     And user "Alice" has uploaded file with content "other data" to "text.txt"
@@ -755,7 +755,7 @@ Feature: Create a link share for a resource
       | upload           |
       | createOnly       |
 
-  @skip-local-run
+
   Scenario Outline: create a link share of a folder inside project-space with a password that is listed in the Banned-Password-List using permissions endpoint
     Given the config "OC_PASSWORD_POLICY_BANNED_PASSWORDS_LIST" has been set to path "config/drone/banned-password-list.txt"
     And using spaces DAV path
@@ -1155,7 +1155,7 @@ Feature: Create a link share for a resource
       | edit             |
       | internal         |
 
-  @skip-local-run
+
   Scenario Outline: create a link share of a file inside project-space with a password that is listed in the Banned-Password-List using permissions endpoint
     Given the config "OC_PASSWORD_POLICY_BANNED_PASSWORDS_LIST" has been set to path "config/drone/banned-password-list.txt"
     And using spaces DAV path
@@ -1610,7 +1610,7 @@ Feature: Create a link share for a resource
       | upload           |
       | createOnly       |
 
-  @skip-local-run
+
   Scenario Outline: try to create a link share of a project-space with a password that is listed in the Banned-Password-List using permissions endpoint
     Given the config "OC_PASSWORD_POLICY_BANNED_PASSWORDS_LIST" has been set to path "config/drone/banned-password-list.txt"
     And using spaces DAV path

--- a/tests/acceptance/features/apiSharingNgLinkSharePermission/updateLinkShare.feature
+++ b/tests/acceptance/features/apiSharingNgLinkSharePermission/updateLinkShare.feature
@@ -230,7 +230,7 @@ Feature: Update a link share for a resource
     And the public should be able to download file "textfile1.txt" from the last link share with password "%public%" and the content should be "other data"
     And the public download of file "textfile1.txt" from the last link share with password "$heLlo*1234*" should fail with HTTP status code "401" using shareNg
 
-  @skip-local-run
+
   Scenario Outline: update a file's link share with a password that is listed in the Banned-Password-List using permissions endpoint
     Given the config "OC_PASSWORD_POLICY_BANNED_PASSWORDS_LIST" has been set to path "config/drone/banned-password-list.txt"
     And user "Alice" has uploaded file with content "other data" to "text.txt"

--- a/tests/acceptance/run_api_tests.sh
+++ b/tests/acceptance/run_api_tests.sh
@@ -5,6 +5,7 @@ export LOCAL_TEST=true
 export START_EMAIL=true
 export WITH_WRAPPER=true
 export STORAGE_DRIVER=${STORAGE_DRIVER:-decomposed}
+export TEST_ROOT_PATH="/drone/src/tests"
 
 # LOCAL TEST WITHOUT EXTRA ENVS
 TEST_SERVER_URL="https://opencloud-server:9200"


### PR DESCRIPTION
- set correct path if you run local-test with opencloud-docker-server 

OC_PASSWORD_POLICY_BANNED_PASSWORDS_LIST="/drone/src/tests/config/drone/banned-password-list.txt"

- add command to make file to run test with posix storage

```
BEHAT_FEATURE='tests/acceptance/features/apiSharingNgLinkShareRoot/createLinkShare.feature' \      
make -C tests/acceptance/docker test-opencloud-feature-posix-storage 
```

or just run apiGraph suite with posix  `make -C tests/acceptance/docker localApiTests-apiGraph-posix`