### PR TITLE
fix: make recursion and missing opencloud node generate step

### DIFF
--- a/.make/default.mk
+++ b/.make/default.mk
@@ -5,7 +5,7 @@ node-generate-dev-default: node-generate-prod
 node-generate-prod-default: noop
 
 .PHONY: go-generate-default
-go-generate-default: go-generate
+go-generate-default: noop
 
 .PHONY: generate
 generate: generate-prod # production is always the default

--- a/opencloud/Makefile
+++ b/opencloud/Makefile
@@ -35,3 +35,9 @@ dev-docker-multiarch:
 debug-docker:
 	$(MAKE) --no-print-directory debug-linux-docker-$(GOARCH)
 	docker build -f docker/Dockerfile.linux.debug.$(GOARCH) -t opencloud-eu/opencloud:debug .
+
+.PHONY: node-generate-prod
+node-generate-prod: # opencloud needs assets of all other modules
+	@if [ $(MAKE_DEPTH) -le 1 ]; then \
+	$(MAKE) --no-print-directory -C .. node-generate-prod \
+	; fi;


### PR DESCRIPTION
## Description
i introduced a recursive make call (make go-generate) in https://github.com/opencloud-eu/opencloud/pull/278, beside that generation assets in ./opencloud (make generate) failed too.

```bash
make -C opencloud generate build
```

## Related Issue
- Fixes https://github.com/opencloud-eu/opencloud/issues/315

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- reproduced locally

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [X] Code changes
- [ ] ~~Unit tests added~~
- [ ] ~~Acceptance tests added~~
- [ ] ~~Documentation added~~
