### PR TITLE
Reintroduce check for go before including bingo Makefile

### DIFF
--- a/opencloud/Makefile
+++ b/opencloud/Makefile
@@ -7,7 +7,9 @@ ifdef ENABLE_VIPS
 	TAGS := ${TAGS},enable_vips
 endif
 
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../.bingo/Variables.mk
+endif
 include ../.make/default.mk
 include ../.make/recursion.mk
 include ../.make/go.mk

--- a/pkg/Makefile
+++ b/pkg/Makefile
@@ -1,7 +1,9 @@
 SHELL := bash
 NAME := pkg
 
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../.bingo/Variables.mk
+endif
 include ../.make/default.mk
 include ../.make/recursion.mk
 include ../.make/go.mk

--- a/protogen/Makefile
+++ b/protogen/Makefile
@@ -1,7 +1,9 @@
 SHELL := bash
 NAME := protogen
 
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../.bingo/Variables.mk
+endif
 include ../.make/default.mk
 include ../.make/recursion.mk
 include ../.make/generate.mk

--- a/services/activitylog/Makefile
+++ b/services/activitylog/Makefile
@@ -3,7 +3,10 @@ NAME := activitylog
 OUTPUT_DIR = ./pkg/service/l10n
 TEMPLATE_FILE = ./pkg/service/l10n/activitylog.pot
 
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
+endif
+
 include ../../.make/default.mk
 include ../../.make/recursion.mk
 include ../../.make/go.mk

--- a/services/antivirus/Makefile
+++ b/services/antivirus/Makefile
@@ -1,7 +1,10 @@
 SHELL := bash
 NAME := antivirus
 
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
+endif
+
 include ../../.make/default.mk
 include ../../.make/recursion.mk
 include ../../.make/go.mk

--- a/services/app-provider/Makefile
+++ b/services/app-provider/Makefile
@@ -1,7 +1,10 @@
 SHELL := bash
 NAME := app-provider
 
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
+endif
+
 include ../../.make/default.mk
 include ../../.make/recursion.mk
 include ../../.make/go.mk

--- a/services/app-registry/Makefile
+++ b/services/app-registry/Makefile
@@ -1,7 +1,10 @@
 SHELL := bash
 NAME := app-registry
 
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
+endif
+
 include ../../.make/default.mk
 include ../../.make/recursion.mk
 include ../../.make/go.mk

--- a/services/audit/Makefile
+++ b/services/audit/Makefile
@@ -1,7 +1,10 @@
 SHELL := bash
 NAME := audit
 
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
+endif
+
 include ../../.make/default.mk
 include ../../.make/recursion.mk
 include ../../.make/go.mk

--- a/services/auth-app/Makefile
+++ b/services/auth-app/Makefile
@@ -1,7 +1,10 @@
 SHELL := bash
 NAME := auth-app
 
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
+endif
+
 include ../../.make/default.mk
 include ../../.make/recursion.mk
 include ../../.make/go.mk

--- a/services/auth-basic/Makefile
+++ b/services/auth-basic/Makefile
@@ -1,7 +1,10 @@
 SHELL := bash
 NAME := auth-basic
 
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
+endif
+
 include ../../.make/default.mk
 include ../../.make/recursion.mk
 include ../../.make/go.mk

--- a/services/auth-bearer/Makefile
+++ b/services/auth-bearer/Makefile
@@ -1,7 +1,10 @@
 SHELL := bash
 NAME := auth-bearer
 
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
+endif
+
 include ../../.make/default.mk
 include ../../.make/recursion.mk
 include ../../.make/go.mk

--- a/services/auth-machine/Makefile
+++ b/services/auth-machine/Makefile
@@ -1,7 +1,10 @@
 SHELL := bash
 NAME := auth-machine
 
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
+endif
+
 include ../../.make/default.mk
 include ../../.make/recursion.mk
 include ../../.make/go.mk

--- a/services/auth-service/Makefile
+++ b/services/auth-service/Makefile
@@ -1,7 +1,10 @@
 SHELL := bash
 NAME := auth-service
 
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
+endif
+
 include ../../.make/default.mk
 include ../../.make/recursion.mk
 include ../../.make/go.mk

--- a/services/clientlog/Makefile
+++ b/services/clientlog/Makefile
@@ -1,7 +1,10 @@
 SHELL := bash
 NAME := clientlog
 
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
+endif
+
 include ../../.make/default.mk
 include ../../.make/recursion.mk
 include ../../.make/go.mk

--- a/services/collaboration/Makefile
+++ b/services/collaboration/Makefile
@@ -1,7 +1,10 @@
 SHELL := bash
 NAME := collaboration
 
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
+endif
+
 include ../../.make/default.mk
 include ../../.make/recursion.mk
 include ../../.make/go.mk

--- a/services/eventhistory/Makefile
+++ b/services/eventhistory/Makefile
@@ -1,7 +1,10 @@
 SHELL := bash
 NAME := eventhistory
 
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
+endif
+
 include ../../.make/default.mk
 include ../../.make/recursion.mk
 include ../../.make/go.mk

--- a/services/frontend/Makefile
+++ b/services/frontend/Makefile
@@ -1,7 +1,10 @@
 SHELL := bash
 NAME := frontend
 
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
+endif
+
 include ../../.make/default.mk
 include ../../.make/recursion.mk
 include ../../.make/go.mk

--- a/services/gateway/Makefile
+++ b/services/gateway/Makefile
@@ -1,7 +1,10 @@
 SHELL := bash
 NAME := gateway
 
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
+endif
+
 include ../../.make/default.mk
 include ../../.make/recursion.mk
 include ../../.make/go.mk

--- a/services/graph/Makefile
+++ b/services/graph/Makefile
@@ -3,7 +3,10 @@ NAME := graph
 OUTPUT_DIR = ./pkg/l10n
 TEMPLATE_FILE = ./pkg/l10n/graph.pot
 
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
+endif
+
 include ../../.make/default.mk
 include ../../.make/recursion.mk
 include ../../.make/go.mk

--- a/services/groups/Makefile
+++ b/services/groups/Makefile
@@ -1,7 +1,10 @@
 SHELL := bash
 NAME := groups
 
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
+endif
+
 include ../../.make/default.mk
 include ../../.make/recursion.mk
 include ../../.make/go.mk

--- a/services/idm/Makefile
+++ b/services/idm/Makefile
@@ -2,7 +2,10 @@ SHELL := bash
 NAME := idm
 TAGS := disable_crypt
 
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
+endif
+
 include ../../.make/default.mk
 include ../../.make/recursion.mk
 include ../../.make/go.mk

--- a/services/idp/Makefile
+++ b/services/idp/Makefile
@@ -1,7 +1,10 @@
 SHELL := bash
 NAME := idp
 
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
+endif
+
 include ../../.make/default.mk
 include ../../.make/recursion.mk
 include ../../.make/go.mk

--- a/services/invitations/Makefile
+++ b/services/invitations/Makefile
@@ -1,7 +1,10 @@
 SHELL := bash
 NAME := invitations
 
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
+endif
+
 include ../../.make/default.mk
 include ../../.make/recursion.mk
 include ../../.make/go.mk

--- a/services/nats/Makefile
+++ b/services/nats/Makefile
@@ -1,7 +1,10 @@
 SHELL := bash
 NAME := nats
 
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
+endif
+
 include ../../.make/default.mk
 include ../../.make/recursion.mk
 include ../../.make/go.mk

--- a/services/notifications/Makefile
+++ b/services/notifications/Makefile
@@ -3,7 +3,10 @@ NAME := notifications
 OUTPUT_DIR = ./pkg/email/l10n
 TEMPLATE_FILE = ./pkg/email/l10n/notifications.pot
 
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
+endif
+
 include ../../.make/default.mk
 include ../../.make/recursion.mk
 include ../../.make/go.mk

--- a/services/ocdav/Makefile
+++ b/services/ocdav/Makefile
@@ -1,7 +1,10 @@
 SHELL := bash
 NAME := ocdav
 
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
+endif
+
 include ../../.make/default.mk
 include ../../.make/recursion.mk
 include ../../.make/go.mk

--- a/services/ocm/Makefile
+++ b/services/ocm/Makefile
@@ -1,7 +1,10 @@
 SHELL := bash
 NAME := ocm
 
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
+endif
+
 include ../../.make/default.mk
 include ../../.make/recursion.mk
 include ../../.make/go.mk

--- a/services/ocs/Makefile
+++ b/services/ocs/Makefile
@@ -1,7 +1,10 @@
 SHELL := bash
 NAME := ocs
 
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
+endif
+
 include ../../.make/default.mk
 include ../../.make/recursion.mk
 include ../../.make/go.mk

--- a/services/policies/Makefile
+++ b/services/policies/Makefile
@@ -1,7 +1,10 @@
 SHELL := bash
 NAME := policies
 
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
+endif
+
 include ../../.make/default.mk
 include ../../.make/recursion.mk
 include ../../.make/go.mk

--- a/services/postprocessing/Makefile
+++ b/services/postprocessing/Makefile
@@ -1,7 +1,10 @@
 SHELL := bash
 NAME := postprocessing
 
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
+endif
+
 include ../../.make/default.mk
 include ../../.make/recursion.mk
 include ../../.make/go.mk

--- a/services/proxy/Makefile
+++ b/services/proxy/Makefile
@@ -1,7 +1,10 @@
 SHELL := bash
 NAME := proxy
 
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
+endif
+
 include ../../.make/default.mk
 include ../../.make/recursion.mk
 include ../../.make/go.mk

--- a/services/search/Makefile
+++ b/services/search/Makefile
@@ -1,7 +1,10 @@
 SHELL := bash
 NAME := search
 
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
+endif
+
 include ../../.make/default.mk
 include ../../.make/recursion.mk
 include ../../.make/go.mk

--- a/services/settings/Makefile
+++ b/services/settings/Makefile
@@ -3,7 +3,10 @@ NAME := settings
 OUTPUT_DIR = ./pkg/service/v0/l10n
 TEMPLATE_FILE = ./pkg/service/v0/l10n/settings.pot
 
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
+endif
+
 include ../../.make/default.mk
 include ../../.make/recursion.mk
 include ../../.make/go.mk

--- a/services/sharing/Makefile
+++ b/services/sharing/Makefile
@@ -1,7 +1,10 @@
 SHELL := bash
 NAME := sharing
 
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
+endif
+
 include ../../.make/default.mk
 include ../../.make/recursion.mk
 include ../../.make/go.mk

--- a/services/sse/Makefile
+++ b/services/sse/Makefile
@@ -1,7 +1,10 @@
 SHELL := bash
 NAME := sse
 
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
+endif
+
 include ../../.make/default.mk
 include ../../.make/recursion.mk
 include ../../.make/go.mk

--- a/services/storage-publiclink/Makefile
+++ b/services/storage-publiclink/Makefile
@@ -1,7 +1,10 @@
 SHELL := bash
 NAME := storage-publiclink
 
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
+endif
+
 include ../../.make/default.mk
 include ../../.make/recursion.mk
 include ../../.make/go.mk

--- a/services/storage-shares/Makefile
+++ b/services/storage-shares/Makefile
@@ -1,7 +1,10 @@
 SHELL := bash
 NAME := storage-shares
 
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
+endif
+
 include ../../.make/default.mk
 include ../../.make/recursion.mk
 include ../../.make/go.mk

--- a/services/storage-system/Makefile
+++ b/services/storage-system/Makefile
@@ -1,7 +1,10 @@
 SHELL := bash
 NAME := storage-system
 
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
+endif
+
 include ../../.make/default.mk
 include ../../.make/recursion.mk
 include ../../.make/go.mk

--- a/services/storage-users/Makefile
+++ b/services/storage-users/Makefile
@@ -1,7 +1,10 @@
 SHELL := bash
 NAME := storage-users
 
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
+endif
+
 include ../../.make/default.mk
 include ../../.make/recursion.mk
 include ../../.make/go.mk

--- a/services/thumbnails/Makefile
+++ b/services/thumbnails/Makefile
@@ -1,7 +1,10 @@
 SHELL := bash
 NAME := thumbnails
 
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
+endif
+
 include ../../.make/default.mk
 include ../../.make/recursion.mk
 include ../../.make/go.mk

--- a/services/userlog/Makefile
+++ b/services/userlog/Makefile
@@ -3,7 +3,10 @@ NAME := userlog
 OUTPUT_DIR = ./pkg/service/l10n
 TEMPLATE_FILE = ./pkg/service/l10n/userlog.pot
 
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
+endif
+
 include ../../.make/default.mk
 include ../../.make/recursion.mk
 include ../../.make/go.mk

--- a/services/users/Makefile
+++ b/services/users/Makefile
@@ -1,7 +1,10 @@
 SHELL := bash
 NAME := users
 
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
+endif
+
 include ../../.make/default.mk
 include ../../.make/recursion.mk
 include ../../.make/go.mk

--- a/services/web/Makefile
+++ b/services/web/Makefile
@@ -3,7 +3,10 @@ NAME := web
 WEB_ASSETS_VERSION = v1.0.0
 WEB_ASSETS_BRANCH = main
 
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
+endif
+
 include ../../.make/default.mk
 include ../../.make/recursion.mk
 include ../../.make/go.mk

--- a/services/webdav/Makefile
+++ b/services/webdav/Makefile
@@ -1,7 +1,10 @@
 SHELL := bash
 NAME := webdav
 
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
+endif
+
 include ../../.make/default.mk
 include ../../.make/recursion.mk
 include ../../.make/go.mk

--- a/services/webfinger/Makefile
+++ b/services/webfinger/Makefile
@@ -1,7 +1,10 @@
 SHELL := bash
 NAME := webfinger
 
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
+endif
+
 include ../../.make/default.mk
 include ../../.make/recursion.mk
 include ../../.make/go.mk


### PR DESCRIPTION
This re-adds the check for go being installed before including the bingo variables make file to avoid repeating errors about missing a missing go binary when running 'make node-generate' in the ci (the node container doesn't have go installed)

