### PR TITLE
chore: update collabora image

### DIFF
--- a/deployments/examples/opencloud_full/collabora.yml
+++ b/deployments/examples/opencloud_full/collabora.yml
@@ -53,7 +53,7 @@ services:
     restart: always
 
   collabora:
-    image: collabora/code:24.04.13.2.1
+    image: collabora/code:25.04.1.1.1
     # release notes: https://www.collaboraonline.com/release-notes/
     networks:
       opencloud-net:
@@ -83,4 +83,5 @@ services:
     entrypoint: ['/bin/bash', '-c']
     command: ['coolconfig generate-proof-key && /start-collabora-online.sh']
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:9980/hosting/discovery" ]
+      test: ["CMD", "bash", "-c", "exec 3<>/dev/tcp/127.0.0.1/9980 && echo -e 'GET /hosting/discovery HTTP/1.1\r\nHost: localhost:9980\r\n\r\n' >&3 && head -n 1 <&3 | grep '200 OK'"]
+


### PR DESCRIPTION
 # Update Collabora Online to version 25.04.1.1.1

  ## Summary
  This PR updates the Collabora Online integration from version 24.04.13.2.1 to 25.04.1.1.1, providing users with the latest features and improvements from Collabora.

  ## Changes
  - Update Collabora Docker image from collabora/code:24.04.13.2.1 to collabora/code:25.04.1.1.1
  - Improve the healthcheck method to use a more reliable bash-based approach instead of curl
  - The new healthcheck properly validates that the Collabora service responds with a 200 OK status

  ## Testing
  - Verified that the updated Collabora instance starts correctly
  - Confirmed document editing functionality works as expected
  - Tested the new healthcheck mechanism

  ## Related
  - Based on Collabora Online release notes: https://www.collaboraonline.com/release-notes/

