### PR TITLE
chore: bump Collabora in deployment example and fix entrypoint

### DIFF
--- a/deployments/examples/opencloud_full/collabora.yml
+++ b/deployments/examples/opencloud_full/collabora.yml
@@ -53,7 +53,7 @@ services:
     restart: always
 
   collabora:
-    image: collabora/code:24.04.12.2.1
+    image: collabora/code:24.04.13.2.1
     # release notes: https://www.collaboraonline.com/release-notes/
     networks:
       opencloud-net:
@@ -80,6 +80,7 @@ services:
     logging:
       driver: ${LOG_DRIVER:-local}
     restart: always
-    command: ["bash", "-c", "coolconfig generate-proof-key ; /start-collabora-online.sh"]
+    entrypoint: ['/bin/bash', '-c']
+    command: ['coolconfig generate-proof-key && /start-collabora-online.sh']
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://localhost:9980/hosting/discovery" ]


### PR DESCRIPTION
Bumps Collabora in the deployment example to `24.04.13.2.1` and fixes the entrypoint. It seems to have changed with newer versions of the docker image, hence we need to specify the entrypoint manually to make the start commands work.
