### PR TITLE
set min go version to 1.24.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/opencloud-eu/opencloud
 
-go 1.23.1
-
-toolchain go1.23.6
+go 1.24.0
 
 require (
 	dario.cat/mergo v1.0.1


### PR DESCRIPTION
## Description
the min version of go is 1.24.0 because of https://github.com/opencloud-eu/opencloud/blob/d3a5b79bc051c7015ff7591382c6fb745c808d4e/.bingo/mockery.mod#L4

## Motivation and Context
make it less confusing for the developer trying to build OpenCloud

## How Has This Been Tested?
- run `make clean`
- run `make -C opencloud build`
- start the server
- login to the server

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added
