### PR TITLE
fix: docs link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ opencloud/bin/opencloud init && opencloud/bin/opencloud server
 ```
 This creates a server configuration (by default in `$HOME/.opencloud`) and starts the server.
 
-For more setup- and installation options consult the [Development Documentation](https://docs.opencloud.eu/opencloud/).
+For more setup- and installation options consult the [Development Documentation](https://docs.opencloud.eu/).
 
 ### Contribute
 


### PR DESCRIPTION
Fixing docs link in readme, as mentioned here https://github.com/opencloud-eu/opencloud/issues/242#issuecomment-2691389236