### PR TITLE
fix: add Traefik middleware in deployment example to mitigate status 415 for MKCOL/MOVE

### DIFF
--- a/deployments/examples/opencloud_full/opencloud.yml
+++ b/deployments/examples/opencloud_full/opencloud.yml
@@ -71,6 +71,11 @@ services:
       - "traefik.http.routers.opencloud.tls.certresolver=http"
       - "traefik.http.routers.opencloud.service=opencloud"
       - "traefik.http.services.opencloud.loadbalancer.server.port=9200"
+      # fix for MKCOL and MOVE
+      - "traefik.http.routers.opencloud-mkcol.rule=Host(`${OC_DOMAIN:-cloud.opencloud.test}`) && (Method(`MKCOL`) || Method(`MOVE`))"
+      - "traefik.http.routers.opencloud-mkcol.middlewares=opencloud-mkcol-body"
+      - "traefik.http.routers.opencloud-mkcol.service=opencloud"
+      - "traefik.http.middlewares.opencloud-mkcol-body.buffering.maxRequestBodyBytes=1"
     logging:
       driver: ${LOG_DRIVER:-local}
     restart: always


### PR DESCRIPTION
## Description

See #675 for details.

Creating folders or moving files is not possible when using Traefik with OpenCloud. The MKCOL/MOVE requests produce status 415.

The underlying problem is described here, along with a fix in the Traefik configuration:
https://github.com/owncloud/ocis/issues/10809#issuecomment-2695403425

Since the deployment example in `deployments/examples/opencloud_full/opencloud.yml` is affected, I added this fix to the Docker labels:

```diff
+      - "traefik.http.routers.opencloud-mkcol.rule=Host(`${OC_DOMAIN:-cloud.opencloud.test}`) && (Method(`MKCOL`) || Method(`MOVE`))"
+      - "traefik.http.routers.opencloud-mkcol.middlewares?opencloud-mkcol-body"
+      - "traefik.http.routers.opencloud-mkcol.service=opencloud"
+      - "traefik.http.middlewares.opencloud-mkcol-body.buffering.maxRequestBodyBytes=1"
```

I'm not sure if other proxies (Caddy?) are affected, so maybe this should be mitigated in the server instead. But I'll leave this here anyway so OpenCloud can be run through Traefik at all.

## Related Issue
- Fixes #675 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added

(Not sure which checkboxes apply here, since this is "only" a documentation/example change)