### PR TITLE
Fix build with go 1.24

### DIFF
--- a/pkg/crypto/gencert.go
+++ b/pkg/crypto/gencert.go
@@ -65,12 +65,12 @@ func GenTempCertForAddr(addr string) (tls.Certificate, error) {
 // persistCertificate generates a certificate using pk as private key and proceeds to store it into a file named certName.
 func persistCertificate(certName string, l log.Logger, pk interface{}) error {
 	if err := ensureExistsDir(certName); err != nil {
-		return fmt.Errorf("creating certificate destination: " + certName)
+		return fmt.Errorf("creating certificate destination: %s", certName)
 	}
 
 	certificate, err := generateCertificate(pk)
 	if err != nil {
-		return fmt.Errorf("creating certificate: " + filepath.Dir(certName))
+		return fmt.Errorf("creating certificate: %s", filepath.Dir(certName))
 	}
 
 	certOut, err := os.Create(certName)
@@ -108,7 +108,7 @@ func generateCertificate(pk interface{}) ([]byte, error) {
 // persistKey persists the private key used to generate the certificate at the configured location.
 func persistKey(destination string, l log.Logger, pk interface{}) error {
 	if err := ensureExistsDir(destination); err != nil {
-		return fmt.Errorf("creating key destination: " + destination)
+		return fmt.Errorf("creating key destination: %s", destination)
 	}
 
 	keyOut, err := os.OpenFile(destination, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)

--- a/pkg/l10n/l10n.go
+++ b/pkg/l10n/l10n.go
@@ -54,7 +54,7 @@ func NewTranslatorFromCommonConfig(defaultLocale string, domain string, path str
 
 // Translate translates a string to the locale
 func (t Translator) Translate(str, locale string) string {
-	return t.Locale(locale).Get(str)
+	return t.Locale(locale).Get("%s", str)
 }
 
 // Locale returns the gotext.Locale, use `.Get` method to translate strings

--- a/pkg/tracing/tracing.go
+++ b/pkg/tracing/tracing.go
@@ -159,14 +159,14 @@ func parseAgentConfig(ae string) (string, string, error) {
 
 	p := strings.Split(ae, ":")
 	if len(p) != 2 {
-		return "", "", fmt.Errorf(fmt.Sprintf("invalid agent endpoint `%s`. expected format: `hostname:port`", ae))
+		return "", "", fmt.Errorf("invalid agent endpoint `%s`. expected format: `hostname:port`", ae)
 	}
 
 	switch {
 	case p[0] == "" && p[1] == "": // case ae = ":"
-		return "", "", fmt.Errorf(fmt.Sprintf("invalid agent endpoint `%s`. expected format: `hostname:port`", ae))
+		return "", "", fmt.Errorf("invalid agent endpoint `%s`. expected format: `hostname:port`", ae)
 	case p[0] == "":
-		return "", "", fmt.Errorf(fmt.Sprintf("invalid agent endpoint `%s`. expected format: `hostname:port`", ae))
+		return "", "", fmt.Errorf("invalid agent endpoint `%s`. expected format: `hostname:port`", ae)
 	}
 	return p[0], p[1], nil
 }

--- a/services/notifications/pkg/email/composer.go
+++ b/services/notifications/pkg/email/composer.go
@@ -21,19 +21,19 @@ var (
 func NewTextTemplate(mt MessageTemplate, locale, defaultLocale string, translationPath string, vars map[string]string) (MessageTemplate, error) {
 	var err error
 	t := l10n.NewTranslatorFromCommonConfig(defaultLocale, _domain, translationPath, _translationFS, "l10n/locale").Locale(locale)
-	mt.Subject, err = composeMessage(t.Get(mt.Subject), vars)
+	mt.Subject, err = composeMessage(t.Get("%s", mt.Subject), vars)
 	if err != nil {
 		return mt, err
 	}
-	mt.Greeting, err = composeMessage(t.Get(mt.Greeting), vars)
+	mt.Greeting, err = composeMessage(t.Get("%s", mt.Greeting), vars)
 	if err != nil {
 		return mt, err
 	}
-	mt.MessageBody, err = composeMessage(t.Get(mt.MessageBody), vars)
+	mt.MessageBody, err = composeMessage(t.Get("%s", mt.MessageBody), vars)
 	if err != nil {
 		return mt, err
 	}
-	mt.CallToAction, err = composeMessage(t.Get(mt.CallToAction), vars)
+	mt.CallToAction, err = composeMessage(t.Get("%s", mt.CallToAction), vars)
 	if err != nil {
 		return mt, err
 	}
@@ -44,19 +44,19 @@ func NewTextTemplate(mt MessageTemplate, locale, defaultLocale string, translati
 func NewHTMLTemplate(mt MessageTemplate, locale, defaultLocale string, translationPath string, vars map[string]string) (MessageTemplate, error) {
 	var err error
 	t := l10n.NewTranslatorFromCommonConfig(defaultLocale, _domain, translationPath, _translationFS, "l10n/locale").Locale(locale)
-	mt.Subject, err = composeMessage(t.Get(mt.Subject), vars)
+	mt.Subject, err = composeMessage(t.Get("%s", mt.Subject), vars)
 	if err != nil {
 		return mt, err
 	}
-	mt.Greeting, err = composeMessage(newlineToBr(t.Get(mt.Greeting)), vars)
+	mt.Greeting, err = composeMessage(newlineToBr(t.Get("%s", mt.Greeting)), vars)
 	if err != nil {
 		return mt, err
 	}
-	mt.MessageBody, err = composeMessage(newlineToBr(t.Get(mt.MessageBody)), vars)
+	mt.MessageBody, err = composeMessage(newlineToBr(t.Get("%s", mt.MessageBody)), vars)
 	if err != nil {
 		return mt, err
 	}
-	mt.CallToAction, err = composeMessage(callToActionToHTML(t.Get(mt.CallToAction)), vars)
+	mt.CallToAction, err = composeMessage(callToActionToHTML(t.Get("%s", mt.CallToAction)), vars)
 	if err != nil {
 		return mt, err
 	}
@@ -71,18 +71,18 @@ func NewGroupedTextTemplate(gmt GroupedMessageTemplate, vars map[string]string, 
 
 	var err error
 	t := l10n.NewTranslatorFromCommonConfig(defaultLocale, _domain, translationPath, _translationFS, "l10n/locale").Locale(locale)
-	gmt.Subject, err = composeMessage(t.Get(gmt.Subject), vars)
+	gmt.Subject, err = composeMessage(t.Get("%s", gmt.Subject), vars)
 	if err != nil {
 		return gmt, err
 	}
-	gmt.Greeting, err = composeMessage(t.Get(gmt.Greeting), vars)
+	gmt.Greeting, err = composeMessage(t.Get("%s", gmt.Greeting), vars)
 	if err != nil {
 		return gmt, err
 	}
 
 	bodyParts := make([]string, 0, len(mtsVars))
 	for i, mt := range mts {
-		bodyPart, err := composeMessage(t.Get(mt.MessageBody), mtsVars[i])
+		bodyPart, err := composeMessage(t.Get("%s", mt.MessageBody), mtsVars[i])
 		if err != nil {
 			return gmt, err
 		}
@@ -100,18 +100,18 @@ func NewGroupedHTMLTemplate(gmt GroupedMessageTemplate, vars map[string]string, 
 
 	var err error
 	t := l10n.NewTranslatorFromCommonConfig(defaultLocale, _domain, translationPath, _translationFS, "l10n/locale").Locale(locale)
-	gmt.Subject, err = composeMessage(t.Get(gmt.Subject), vars)
+	gmt.Subject, err = composeMessage(t.Get("%s", gmt.Subject), vars)
 	if err != nil {
 		return gmt, err
 	}
-	gmt.Greeting, err = composeMessage(newlineToBr(t.Get(gmt.Greeting)), vars)
+	gmt.Greeting, err = composeMessage(newlineToBr(t.Get("%s", gmt.Greeting)), vars)
 	if err != nil {
 		return gmt, err
 	}
 
 	bodyParts := make([]string, 0, len(mtsVars))
 	for i, mt := range mts {
-		bodyPart, err := composeMessage(t.Get(mt.MessageBody), mtsVars[i])
+		bodyPart, err := composeMessage(t.Get("%s", mt.MessageBody), mtsVars[i])
 		if err != nil {
 			return gmt, err
 		}

--- a/services/search/pkg/service/grpc/v0/service.go
+++ b/services/search/pkg/service/grpc/v0/service.go
@@ -163,9 +163,9 @@ func (s Service) Search(ctx context.Context, in *searchsvc.SearchRequest, out *s
 		if err != nil {
 			switch err.(type) {
 			case errtypes.BadRequest:
-				return merrors.BadRequest(s.id, err.Error())
+				return merrors.BadRequest(s.id, "%s", err.Error())
 			default:
-				return merrors.InternalServerError(s.id, err.Error())
+				return merrors.InternalServerError(s.id, "%s", err.Error())
 			}
 		}
 

--- a/services/thumbnails/pkg/service/grpc/v0/service.go
+++ b/services/thumbnails/pkg/service/grpc/v0/service.go
@@ -129,7 +129,7 @@ func (g Thumbnail) checkThumbnail(req *thumbnailssvc.GetThumbnailRequest, sRes *
 	}
 	tr, err := thumbnail.PrepareRequest(int(req.GetWidth()), int(req.GetHeight()), tType, sRes.GetInfo().GetChecksum().GetSum(), req.GetProcessor())
 	if err != nil {
-		return "", tr, merrors.BadRequest(g.serviceID, err.Error())
+		return "", tr, merrors.BadRequest(g.serviceID, "%s", err.Error())
 	}
 
 	if key, exists := g.manager.CheckThumbnail(tr); exists {
@@ -158,7 +158,7 @@ func (g Thumbnail) handleCS3Source(ctx context.Context, req *thumbnailssvc.GetTh
 	r, err := g.cs3Source.Get(ctx, src.GetPath())
 	switch {
 	case errors.Is(err, terrors.ErrImageTooLarge):
-		return "", merrors.Forbidden(g.serviceID, err.Error())
+		return "", merrors.Forbidden(g.serviceID, "%s", err.Error())
 	case err != nil:
 		return "", merrors.InternalServerError(g.serviceID, "could not get image from source: %s", err.Error())
 	}
@@ -175,7 +175,7 @@ func (g Thumbnail) handleCS3Source(ctx context.Context, req *thumbnailssvc.GetTh
 
 	key, err = g.manager.Generate(tr, img)
 	if errors.Is(err, terrors.ErrImageTooLarge) {
-		return "", merrors.Forbidden(g.serviceID, err.Error())
+		return "", merrors.Forbidden(g.serviceID, "%s", err.Error())
 	}
 	return key, err
 }
@@ -251,7 +251,7 @@ func (g Thumbnail) handleWebdavSource(ctx context.Context, req *thumbnailssvc.Ge
 	r, err := g.webdavSource.Get(ctx, imgURL.String())
 	switch {
 	case errors.Is(err, terrors.ErrImageTooLarge):
-		return "", merrors.Forbidden(g.serviceID, err.Error())
+		return "", merrors.Forbidden(g.serviceID, "%s", err.Error())
 	case err != nil:
 		return "", merrors.InternalServerError(g.serviceID, "could not get image from source: %s", err.Error())
 	}
@@ -267,7 +267,7 @@ func (g Thumbnail) handleWebdavSource(ctx context.Context, req *thumbnailssvc.Ge
 
 	key, err = g.manager.Generate(tr, img)
 	if errors.Is(err, terrors.ErrImageTooLarge) {
-		return "", merrors.Forbidden(g.serviceID, err.Error())
+		return "", merrors.Forbidden(g.serviceID, "%s", err.Error())
 	}
 	return key, err
 }

--- a/services/userlog/pkg/service/conversion.go
+++ b/services/userlog/pkg/service/conversion.go
@@ -376,7 +376,7 @@ func composeMessage(nt NotificationTemplate, locale, defaultLocale, path string,
 
 func loadTemplates(nt NotificationTemplate, locale, defaultLocale, path string) (string, string) {
 	t := l10n.NewTranslatorFromCommonConfig(defaultLocale, _domain, path, _translationFS, "l10n/locale").Locale(locale)
-	return t.Get(nt.Subject), t.Get(nt.Message)
+	return t.Get("%s", nt.Subject), t.Get("%s", nt.Message)
 }
 
 func executeTemplate(raw string, vars map[string]interface{}) (string, error) {


### PR DESCRIPTION
Go 1.24 does some stricter checks now on arguments to functions accepting format strings.
This commit fixes a couple of "non-constant format string in call to ..." errors when running the unit tests.