### PR TITLE
DNM test exclude/include condition

### DIFF
--- a/.woodpecker.star
+++ b/.woodpecker.star
@@ -2251,18 +2251,12 @@ def skipIfUnchanged(ctx, type):
         return []
 
     base = [
-        ".github/**",
-        ".vscode/**",
-        "changelog/**",
-        "docs/**",
-        "deployments/**",
         "CHANGELOG.md",
         "CONTRIBUTING.md",
         "LICENSE",
         "README.md",
     ]
     unit = [
-        "**/*_test.go",
     ]
     acceptance = [
         "tests/acceptance/**",

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![OpenCloud logo](https://raw.githubusercontent.com/opencloud-eu/opencloud/refs/heads/main/opencloud_logo.png)
-
+BLA
 [![status-badge](https://ci.opencloud.eu/api/badges/3/status.svg)](https://ci.opencloud.eu/repos/3)
  [![Matrix](https://img.shields.io/matrix/opencloud%3Amatrix.org?logo=matrix)](https://app.element.io/#/room/#opencloud:matrix.org)
  [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)

--- a/opencloud/cmd/opencloud/main.go
+++ b/opencloud/cmd/opencloud/main.go
@@ -10,6 +10,7 @@ import (
 func main() {
 	if err := command.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
+
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
This is just for show-casing some weird CI behavior.

Something is weird with the `exclude` patterns on the `when` `path` condition. This PR changes the some go code and the README. So it should run the full blown test suite. However most if the test a skipped.

As soon as I remove the README change all test are enabled. :dizzy_face: 

cc @micbar