### PR TITLE
posixfs: Use userid as the foldername for personal space

### DIFF
--- a/services/storage-users/pkg/config/defaults/defaultconfig.go
+++ b/services/storage-users/pkg/config/defaults/defaultconfig.go
@@ -143,7 +143,7 @@ func DefaultConfig() *config.Config {
 				UseSpaceGroups:             false,
 				Root:                       filepath.Join(defaults.BaseDataPath(), "storage", "users"),
 				PersonalSpaceAliasTemplate: "{{.SpaceType}}/{{.User.Username | lower}}",
-				PersonalSpacePathTemplate:  "users/{{.User.Username}}",
+				PersonalSpacePathTemplate:  "users/{{.User.Id.OpaqueId}}",
 				GeneralSpaceAliasTemplate:  "{{.SpaceType}}/{{.SpaceName | replace \" \" \"-\" | lower}}",
 				GeneralSpacePathTemplate:   "projects/{{.SpaceId}}",
 				PermissionsEndpoint:        "eu.opencloud.api.settings",


### PR DESCRIPTION
This avoids loosing the user's personal space after renaming the user.

Closes: #192