### PR TITLE
proxy(router): Allow to set some outgoing headers

### DIFF
--- a/pkg/middleware/account.go
+++ b/pkg/middleware/account.go
@@ -42,7 +42,7 @@ func ExtractAccountUUID(opts ...account.Option) func(http.Handler) http.Handler 
 	}
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			token := r.Header.Get("x-access-token")
+			token := r.Header.Get(revactx.TokenHeader)
 			if len(token) == 0 {
 				roleIDsJSON, _ := json.Marshal([]string{})
 				ctx := metadata.Set(r.Context(), RoleIDs, string(roleIDsJSON))

--- a/services/activitylog/pkg/service/http.go
+++ b/services/activitylog/pkg/service/http.go
@@ -45,7 +45,7 @@ func (s *ActivitylogService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // HandleGetItemActivities handles the request to get the activities of an item.
 func (s *ActivitylogService) HandleGetItemActivities(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	ctx = metadata.AppendToOutgoingContext(ctx, revactx.TokenHeader, r.Header.Get("X-Access-Token"))
+	ctx = metadata.AppendToOutgoingContext(ctx, revactx.TokenHeader, r.Header.Get(revactx.TokenHeader))
 
 	activeUser, ok := revactx.ContextGetUser(ctx)
 	if !ok {

--- a/services/auth-app/pkg/service/service.go
+++ b/services/auth-app/pkg/service/service.go
@@ -278,7 +278,7 @@ func (a *AuthAppService) authenticateUser(userID, userName string, gwc gateway.G
 
 func getContext(r *http.Request) context.Context {
 	ctx := r.Context()
-	return metadata.AppendToOutgoingContext(ctx, ctxpkg.TokenHeader, r.Header.Get("X-Access-Token"))
+	return metadata.AppendToOutgoingContext(ctx, ctxpkg.TokenHeader, r.Header.Get(ctxpkg.TokenHeader))
 }
 
 func buildClientID(userID, userName string) string {

--- a/services/graph/pkg/middleware/auth.go
+++ b/services/graph/pkg/middleware/auth.go
@@ -42,7 +42,7 @@ func Auth(opts ...account.Option) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ctx := r.Context()
-			t := r.Header.Get("x-access-token")
+			t := r.Header.Get(revactx.TokenHeader)
 			if t == "" {
 				errorcode.InvalidAuthenticationToken.Render(w, r, http.StatusUnauthorized, "Access token is empty.")
 				/* msgraph error for GET https://graph.microsoft.com/v1.0/me

--- a/services/graph/pkg/middleware/auth.go
+++ b/services/graph/pkg/middleware/auth.go
@@ -11,7 +11,6 @@ import (
 	opkgm "github.com/opencloud-eu/opencloud/pkg/middleware"
 	"github.com/opencloud-eu/opencloud/services/graph/pkg/errorcode"
 	"github.com/opencloud-eu/reva/v2/pkg/auth/scope"
-	ctxpkg "github.com/opencloud-eu/reva/v2/pkg/ctx"
 	revactx "github.com/opencloud-eu/reva/v2/pkg/ctx"
 	"github.com/opencloud-eu/reva/v2/pkg/token/manager/jwt"
 )
@@ -84,10 +83,10 @@ func Auth(opts ...account.Option) func(http.Handler) http.Handler {
 			}
 			ctx = metadata.AppendToOutgoingContext(ctx, revactx.TokenHeader, t)
 
-			initiatorID := r.Header.Get(ctxpkg.InitiatorHeader)
+			initiatorID := r.Header.Get(revactx.InitiatorHeader)
 			if initiatorID != "" {
-				ctx = ctxpkg.ContextSetInitiator(ctx, initiatorID)
-				ctx = metadata.AppendToOutgoingContext(ctx, ctxpkg.InitiatorHeader, initiatorID)
+				ctx = revactx.ContextSetInitiator(ctx, initiatorID)
+				ctx = metadata.AppendToOutgoingContext(ctx, revactx.InitiatorHeader, initiatorID)
 			}
 
 			next.ServeHTTP(w, r.WithContext(ctx))

--- a/services/proxy/pkg/command/server.go
+++ b/services/proxy/pkg/command/server.go
@@ -294,6 +294,7 @@ func loadMiddlewares(logger log.Logger, cfg *config.Config,
 		authenticators = append(authenticators, middleware.AppAuthAuthenticator{
 			Logger:              logger,
 			RevaGatewaySelector: gatewaySelector,
+			UserRoleAssigner:    roleAssigner,
 		})
 	}
 	authenticators = append(authenticators, middleware.NewOIDCAuthenticator(

--- a/services/proxy/pkg/config/config.go
+++ b/services/proxy/pkg/config/config.go
@@ -64,9 +64,12 @@ type Route struct {
 	// Backend is a static URL to forward the request to
 	Backend string `yaml:"backend,omitempty"`
 	// Service name to look up in the registry
-	Service     string `yaml:"service,omitempty"`
-	ApacheVHost bool   `yaml:"apache_vhost,omitempty"`
-	Unprotected bool   `yaml:"unprotected,omitempty"`
+	Service           string            `yaml:"service,omitempty"`
+	ApacheVHost       bool              `yaml:"apache_vhost,omitempty"`
+	Unprotected       bool              `yaml:"unprotected,omitempty"`
+	AdditionalHeaders map[string]string `yaml:"additional_headers,omitempty"`
+	RemoteUserHeader  string            `yaml:"remote_user_header,omitempty"`
+	SkipXAccessToken  bool              `yaml:"skip_x_access_token"`
 }
 
 // RouteType defines the type of route

--- a/services/proxy/pkg/middleware/account_resolver.go
+++ b/services/proxy/pkg/middleware/account_resolver.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/jellydator/ttlcache/v3"
+	"github.com/opencloud-eu/opencloud/services/proxy/pkg/router"
 	"github.com/opencloud-eu/opencloud/services/proxy/pkg/user/backend"
 	"github.com/opencloud-eu/opencloud/services/proxy/pkg/userroles"
 
@@ -209,7 +210,13 @@ func (m accountResolver) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		}
 	}
 
-	req.Header.Set(revactx.TokenHeader, token)
+	ri := router.ContextRoutingInfo(ctx)
+	if ri.RemoteUserHeader() != "" {
+		req.Header.Set(ri.RemoteUserHeader(), user.GetId().GetOpaqueId())
+	}
+	if !ri.SkipXAccessToken() {
+		req.Header.Set(revactx.TokenHeader, token)
+	}
 
 	m.next.ServeHTTP(w, req)
 }

--- a/services/proxy/pkg/middleware/account_resolver_test.go
+++ b/services/proxy/pkg/middleware/account_resolver_test.go
@@ -9,6 +9,7 @@ import (
 	userv1beta1 "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	"github.com/opencloud-eu/opencloud/pkg/log"
 	"github.com/opencloud-eu/opencloud/pkg/oidc"
+	"github.com/opencloud-eu/opencloud/services/proxy/pkg/router"
 	"github.com/opencloud-eu/opencloud/services/proxy/pkg/user/backend"
 	"github.com/opencloud-eu/opencloud/services/proxy/pkg/user/backend/mocks"
 	userRoleMocks "github.com/opencloud-eu/opencloud/services/proxy/pkg/userroles/mocks"
@@ -206,6 +207,7 @@ func mockRequest(claims map[string]interface{}) (*http.Request, *httptest.Respon
 	}
 
 	ctx := oidc.NewContext(context.Background(), claims)
+	ctx = router.SetRoutingInfo(ctx, router.RoutingInfo{})
 	req := httptest.NewRequest("GET", "http://example.com/foo", nil).WithContext(ctx)
 	rw := httptest.NewRecorder()
 

--- a/services/proxy/pkg/middleware/app_auth_test.go
+++ b/services/proxy/pkg/middleware/app_auth_test.go
@@ -5,19 +5,24 @@ import (
 	"net/http/httptest"
 
 	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
+	userv1beta1 "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	rpcv1beta1 "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
-	"github.com/opencloud-eu/reva/v2/pkg/rgrpc/todo/pool"
-	"google.golang.org/grpc"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/opencloud-eu/opencloud/pkg/log"
+	userRoleMocks "github.com/opencloud-eu/opencloud/services/proxy/pkg/userroles/mocks"
+	revactx "github.com/opencloud-eu/reva/v2/pkg/ctx"
+	"github.com/opencloud-eu/reva/v2/pkg/rgrpc/todo/pool"
+	"github.com/stretchr/testify/mock"
+	"google.golang.org/grpc"
 )
 
 var _ = Describe("Authenticating requests", Label("AppAuthAuthenticator"), func() {
 	var authenticator Authenticator
 	BeforeEach(func() {
 		pool.RemoveSelector("GatewaySelector" + "eu.opencloud.api.gateway")
+		ra := &userRoleMocks.UserRoleAssigner{}
+		ra.On("ApplyUserRole", mock.Anything, mock.Anything, mock.Anything).Return(&userv1beta1.User{}, nil)
 		authenticator = AppAuthAuthenticator{
 			Logger: log.NewLogger(),
 			RevaGatewaySelector: pool.GetSelector[gateway.GatewayAPIClient](
@@ -39,6 +44,7 @@ var _ = Describe("Authenticating requests", Label("AppAuthAuthenticator"), func(
 					}
 				},
 			),
+			UserRoleAssigner: ra,
 		}
 	})
 
@@ -51,7 +57,12 @@ var _ = Describe("Authenticating requests", Label("AppAuthAuthenticator"), func(
 
 			Expect(valid).To(Equal(true))
 			Expect(req2).ToNot(BeNil())
-			Expect(req2.Header.Get("x-access-token")).To(Equal("reva-token"))
+			user, ok := revactx.ContextGetUser(req2.Context())
+			Expect(ok).To(BeTrue())
+			Expect(user).ToNot(BeNil())
+			token, ok := revactx.ContextGetToken(req2.Context())
+			Expect(ok).To(BeTrue())
+			Expect(token).To(Equal("reva-token"))
 		})
 	})
 

--- a/services/proxy/pkg/middleware/authentication_test.go
+++ b/services/proxy/pkg/middleware/authentication_test.go
@@ -163,7 +163,7 @@ var _ = Describe("Authenticating requests", Label("Authentication"), func() {
 				EnableBasicAuth(true),
 			)
 			testHandler := handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				Expect(r.Header.Get(_headerRevaAccessToken)).To(Equal("otherexampletoken"))
+				Expect(r.Header.Get(headerRevaAccessToken)).To(Equal("otherexampletoken"))
 			}))
 			rr := httptest.NewRecorder()
 			testHandler.ServeHTTP(rr, req)
@@ -178,7 +178,7 @@ var _ = Describe("Authenticating requests", Label("Authentication"), func() {
 				EnableBasicAuth(true),
 			)
 			testHandler := handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				Expect(r.Header.Get(_headerRevaAccessToken)).To(Equal("exampletoken"))
+				Expect(r.Header.Get(headerRevaAccessToken)).To(Equal("exampletoken"))
 			}))
 			rr := httptest.NewRecorder()
 			testHandler.ServeHTTP(rr, req)
@@ -193,7 +193,7 @@ var _ = Describe("Authenticating requests", Label("Authentication"), func() {
 				EnableBasicAuth(true),
 			)
 			testHandler := handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				Expect(r.Header.Get(_headerRevaAccessToken)).To(Equal("otherexampletoken"))
+				Expect(r.Header.Get(headerRevaAccessToken)).To(Equal("otherexampletoken"))
 			}))
 			rr := httptest.NewRecorder()
 			testHandler.ServeHTTP(rr, req)

--- a/services/proxy/pkg/middleware/create_home.go
+++ b/services/proxy/pkg/middleware/create_home.go
@@ -45,7 +45,7 @@ func (m createHome) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	token := req.Header.Get("x-access-token")
+	token := req.Header.Get(revactx.TokenHeader)
 
 	// we need to pass the token to authenticate the CreateHome request.
 	//ctx := tokenpkg.ContextSetToken(r.Context(), token)
@@ -84,7 +84,7 @@ func (m createHome) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 }
 
 func (m createHome) shouldServe(req *http.Request) bool {
-	return req.Header.Get("x-access-token") != ""
+	return req.Header.Get(revactx.TokenHeader) != ""
 }
 
 func (m createHome) getUserRoles(user *userv1beta1.User) ([]string, error) {

--- a/services/proxy/pkg/middleware/public_share_auth.go
+++ b/services/proxy/pkg/middleware/public_share_auth.go
@@ -6,11 +6,12 @@ import (
 
 	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
 	"github.com/opencloud-eu/opencloud/pkg/log"
+	revactx "github.com/opencloud-eu/reva/v2/pkg/ctx"
 	"github.com/opencloud-eu/reva/v2/pkg/rgrpc/todo/pool"
 )
 
 const (
-	_headerRevaAccessToken  = "x-access-token"
+	headerRevaAccessToken   = revactx.TokenHeader
 	headerShareToken        = "public-token"
 	basicAuthPasswordPrefix = "password|"
 	authenticationType      = "publicshares"
@@ -118,7 +119,7 @@ func (a PublicShareAuthenticator) Authenticate(r *http.Request) (*http.Request, 
 		return nil, false
 	}
 
-	r.Header.Add(_headerRevaAccessToken, authResp.Token)
+	r.Header.Add(headerRevaAccessToken, authResp.Token)
 
 	a.Logger.Debug().
 		Str("authenticator", "public_share").

--- a/services/proxy/pkg/middleware/public_share_auth_test.go
+++ b/services/proxy/pkg/middleware/public_share_auth_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Authenticating requests", Label("PublicShareAuthenticator"), f
 				Expect(req2).ToNot(BeNil())
 
 				h := req2.Header
-				Expect(h.Get(_headerRevaAccessToken)).To(Equal("exampletoken"))
+				Expect(h.Get(headerRevaAccessToken)).To(Equal("exampletoken"))
 			})
 		})
 		Context("using signature authentication", func() {
@@ -71,7 +71,7 @@ var _ = Describe("Authenticating requests", Label("PublicShareAuthenticator"), f
 				Expect(req2).ToNot(BeNil())
 
 				h := req2.Header
-				Expect(h.Get(_headerRevaAccessToken)).To(Equal("exampletoken"))
+				Expect(h.Get(headerRevaAccessToken)).To(Equal("exampletoken"))
 			})
 		})
 	})
@@ -85,7 +85,7 @@ var _ = Describe("Authenticating requests", Label("PublicShareAuthenticator"), f
 				Expect(req2).ToNot(BeNil())
 
 				h := req2.Header
-				Expect(h.Get(_headerRevaAccessToken)).To(Equal("otherexampletoken"))
+				Expect(h.Get(headerRevaAccessToken)).To(Equal("otherexampletoken"))
 			})
 		})
 		Context("not using a public-token", func() {

--- a/services/proxy/pkg/router/router.go
+++ b/services/proxy/pkg/router/router.go
@@ -209,6 +209,8 @@ func (rt Router) Route(r *http.Request) (RoutingInfo, bool) {
 		if rt.rewriters[pol][rtype][r.Method] != nil {
 			// use specific method
 			method = r.Method
+		} else {
+			method = ""
 		}
 
 		for _, ri := range rt.rewriters[pol][rtype][method] {


### PR DESCRIPTION
This introduces the "additional_headers", "remote_user_header" and
"skip_x_access_token" config keys to allow configuring routes to
external services that require addtional headers to be set.

"remote_user_header": defines the name of a Header that will carry the
userid of the authenticated user on the outgoing request.

"additional_headers": defines a list of header names and values that will
be added to outgoing requests on matching routes.

"skip_x_access_token": when set to true the reva access token will not
be added to the outgoing request.

This is the groundwork for #206 I'll submit required `opencloud_full` adjustments in a separate PR.

