### PR TITLE
[full-ci] only use wrapper when requested

### DIFF
--- a/.woodpecker.star
+++ b/.woodpecker.star
@@ -2071,11 +2071,18 @@ def opencloudServer(storage = "decomposed", accounts_hash_difficulty = 4, depend
     for item in extra_server_environment:
         environment[item] = extra_server_environment[item]
 
-    wrapper_commands = [
-        "make -C %s build" % dirs["ocWrapper"],
+    server_commands = [
         "env | sort",
-        "%s/bin/ocwrapper serve --bin %s --url %s --admin-username admin --admin-password admin" % (dirs["ocWrapper"], dirs["opencloudBin"], environment["OC_URL"]),
     ]
+    if with_wrapper:
+        server_commands += [
+            "make -C %s build" % dirs["ocWrapper"],
+            "%s/bin/ocwrapper serve --bin %s --url %s --admin-username admin --admin-password admin" % (dirs["ocWrapper"], dirs["opencloudBin"], environment["OC_URL"]),
+        ]
+    else:
+        server_commands += [
+            "%s server" % dirs["opencloudBin"],
+        ]
 
     wait_for_opencloud = {
         "name": "wait-for-%s" % container_name,
@@ -2102,7 +2109,7 @@ def opencloudServer(storage = "decomposed", accounts_hash_difficulty = 4, depend
             "%s init --insecure true" % dirs["opencloudBin"],
             "cat $OC_CONFIG_DIR/opencloud.yaml",
             "cp tests/config/woodpecker/app-registry.yaml $OC_CONFIG_DIR/app-registry.yaml",
-        ] + wrapper_commands,
+        ] + server_commands,
     }
 
     steps = [


### PR DESCRIPTION
## Description
only use the wrapper in the tests if needed, otherwise just run opencloud binary by itself

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/opencloud-eu/opencloud/issues/408

## Motivation and Context
make the function do what it promises

## How Has This Been Tested?
:wood: - :pick: (:bird:)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added
