### PR TITLE
chore: bump unzip extension to v1.0.2

### DIFF
--- a/deployments/examples/opencloud_full/web_extensions/unzip.yml
+++ b/deployments/examples/opencloud_full/web_extensions/unzip.yml
@@ -6,12 +6,10 @@ services:
         condition: service_completed_successfully
 
   unzip-init:
-    image: opencloudeu/web-extensions:unzip-1.0.0
+    image: opencloudeu/web-extensions:unzip-1.0.2
     user: root
     volumes:
       - opencloud-apps:/apps
     entrypoint:
       - /bin/sh
     command: ["-c", "cp -R /usr/share/nginx/html/unzip/ /apps"]
-
-


### PR DESCRIPTION
Bumps the unzip extension in the opencloud deployment example to `v1.0.2`.