### PR TITLE
PosixTest. Check that version, share and link still exist

### DIFF
--- a/tests/acceptance/bootstrap/CliContext.php
+++ b/tests/acceptance/bootstrap/CliContext.php
@@ -579,6 +579,30 @@ class CliContext implements Context {
 	}
 
 	/**
+	 * @When the administrator renames the file :file to :newName for user :user on the POSIX filesystem
+	 *
+	 * @param string $user
+	 * @param string $file
+	 * @param string $newName
+	 *
+	 * @return void
+	 */
+	public function theAdministratorRenamesFile(string $user, string $file, string $newName): void {
+		$userUuid = $this->featureContext->getUserIdByUserName($user);
+		$storagePath = $this->getUsersStoragePath();
+
+		$source = "$storagePath/$userUuid/$file";
+		$destination = "$storagePath/$userUuid/$newName";
+
+		$body = [
+		  "command" => "mv $source $destination",
+		  "raw" => true
+		];
+		$this->featureContext->setResponse(CliHelper::runCommand($body));
+		sleep(1);
+	}
+
+	/**
 	 * @When the administrator moves the file :file to the folder :folder for user :user on the POSIX filesystem
 	 *
 	 * @param string $user

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -466,6 +466,8 @@ default:
         - FeatureContext: *common_feature_context_params
         - CliContext:
         - OcConfigContext:
+        - SharingNgContext:
+        - PublicWebDavContext:
 
     coreApiMain:
       paths:


### PR DESCRIPTION
tests for: 
- rename file on POSIX filesystem
- checking that file versions are still up to date after renaming or changing the contents of a file in a POSIX file system
- checking that share and public link still up to date after renaming or changing the contents of a file in a POSIX file system