### PR TITLE
[full-ci] chore(web): bump web to v2.3.0

### DIFF
--- a/.woodpecker.env
+++ b/.woodpecker.env
@@ -1,3 +1,3 @@
 # The test runner source for UI tests
-WEB_COMMITID=0e77efc9fac45c38796ade9fbee0b6345e910e65
+WEB_COMMITID=8c10b33af6ec3a949f95a57f197ee915d666f343
 WEB_BRANCH=main

--- a/.woodpecker.env
+++ b/.woodpecker.env
@@ -1,3 +1,3 @@
 # The test runner source for UI tests
-WEB_COMMITID=81996a0479fa7c1aa7b40d96ba2bea14569d46b6
+WEB_COMMITID=0e77efc9fac45c38796ade9fbee0b6345e910e65
 WEB_BRANCH=main

--- a/services/web/Makefile
+++ b/services/web/Makefile
@@ -1,6 +1,6 @@
 SHELL := bash
 NAME := web
-WEB_ASSETS_VERSION = v2.3.0
+WEB_ASSETS_VERSION = v2.4.0
 WEB_ASSETS_BRANCH = main
 
 ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI


### PR DESCRIPTION
Bumps web version to v2.4.0 for the upcoming rolling release.
se changelog here: https://github.com/opencloud-eu/web/pull/603