### PR TITLE
[full-ci] check that user has only one personal space

### DIFF
--- a/tests/acceptance/TestHelpers/GraphHelper.php
+++ b/tests/acceptance/TestHelpers/GraphHelper.php
@@ -1069,7 +1069,7 @@ class GraphHelper {
 		array  $body = [],
 		array  $headers = []
 	): ResponseInterface {
-		$url = self::getFullUrl($baseUrl, 'drives/' . $urlArguments);
+		$url = self::getBetaFullUrl($baseUrl, 'drives/' . $urlArguments);
 
 		return HttpRequestHelper::get($url, $xRequestId, $user, $password, $headers, $body);
 	}

--- a/tests/acceptance/bootstrap/Provisioning.php
+++ b/tests/acceptance/bootstrap/Provisioning.php
@@ -1985,8 +1985,29 @@ trait Provisioning {
 		if ($this->isTestingWithLdap()) {
 			$this->deleteLdapUsersAndGroups();
 		}
+
+		$assertionFailed = false;
+		$errorMessage = '';
+
+		// check that created users have only one personal space
+		try {
+			$this->setResponse(
+				$this->spacesContext->listAllAvailableSpaces("admin", "%24filter=driveType+eq+personal")
+			);
+			$this->spacesContext->jsonRespondedShouldContainOnlyOneSpace();
+			$this->spacesContext->jsonRespondedShouldNotContainSpaceWithoutName();
+		} catch (\Throwable $e) {
+			$assertionFailed = true;
+			$errorMessage = $e->getMessage();
+			echo "\n[WARNING] Space assertion failed: " . $errorMessage . "\n";
+		}
+
 		$this->cleanupDatabaseUsers();
 		$this->cleanupDatabaseGroups();
+
+		if ($assertionFailed) {
+			throw new \Exception("Space assertion failed:\n" . $errorMessage);
+		}
 	}
 
 	/**

--- a/tests/acceptance/bootstrap/SpacesContext.php
+++ b/tests/acceptance/bootstrap/SpacesContext.php
@@ -1088,6 +1088,74 @@ class SpacesContext implements Context {
 	}
 
 	/**
+	 * @return void
+	 * @throws Exception
+	 */
+	public function jsonRespondedShouldContainOnlyOneSpace(): void {
+		$response = $response ?? $this->featureContext->getResponse();
+		$decodedResponse = $this->featureContext->getJsonDecodedResponse($response);
+		$userAdmin = $this->featureContext->getAdminUsername();
+
+		$aliases = [];
+		foreach ($decodedResponse['value'] as $space) {
+			$alias = $space['driveAlias'];
+			if (isset($aliases[$alias])) {
+				GraphHelper::disableSpace(
+					$this->featureContext->getBaseUrl(),
+					$userAdmin,
+					$this->featureContext->getPasswordForUser($userAdmin),
+					$space["id"],
+					$this->featureContext->getStepLineRef()
+				);
+				GraphHelper::deleteSpace(
+					$this->featureContext->getBaseUrl(),
+					$userAdmin,
+					$this->featureContext->getPasswordForUser($userAdmin),
+					$space["id"],
+					$this->featureContext->getStepLineRef()
+				);
+				Assert::fail(
+					"Duplicate space found: '$alias'\nResponse:\n" . json_encode($decodedResponse, JSON_PRETTY_PRINT)
+				);
+			}
+			$aliases[$alias] = true;
+		}
+
+	}
+
+	/**
+	 * @return void
+	 * @throws Exception
+	 */
+	public function jsonRespondedShouldNotContainSpaceWithoutName(): void {
+		$response = $response ?? $this->featureContext->getResponse();
+		$decodedResponse = $this->featureContext->getJsonDecodedResponse($response);
+		$userAdmin = $this->featureContext->getAdminUsername();
+
+		foreach ($decodedResponse['value'] as $space) {
+			if ($space['name'] === "") {
+				GraphHelper::disableSpace(
+					$this->featureContext->getBaseUrl(),
+					$userAdmin,
+					$this->featureContext->getPasswordForUser($userAdmin),
+					$space["id"],
+					$this->featureContext->getStepLineRef()
+				);
+				GraphHelper::deleteSpace(
+					$this->featureContext->getBaseUrl(),
+					$userAdmin,
+					$this->featureContext->getPasswordForUser($userAdmin),
+					$space["id"],
+					$this->featureContext->getStepLineRef()
+				);
+				Assert::fail(
+					"Space without name found. \nResponse:\n" . json_encode($decodedResponse, JSON_PRETTY_PRINT)
+				);
+			}
+		}
+	}
+
+	/**
 	 * @Then /^the user "([^"]*)" should (not |)have a space called "([^"]*)"$/
 	 *
 	 * @param string $user


### PR DESCRIPTION
While testing https://github.com/opencloud-eu/opencloud/issues/735, I found that the user had two identical personal spaces. I couldn't reproduce this manually so I wrote a test for it

Here before deleting the test users, I added a check that the users don't have two personal spaces and that we don't have incompatible data (space without name) such as `“driveAlias”: “personal/"`.

let's see what CI has to say
СС @aduffeck 