### PR TITLE
nats: Don't enable debug and trace logging by default

### DIFF
--- a/services/nats/pkg/command/server.go
+++ b/services/nats/pkg/command/server.go
@@ -78,7 +78,7 @@ func Server(cfg *config.Config) *cli.Command {
 			}
 			natsServer, err := nats.NewNATSServer(
 				ctx,
-				logging.NewLogWrapper(logger),
+				logger,
 				nats.Host(cfg.Nats.Host),
 				nats.Port(cfg.Nats.Port),
 				nats.ClusterID(cfg.Nats.ClusterID),

--- a/services/nats/pkg/server/nats/nats.go
+++ b/services/nats/pkg/server/nats/nats.go
@@ -5,6 +5,9 @@ import (
 	"time"
 
 	nserver "github.com/nats-io/nats-server/v2/server"
+	"github.com/opencloud-eu/opencloud/pkg/log"
+	"github.com/opencloud-eu/opencloud/services/nats/pkg/logging"
+	"github.com/rs/zerolog"
 )
 
 var NATSListenAndServeLoopTimer = 1 * time.Second
@@ -15,7 +18,7 @@ type NATSServer struct {
 }
 
 // NatsOption configures the new NATSServer instance
-func NewNATSServer(ctx context.Context, logger nserver.Logger, opts ...NatsOption) (*NATSServer, error) {
+func NewNATSServer(ctx context.Context, logger log.Logger, opts ...NatsOption) (*NATSServer, error) {
 	natsOpts := &nserver.Options{}
 
 	for _, o := range opts {
@@ -32,7 +35,8 @@ func NewNATSServer(ctx context.Context, logger nserver.Logger, opts ...NatsOptio
 		return nil, err
 	}
 
-	server.SetLoggerV2(logger, true, true, false)
+	nLogger := logging.NewLogWrapper(logger)
+	server.SetLoggerV2(nLogger, logger.GetLevel() <= zerolog.DebugLevel, logger.GetLevel() <= zerolog.TraceLevel, false)
 
 	return &NATSServer{
 		ctx:    ctx,


### PR DESCRIPTION
Only enable trace and/or debug logging when the outer logger has the log level set accordingly. Even when the though the messages where not really logged the nats service wasted quite some cycles especially in the trace log related code path.

Related issue: #716

For details see: https://github.com/opencloud-eu/opencloud/issues/716#issuecomment-2866835467