### PR TITLE
delete assets before trying to clone them

### DIFF
--- a/services/web/Makefile
+++ b/services/web/Makefile
@@ -32,6 +32,7 @@ ci-node-generate: pull-assets
 
 .PHONY: pull-assets
 pull-assets:
+	rm -rf assets/core/origin
 	git clean -xfd assets
 	git clone -b main --depth 1 https://github.com/opencloud-eu/web.git assets/core/origin
 	make -C assets/core/origin release


### PR DESCRIPTION
## Description
make sure the assets folder does not exist, before trying to clone the assets

## Motivation and Context
in the case that the build process fails in `make -C assets/core/origin release` the assets folder is not cleaned up, the next time `make generate` is run the user gets errors like this:

```
make[1]: Verzeichnis „/home/artur/www/opencloud/opencloud/services/web“ wird betreten
git clean -xfd assets
git clone -b main --depth 1 https://github.com/opencloud-eu/web.git assets/core/origin
fatal: Zielpfad 'assets/core/origin' existiert bereits und ist kein leeres Verzeichnis.
make[1]: *** [Makefile:36: pull-assets] Fehler 128
make[1]: Verzeichnis „/home/artur/www/opencloud/opencloud/services/web“ wird verlassen
make: *** [Makefile:146: generate] Fehler 1
```

## How Has This Been Tested?
run `make generate` multiple times with `make -C assets/core/origin release` failing

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added
