### PR TITLE
fix cache in CI

### DIFF
--- a/tests/config/woodpecker/check_web_cache.sh
+++ b/tests/config/woodpecker/check_web_cache.sh
@@ -10,16 +10,15 @@ fi
 
 echo "Checking web version - $WEB_COMMITID in cache"
 
-URL="$CACHE_ENDPOINT/$CACHE_BUCKET/opencloud/web-test-runner/$WEB_COMMITID/$1.tar.gz"
+mc alias set s3 "$MC_HOST" "$AWS_ACCESS_KEY_ID" "$AWS_SECRET_ACCESS_KEY"
 
-echo "Checking for the web cache at '$URL'."
-
-if curl --output /dev/null --silent --head --fail "$URL"
+if mc ls --json s3/"$CACHE_BUCKET"/opencloud/web-test-runner/"$WEB_COMMITID"/"$1".tar.gz | grep "\"status\":\"success\"";
 then
 	echo "$1 cache with commit id $WEB_COMMITID already available."
-	# https://discourse.drone.io/t/how-to-exit-a-pipeline-early-without-failing/3951
-	# exit a Pipeline early without failing
-	exit 78
+	ENV="WEB_CACHE_FOUND=true\n"
 else
 	echo "$1 cache with commit id $WEB_COMMITID was not available."
+	ENV="WEB_CACHE_FOUND=false\n"
 fi
+
+echo -e $ENV >> .woodpecker.env


### PR DESCRIPTION
## Description
The web and Go-bingo cache was never found because the bucket is not publicly available and we checked the existence of the cache just with a `curl` request to the public URL.
Now the cache is checked using `mc` and the correct access_id and access_secret

Because woodpecker does not have a custom exit code to skip the following steps without failing them, I'm just writing the result into an env file and reading it in every step that follows.

The pnpm store cache was not working because the filename to write the cache was `pnpm-store.tar.gz` but when checking it trying to restore we used `web-pnpm.tar.gz`

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- part of https://github.com/opencloud-eu/qa/issues/1

## Motivation and Context
save :timer_clock: 
save :earth_asia: 

## How Has This Been Tested?
:robot: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added
