### PR TITLE
fix(decomposeds3): enable async-uploads by default

### DIFF
--- a/services/storage-users/pkg/config/defaults/defaultconfig.go
+++ b/services/storage-users/pkg/config/defaults/defaultconfig.go
@@ -123,6 +123,7 @@ func DefaultConfig() *config.Config {
 				MaxConcurrency:             5,
 				LockCycleDurationFactor:    30,
 				DisableMultipart:           true,
+				AsyncUploads:               true,
 			},
 			Decomposed: config.DecomposedDriver{
 				Propagator:                 "sync",


### PR DESCRIPTION
## Description
decomposedfss3 has not turned on `OC_ASYNC_UPLOADS` by default which leads to unwanted side-effects when enabling virus-scanning or fulltext-search indexing (tika)

## Related Issue
- Fixes https://github.com/opencloud-eu/opencloud/issues/573
- Fixes https://github.com/opencloud-eu/opencloud/issues/656

## Motivation and Context
OC_ASYNC_UPLOADS is enabled by default for posixfs and decomposedfs but currently not for decomposedfss3, to align with the other implementations it should be turned on by default.

## How Has This Been Tested?
- local reproduction

## Screenshots (if appropriate):

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)