### PR TITLE
Automatically find the latest released version of opencloud

### DIFF
--- a/deployments/examples/bare-metal-simple/install.sh
+++ b/deployments/examples/bare-metal-simple/install.sh
@@ -34,10 +34,18 @@ function backup_file () {
     fi
 }
 
+function get_latest_version() {
+     latest_version=`curl --silent "https://api.github.com/repos/opencloud-eu/opencloud/releases/latest" \
+	     | jq -r .tag_name \
+	     | sed -e s/^v//`
+}
+
 # URL pattern of the download file
 # https://github.com/opencloud-eu/opencloud/releases/download/v1.0.0/opencloud-1.0.0-linux-amd64
 
-dlversion="${OC_VERSION:-2.0.0}"
+get_latest_version
+
+dlversion="${OC_VERSION:-$latest_version}"
 dlurl="https://github.com/opencloud-eu/opencloud/releases/download/v${dlversion}/"
 
 sandbox="opencloud-sandbox-${dlversion}"


### PR DESCRIPTION

## Description
So far the latest version of the rolling release was hardcoded in the script, which outdates often.

With this improvement it queries the github api for the latest release and uses the version number from there as default.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added
