### PR TITLE
feat: improve the info about storage path in deployment example

### DIFF
--- a/deployments/examples/opencloud_full/.env
+++ b/deployments/examples/opencloud_full/.env
@@ -64,6 +64,8 @@ LOG_LEVEL=
 # LOG_PRETTY=true
 #
 # Define the openCloud storage location. Set the paths for config and data to a local path.
+# Ensure that the configuration and data directories are owned by the user and group with ID 1000:1000. 
+# This matches the default user inside the container and avoids permission issues when accessing files.
 # Note that especially the data directory can grow big.
 # Leaving it default stores data in docker internal volumes.
 # OC_CONFIG_DIR=/your/local/opencloud/config


### PR DESCRIPTION


## Description
Improve the description about the storage path in the .env. Add that the data directories are owned by the user and group with ID 1000:1000

## Related Issue
- Fixes [docs issue](https://github.com/opencloud-eu/docs/issues/195)

## Motivation and Context
Help user to run into permission issues.

## How Has This Been Tested?
tested with our docker compose full setup



