### PR TITLE
[full-ci] chore(web): bump web to v2.1.1

### DIFF
--- a/.woodpecker.env
+++ b/.woodpecker.env
@@ -1,3 +1,3 @@
 # The test runner source for UI tests
-WEB_COMMITID=4f68c1e1dbcc88839e42c17c57f31dec243d7bd0
-WEB_BRANCH=main
+WEB_COMMITID=59e329cc5fe288cf247cc5272547a77ac59cc000
+WEB_BRANCH=stable-2.1

--- a/services/web/Makefile
+++ b/services/web/Makefile
@@ -1,6 +1,6 @@
 SHELL := bash
 NAME := web
-WEB_ASSETS_VERSION = v2.1.0
+WEB_ASSETS_VERSION = v2.1.1
 WEB_ASSETS_BRANCH = main
 
 ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI


### PR DESCRIPTION
See changelog: https://github.com/opencloud-eu/web/releases/tag/v2.1.1