### PR TITLE
chore: bump web to v2.0.0

### DIFF
--- a/.woodpecker.env
+++ b/.woodpecker.env
@@ -1,3 +1,3 @@
 # The test runner source for UI tests
-WEB_COMMITID=74c8df4f64d9bf957a0652fb92e01529efa3c0b3
+WEB_COMMITID=4a2f3a1d14009676a3a9dfef536ed4fd3e7f4c21
 WEB_BRANCH=main

--- a/services/web/Makefile
+++ b/services/web/Makefile
@@ -1,6 +1,6 @@
 SHELL := bash
 NAME := web
-WEB_ASSETS_VERSION = v1.0.0
+WEB_ASSETS_VERSION = v2.0.0
 WEB_ASSETS_BRANCH = main
 
 ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI


### PR DESCRIPTION
See https://github.com/opencloud-eu/web/releases/tag/v2.0.0 for a full list of changes.