### PR TITLE
Add label bot to stable branch

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -23,5 +23,6 @@ jobs:
             Type:Maintenance
             Type:Security
             Type:Dependencies
+            Type:DevOps
             dependencies
           add_comment: true

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,0 +1,27 @@
+name: Require Pull Request Labels
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: mheap/github-action-required-labels@v5
+        with:
+          mode: minimum
+          count: 1
+          labels: |
+            Type:Bug
+            Type:Enhancement
+            Type:Feature
+            Type:Breaking-Change
+            Type:Test
+            Type:Documentation
+            Type:Maintenance
+            Type:Security
+            Type:Dependencies
+            dependencies
+          add_comment: true


### PR DESCRIPTION
I noticed that we haven't label bot in the stable-2.0
This is a cool feature that would be nice to have in the stable version
