### PR TITLE
Feat: install.sh now honors OC_BASE_DIR and OC_HOST

### DIFF
--- a/deployments/examples/bare-metal-simple/README.md
+++ b/deployments/examples/bare-metal-simple/README.md
@@ -26,6 +26,13 @@ This script should **NOT** be run as user root.
 Set the environment variable `OC_VERSION` to the version you want
 to download. If not set, there is a reasonable default. 
 
+## Data Location
+
+Set the environment variable `OC_BASE_DIR` to a directory where the
+`data` and `config` subdirectories shall be located. Per default,
+both configuration and storage data are within a sandbox subdirectory
+in the current working directory.
+
 # Example
 
 Call

--- a/deployments/examples/bare-metal-simple/README.md
+++ b/deployments/examples/bare-metal-simple/README.md
@@ -35,7 +35,7 @@ in the current working directory.
 
 ## Server Address
 
-Set the environment variable `OC_HOST` to the full qualified hostname
+Set the environment variable `OC_HOST` to the fully qualified hostname
 or of this server to allow remote accesse. Default: `localhost`.
 
 # Example

--- a/deployments/examples/bare-metal-simple/README.md
+++ b/deployments/examples/bare-metal-simple/README.md
@@ -33,6 +33,11 @@ Set the environment variable `OC_BASE_DIR` to a directory where the
 both configuration and storage data are within a sandbox subdirectory
 in the current working directory.
 
+## Server Address
+
+Set the environment variable `OC_HOST` to the full qualified hostname
+or of this server to allow remote accesse. Default: `localhost`.
+
 # Example
 
 Call

--- a/deployments/examples/bare-metal-simple/README.md
+++ b/deployments/examples/bare-metal-simple/README.md
@@ -36,7 +36,7 @@ in the current working directory.
 ## Server Address
 
 Set the environment variable `OC_HOST` to the fully qualified hostname
-or of this server to allow remote accesse. Default: `localhost`.
+of this server to allow remote accesse. Default: `localhost`.
 
 # Example
 

--- a/deployments/examples/bare-metal-simple/install.sh
+++ b/deployments/examples/bare-metal-simple/install.sh
@@ -69,11 +69,10 @@ echo "Downloading ${dlurl}/${dlfile}"
 curl -L -o "${dlfile}" --progress-bar "${dlurl}/${dlfile}"
 chmod 755 ${dlfile}
 
-mkdir data config
-
 basedir="${OC_BASE_DIR:-$(pwd)}"
 export OC_CONFIG_DIR="$basedir/config"
 export OC_BASE_DATA_PATH="$basedir/data"
+mkdir "$OC_CONFIG_DIR" "$OC_BASE_DATA_PATH"
 
 # It is bound to localhost for now to deal with non existing routes
 # to certain host names for example in WSL

--- a/deployments/examples/bare-metal-simple/install.sh
+++ b/deployments/examples/bare-metal-simple/install.sh
@@ -71,8 +71,9 @@ chmod 755 ${dlfile}
 
 mkdir data config
 
-export OC_CONFIG_DIR="$(pwd)/config"
-export OC_BASE_DATA_PATH="$(pwd)/data"
+basedir="${OC_BASE_DIR:-$(pwd)}"
+export OC_CONFIG_DIR="$basedir/config"
+export OC_BASE_DATA_PATH="$basedir/data"
 
 # It is bound to localhost for now to deal with non existing routes
 # to certain host names for example in WSL

--- a/deployments/examples/bare-metal-simple/install.sh
+++ b/deployments/examples/bare-metal-simple/install.sh
@@ -77,7 +77,7 @@ export OC_BASE_DATA_PATH="$basedir/data"
 
 # It is bound to localhost for now to deal with non existing routes
 # to certain host names for example in WSL
-host="localhost"
+host="${OC_HOST:-localhost}"
 
 ./${dlfile} init --insecure yes --ap admin
 

--- a/deployments/examples/bare-metal-simple/install.sh
+++ b/deployments/examples/bare-metal-simple/install.sh
@@ -72,7 +72,7 @@ chmod 755 ${dlfile}
 basedir="${OC_BASE_DIR:-$(pwd)}"
 export OC_CONFIG_DIR="$basedir/config"
 export OC_BASE_DATA_PATH="$basedir/data"
-mkdir "$OC_CONFIG_DIR" "$OC_BASE_DATA_PATH"
+mkdir -p "$OC_CONFIG_DIR" "$OC_BASE_DATA_PATH"
 
 # It is bound to localhost for now to deal with non existing routes
 # to certain host names for example in WSL


### PR DESCRIPTION
<!--

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description

The quick install.sh has hardcoded paths.
This feature adds an option to set (both!) config and data to some specified parent directory as well as the hostname of the server.


## Motivation and Context
Simplifies testing with different back end storages.
Locally and on remote servers

## How Has This Been Tested?
Manually

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation added
