### PR TITLE
🎉 Release 2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.3.1](https://github.com/opencloud-eu/opencloud/releases/tag/v2.3.1) - 2025-05-20
+
+### 📦️ Dependencies
+
+- build(deps): bump github.com/olekukonko/tablewriter from 0.0.5 to 1.0.6 [[#888](https://github.com/opencloud-eu/opencloud/pull/888)]
+
 ## [2.3.0](https://github.com/opencloud-eu/opencloud/releases/tag/v2.3.0) - 2025-05-19
 
 ### ❤️ Thanks to all contributors! ❤️


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `2.3.1` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `main` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [2.3.1](https://github.com/opencloud-eu/opencloud/releases/tag/v2.3.1) - 2025-05-20

### 📦️ Dependencies

- build(deps): bump github.com/olekukonko/tablewriter from 0.0.5 to 1.0.6 [[#888](https://github.com/opencloud-eu/opencloud/pull/888)]