### PR TITLE
feat: clear edition fallback

### DIFF
--- a/services/frontend/pkg/config/defaults/defaultconfig.go
+++ b/services/frontend/pkg/config/defaults/defaultconfig.go
@@ -87,7 +87,7 @@ func DefaultConfig() *config.Config {
 		DefaultUploadProtocol:    "tus",
 		DefaultLinkPermissions:   1,
 		SearchMinLength:          3,
-		Edition:                  "Community",
+		Edition:                  "",
 		Checksums: config.Checksums{
 			SupportedTypes:      []string{"sha1", "md5", "adler32"},
 			PreferredUploadType: "sha1",

--- a/services/frontend/pkg/revaconfig/config.go
+++ b/services/frontend/pkg/revaconfig/config.go
@@ -339,7 +339,7 @@ func FrontendConfigFromStruct(cfg *config.Config, logger log.Logger) (map[string
 						},
 						"version": map[string]interface{}{
 							"product":        "OpenCloud",
-							"edition":        "Community",
+							"edition":        "",
 							"major":          version.ParsedLegacy().Major(),
 							"minor":          version.ParsedLegacy().Minor(),
 							"micro":          version.ParsedLegacy().Patch(),

--- a/services/ocdav/pkg/config/defaults/defaultconfig.go
+++ b/services/ocdav/pkg/config/defaults/defaultconfig.go
@@ -92,7 +92,7 @@ func DefaultConfig() *config.Config {
 			ProductVersion: version.GetString(),
 			Product:        "OpenCloud",
 			ProductName:    "OpenCloud",
-			Edition:        "Community",
+			Edition:        "",
 		},
 	}
 }


### PR DESCRIPTION
Clears the `edition` fallback on "Community" in the capabilities. We want to have this as empty string without any fallback.

closes https://github.com/opencloud-eu/opencloud/issues/392