### PR TITLE
fix: make re-build node artifacts

### DIFF
--- a/opencloud/Makefile
+++ b/opencloud/Makefile
@@ -37,9 +37,3 @@ dev-docker-multiarch:
 debug-docker:
 	$(MAKE) --no-print-directory debug-linux-docker-$(GOARCH)
 	docker build -f docker/Dockerfile.linux.debug.$(GOARCH) -t opencloud-eu/opencloud:debug .
-
-.PHONY: node-generate-prod
-node-generate-prod: # opencloud needs assets of all other modules
-	@if [ $(MAKE_DEPTH) -le 1 ]; then \
-	$(MAKE) --no-print-directory -C .. node-generate-prod \
-	; fi;


### PR DESCRIPTION
## Description
$OC_HOME/opencloud/Makefile contains `node-generate-prod` which is called by `node-generate-dev` (`*-dev` calls `*-prod` if undefined) which then calls all `*-prod` in each service... which overwrites the assets in web.

sounds complicated which it isnt, `porp ™` (a plain old recursion problem) 🤣 , we have multiple ways to fix it:

1. remove the fallback `*-prod` if no `*-dev` step is defined
1. remove the `node-generate-prod` loop in $OC_HOME/opencloud/Makefile

i decided for NR. 2 because I still think it is practical to have that fallback.