### PR TITLE
fix(storage-users): 'uploads sessions' command crash

### DIFF
--- a/services/storage-users/pkg/command/uploads.go
+++ b/services/storage-users/pkg/command/uploads.go
@@ -117,7 +117,7 @@ func ListUploadSessions(cfg *config.Config) *cli.Command {
 			}
 
 			var stream events.Stream
-			if c.Bool("restart") {
+			if c.Bool("restart") || c.Bool("resume") {
 				stream, err = event.NewStream(cfg)
 				if err != nil {
 					fmt.Fprintf(os.Stderr, "Failed to create event stream: %v\n", err)


### PR DESCRIPTION
When started with the '--resume' command line switch the 'storage-users uploads sessions' was crashing because it did not initialize the event queue correctly.

Fixes: #390