### PR TITLE
fix keycloak example #465

### DIFF
--- a/deployments/examples/opencloud_full/keycloak.yml
+++ b/deployments/examples/opencloud_full/keycloak.yml
@@ -21,6 +21,7 @@ services:
       OC_ADMIN_USER_ID: ""
       GRAPH_ASSIGN_DEFAULT_USER_ROLE: "false"
       GRAPH_USERNAME_MATCH: "none"
+      KEYCLOAK_DOMAIN: ${KEYCLOAK_DOMAIN:-keycloak.opencloud.test} 
 
   postgres:
     image: postgres:alpine


### PR DESCRIPTION
https://github.com/opencloud-eu/opencloud/pull/465#issuecomment-2765385244

fix problem when we use `KEYCLOAK_DOMAIN` != `keycloak.opencloud.test` in the `.env`  

how to test: 
- enable `keycloack.yml` in the `.env` of the `opencloud_full` 
- set `KEYCLOAK_DOMAIN=newkeycloak.opencloud.test`
- start `opencloud` `docker compose up -d`
- open [cloud](https://cloud.opencloud.test/) in the browser

Actual: works fine
