### PR TITLE
graph: Add more $select options to ListPermissions endpoint

### DIFF
--- a/services/graph/mocks/drive_item_permissions_provider.go
+++ b/services/graph/mocks/drive_item_permissions_provider.go
@@ -353,9 +353,9 @@ func (_c *DriveItemPermissionsProvider_ListPermissions_Call) RunAndReturn(run fu
 	return _c
 }
 
-// ListSpaceRootPermissions provides a mock function with given fields: ctx, driveID
-func (_m *DriveItemPermissionsProvider) ListSpaceRootPermissions(ctx context.Context, driveID *providerv1beta1.ResourceId) (libregraph.CollectionOfPermissionsWithAllowedValues, error) {
-	ret := _m.Called(ctx, driveID)
+// ListSpaceRootPermissions provides a mock function with given fields: ctx, driveID, selectRoles
+func (_m *DriveItemPermissionsProvider) ListSpaceRootPermissions(ctx context.Context, driveID *providerv1beta1.ResourceId, selectRoles bool) (libregraph.CollectionOfPermissionsWithAllowedValues, error) {
+	ret := _m.Called(ctx, driveID, selectRoles)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ListSpaceRootPermissions")
@@ -363,17 +363,17 @@ func (_m *DriveItemPermissionsProvider) ListSpaceRootPermissions(ctx context.Con
 
 	var r0 libregraph.CollectionOfPermissionsWithAllowedValues
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, *providerv1beta1.ResourceId) (libregraph.CollectionOfPermissionsWithAllowedValues, error)); ok {
-		return rf(ctx, driveID)
+	if rf, ok := ret.Get(0).(func(context.Context, *providerv1beta1.ResourceId, bool) (libregraph.CollectionOfPermissionsWithAllowedValues, error)); ok {
+		return rf(ctx, driveID, selectRoles)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, *providerv1beta1.ResourceId) libregraph.CollectionOfPermissionsWithAllowedValues); ok {
-		r0 = rf(ctx, driveID)
+	if rf, ok := ret.Get(0).(func(context.Context, *providerv1beta1.ResourceId, bool) libregraph.CollectionOfPermissionsWithAllowedValues); ok {
+		r0 = rf(ctx, driveID, selectRoles)
 	} else {
 		r0 = ret.Get(0).(libregraph.CollectionOfPermissionsWithAllowedValues)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, *providerv1beta1.ResourceId) error); ok {
-		r1 = rf(ctx, driveID)
+	if rf, ok := ret.Get(1).(func(context.Context, *providerv1beta1.ResourceId, bool) error); ok {
+		r1 = rf(ctx, driveID, selectRoles)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -389,13 +389,14 @@ type DriveItemPermissionsProvider_ListSpaceRootPermissions_Call struct {
 // ListSpaceRootPermissions is a helper method to define mock.On call
 //   - ctx context.Context
 //   - driveID *providerv1beta1.ResourceId
-func (_e *DriveItemPermissionsProvider_Expecter) ListSpaceRootPermissions(ctx interface{}, driveID interface{}) *DriveItemPermissionsProvider_ListSpaceRootPermissions_Call {
-	return &DriveItemPermissionsProvider_ListSpaceRootPermissions_Call{Call: _e.mock.On("ListSpaceRootPermissions", ctx, driveID)}
+//   - selectRoles bool
+func (_e *DriveItemPermissionsProvider_Expecter) ListSpaceRootPermissions(ctx interface{}, driveID interface{}, selectRoles interface{}) *DriveItemPermissionsProvider_ListSpaceRootPermissions_Call {
+	return &DriveItemPermissionsProvider_ListSpaceRootPermissions_Call{Call: _e.mock.On("ListSpaceRootPermissions", ctx, driveID, selectRoles)}
 }
 
-func (_c *DriveItemPermissionsProvider_ListSpaceRootPermissions_Call) Run(run func(ctx context.Context, driveID *providerv1beta1.ResourceId)) *DriveItemPermissionsProvider_ListSpaceRootPermissions_Call {
+func (_c *DriveItemPermissionsProvider_ListSpaceRootPermissions_Call) Run(run func(ctx context.Context, driveID *providerv1beta1.ResourceId, selectRoles bool)) *DriveItemPermissionsProvider_ListSpaceRootPermissions_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*providerv1beta1.ResourceId))
+		run(args[0].(context.Context), args[1].(*providerv1beta1.ResourceId), args[2].(bool))
 	})
 	return _c
 }
@@ -405,7 +406,7 @@ func (_c *DriveItemPermissionsProvider_ListSpaceRootPermissions_Call) Return(_a0
 	return _c
 }
 
-func (_c *DriveItemPermissionsProvider_ListSpaceRootPermissions_Call) RunAndReturn(run func(context.Context, *providerv1beta1.ResourceId) (libregraph.CollectionOfPermissionsWithAllowedValues, error)) *DriveItemPermissionsProvider_ListSpaceRootPermissions_Call {
+func (_c *DriveItemPermissionsProvider_ListSpaceRootPermissions_Call) RunAndReturn(run func(context.Context, *providerv1beta1.ResourceId, bool) (libregraph.CollectionOfPermissionsWithAllowedValues, error)) *DriveItemPermissionsProvider_ListSpaceRootPermissions_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/services/graph/mocks/drive_item_permissions_provider.go
+++ b/services/graph/mocks/drive_item_permissions_provider.go
@@ -294,9 +294,9 @@ func (_c *DriveItemPermissionsProvider_Invite_Call) RunAndReturn(run func(contex
 	return _c
 }
 
-// ListPermissions provides a mock function with given fields: ctx, itemID, listFederatedRoles, selectRoles
-func (_m *DriveItemPermissionsProvider) ListPermissions(ctx context.Context, itemID *providerv1beta1.ResourceId, listFederatedRoles bool, selectRoles bool) (libregraph.CollectionOfPermissionsWithAllowedValues, error) {
-	ret := _m.Called(ctx, itemID, listFederatedRoles, selectRoles)
+// ListPermissions provides a mock function with given fields: ctx, itemID, listFederatedRoles, selectedAttrs
+func (_m *DriveItemPermissionsProvider) ListPermissions(ctx context.Context, itemID *providerv1beta1.ResourceId, listFederatedRoles bool, selectedAttrs map[string]struct{}) (libregraph.CollectionOfPermissionsWithAllowedValues, error) {
+	ret := _m.Called(ctx, itemID, listFederatedRoles, selectedAttrs)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ListPermissions")
@@ -304,17 +304,17 @@ func (_m *DriveItemPermissionsProvider) ListPermissions(ctx context.Context, ite
 
 	var r0 libregraph.CollectionOfPermissionsWithAllowedValues
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, *providerv1beta1.ResourceId, bool, bool) (libregraph.CollectionOfPermissionsWithAllowedValues, error)); ok {
-		return rf(ctx, itemID, listFederatedRoles, selectRoles)
+	if rf, ok := ret.Get(0).(func(context.Context, *providerv1beta1.ResourceId, bool, map[string]struct{}) (libregraph.CollectionOfPermissionsWithAllowedValues, error)); ok {
+		return rf(ctx, itemID, listFederatedRoles, selectedAttrs)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, *providerv1beta1.ResourceId, bool, bool) libregraph.CollectionOfPermissionsWithAllowedValues); ok {
-		r0 = rf(ctx, itemID, listFederatedRoles, selectRoles)
+	if rf, ok := ret.Get(0).(func(context.Context, *providerv1beta1.ResourceId, bool, map[string]struct{}) libregraph.CollectionOfPermissionsWithAllowedValues); ok {
+		r0 = rf(ctx, itemID, listFederatedRoles, selectedAttrs)
 	} else {
 		r0 = ret.Get(0).(libregraph.CollectionOfPermissionsWithAllowedValues)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, *providerv1beta1.ResourceId, bool, bool) error); ok {
-		r1 = rf(ctx, itemID, listFederatedRoles, selectRoles)
+	if rf, ok := ret.Get(1).(func(context.Context, *providerv1beta1.ResourceId, bool, map[string]struct{}) error); ok {
+		r1 = rf(ctx, itemID, listFederatedRoles, selectedAttrs)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -331,14 +331,14 @@ type DriveItemPermissionsProvider_ListPermissions_Call struct {
 //   - ctx context.Context
 //   - itemID *providerv1beta1.ResourceId
 //   - listFederatedRoles bool
-//   - selectRoles bool
-func (_e *DriveItemPermissionsProvider_Expecter) ListPermissions(ctx interface{}, itemID interface{}, listFederatedRoles interface{}, selectRoles interface{}) *DriveItemPermissionsProvider_ListPermissions_Call {
-	return &DriveItemPermissionsProvider_ListPermissions_Call{Call: _e.mock.On("ListPermissions", ctx, itemID, listFederatedRoles, selectRoles)}
+//   - selectedAttrs map[string]struct{}
+func (_e *DriveItemPermissionsProvider_Expecter) ListPermissions(ctx interface{}, itemID interface{}, listFederatedRoles interface{}, selectedAttrs interface{}) *DriveItemPermissionsProvider_ListPermissions_Call {
+	return &DriveItemPermissionsProvider_ListPermissions_Call{Call: _e.mock.On("ListPermissions", ctx, itemID, listFederatedRoles, selectedAttrs)}
 }
 
-func (_c *DriveItemPermissionsProvider_ListPermissions_Call) Run(run func(ctx context.Context, itemID *providerv1beta1.ResourceId, listFederatedRoles bool, selectRoles bool)) *DriveItemPermissionsProvider_ListPermissions_Call {
+func (_c *DriveItemPermissionsProvider_ListPermissions_Call) Run(run func(ctx context.Context, itemID *providerv1beta1.ResourceId, listFederatedRoles bool, selectedAttrs map[string]struct{})) *DriveItemPermissionsProvider_ListPermissions_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*providerv1beta1.ResourceId), args[2].(bool), args[3].(bool))
+		run(args[0].(context.Context), args[1].(*providerv1beta1.ResourceId), args[2].(bool), args[3].(map[string]struct{}))
 	})
 	return _c
 }
@@ -348,14 +348,14 @@ func (_c *DriveItemPermissionsProvider_ListPermissions_Call) Return(_a0 libregra
 	return _c
 }
 
-func (_c *DriveItemPermissionsProvider_ListPermissions_Call) RunAndReturn(run func(context.Context, *providerv1beta1.ResourceId, bool, bool) (libregraph.CollectionOfPermissionsWithAllowedValues, error)) *DriveItemPermissionsProvider_ListPermissions_Call {
+func (_c *DriveItemPermissionsProvider_ListPermissions_Call) RunAndReturn(run func(context.Context, *providerv1beta1.ResourceId, bool, map[string]struct{}) (libregraph.CollectionOfPermissionsWithAllowedValues, error)) *DriveItemPermissionsProvider_ListPermissions_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// ListSpaceRootPermissions provides a mock function with given fields: ctx, driveID, selectRoles
-func (_m *DriveItemPermissionsProvider) ListSpaceRootPermissions(ctx context.Context, driveID *providerv1beta1.ResourceId, selectRoles bool) (libregraph.CollectionOfPermissionsWithAllowedValues, error) {
-	ret := _m.Called(ctx, driveID, selectRoles)
+// ListSpaceRootPermissions provides a mock function with given fields: ctx, driveID, selectedAttrs
+func (_m *DriveItemPermissionsProvider) ListSpaceRootPermissions(ctx context.Context, driveID *providerv1beta1.ResourceId, selectedAttrs map[string]struct{}) (libregraph.CollectionOfPermissionsWithAllowedValues, error) {
+	ret := _m.Called(ctx, driveID, selectedAttrs)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ListSpaceRootPermissions")
@@ -363,17 +363,17 @@ func (_m *DriveItemPermissionsProvider) ListSpaceRootPermissions(ctx context.Con
 
 	var r0 libregraph.CollectionOfPermissionsWithAllowedValues
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, *providerv1beta1.ResourceId, bool) (libregraph.CollectionOfPermissionsWithAllowedValues, error)); ok {
-		return rf(ctx, driveID, selectRoles)
+	if rf, ok := ret.Get(0).(func(context.Context, *providerv1beta1.ResourceId, map[string]struct{}) (libregraph.CollectionOfPermissionsWithAllowedValues, error)); ok {
+		return rf(ctx, driveID, selectedAttrs)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, *providerv1beta1.ResourceId, bool) libregraph.CollectionOfPermissionsWithAllowedValues); ok {
-		r0 = rf(ctx, driveID, selectRoles)
+	if rf, ok := ret.Get(0).(func(context.Context, *providerv1beta1.ResourceId, map[string]struct{}) libregraph.CollectionOfPermissionsWithAllowedValues); ok {
+		r0 = rf(ctx, driveID, selectedAttrs)
 	} else {
 		r0 = ret.Get(0).(libregraph.CollectionOfPermissionsWithAllowedValues)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, *providerv1beta1.ResourceId, bool) error); ok {
-		r1 = rf(ctx, driveID, selectRoles)
+	if rf, ok := ret.Get(1).(func(context.Context, *providerv1beta1.ResourceId, map[string]struct{}) error); ok {
+		r1 = rf(ctx, driveID, selectedAttrs)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -389,14 +389,14 @@ type DriveItemPermissionsProvider_ListSpaceRootPermissions_Call struct {
 // ListSpaceRootPermissions is a helper method to define mock.On call
 //   - ctx context.Context
 //   - driveID *providerv1beta1.ResourceId
-//   - selectRoles bool
-func (_e *DriveItemPermissionsProvider_Expecter) ListSpaceRootPermissions(ctx interface{}, driveID interface{}, selectRoles interface{}) *DriveItemPermissionsProvider_ListSpaceRootPermissions_Call {
-	return &DriveItemPermissionsProvider_ListSpaceRootPermissions_Call{Call: _e.mock.On("ListSpaceRootPermissions", ctx, driveID, selectRoles)}
+//   - selectedAttrs map[string]struct{}
+func (_e *DriveItemPermissionsProvider_Expecter) ListSpaceRootPermissions(ctx interface{}, driveID interface{}, selectedAttrs interface{}) *DriveItemPermissionsProvider_ListSpaceRootPermissions_Call {
+	return &DriveItemPermissionsProvider_ListSpaceRootPermissions_Call{Call: _e.mock.On("ListSpaceRootPermissions", ctx, driveID, selectedAttrs)}
 }
 
-func (_c *DriveItemPermissionsProvider_ListSpaceRootPermissions_Call) Run(run func(ctx context.Context, driveID *providerv1beta1.ResourceId, selectRoles bool)) *DriveItemPermissionsProvider_ListSpaceRootPermissions_Call {
+func (_c *DriveItemPermissionsProvider_ListSpaceRootPermissions_Call) Run(run func(ctx context.Context, driveID *providerv1beta1.ResourceId, selectedAttrs map[string]struct{})) *DriveItemPermissionsProvider_ListSpaceRootPermissions_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*providerv1beta1.ResourceId), args[2].(bool))
+		run(args[0].(context.Context), args[1].(*providerv1beta1.ResourceId), args[2].(map[string]struct{}))
 	})
 	return _c
 }
@@ -406,7 +406,7 @@ func (_c *DriveItemPermissionsProvider_ListSpaceRootPermissions_Call) Return(_a0
 	return _c
 }
 
-func (_c *DriveItemPermissionsProvider_ListSpaceRootPermissions_Call) RunAndReturn(run func(context.Context, *providerv1beta1.ResourceId, bool) (libregraph.CollectionOfPermissionsWithAllowedValues, error)) *DriveItemPermissionsProvider_ListSpaceRootPermissions_Call {
+func (_c *DriveItemPermissionsProvider_ListSpaceRootPermissions_Call) RunAndReturn(run func(context.Context, *providerv1beta1.ResourceId, map[string]struct{}) (libregraph.CollectionOfPermissionsWithAllowedValues, error)) *DriveItemPermissionsProvider_ListSpaceRootPermissions_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/services/graph/pkg/service/v0/api_driveitem_permissions.go
+++ b/services/graph/pkg/service/v0/api_driveitem_permissions.go
@@ -51,8 +51,8 @@ const (
 type DriveItemPermissionsProvider interface {
 	Invite(ctx context.Context, resourceId *storageprovider.ResourceId, invite libregraph.DriveItemInvite) (libregraph.Permission, error)
 	SpaceRootInvite(ctx context.Context, driveID *storageprovider.ResourceId, invite libregraph.DriveItemInvite) (libregraph.Permission, error)
-	ListPermissions(ctx context.Context, itemID *storageprovider.ResourceId, listFederatedRoles, selectRoles bool) (libregraph.CollectionOfPermissionsWithAllowedValues, error)
-	ListSpaceRootPermissions(ctx context.Context, driveID *storageprovider.ResourceId, selectRoles bool) (libregraph.CollectionOfPermissionsWithAllowedValues, error)
+	ListPermissions(ctx context.Context, itemID *storageprovider.ResourceId, listFederatedRoles bool, selectedAttrs map[string]struct{}) (libregraph.CollectionOfPermissionsWithAllowedValues, error)
+	ListSpaceRootPermissions(ctx context.Context, driveID *storageprovider.ResourceId, selectedAttrs map[string]struct{}) (libregraph.CollectionOfPermissionsWithAllowedValues, error)
 	DeletePermission(ctx context.Context, itemID *storageprovider.ResourceId, permissionID string) error
 	DeleteSpaceRootPermission(ctx context.Context, driveID *storageprovider.ResourceId, permissionID string) error
 	UpdatePermission(ctx context.Context, itemID *storageprovider.ResourceId, permissionID string, newPermission libregraph.Permission) (libregraph.Permission, error)
@@ -344,7 +344,7 @@ func (s DriveItemPermissionsService) SpaceRootInvite(ctx context.Context, driveI
 }
 
 // ListPermissions lists the permissions of a driveItem
-func (s DriveItemPermissionsService) ListPermissions(ctx context.Context, itemID *storageprovider.ResourceId, listFederatedRoles, selectRoles bool) (libregraph.CollectionOfPermissionsWithAllowedValues, error) {
+func (s DriveItemPermissionsService) ListPermissions(ctx context.Context, itemID *storageprovider.ResourceId, listFederatedRoles bool, selectedAttrs map[string]struct{}) (libregraph.CollectionOfPermissionsWithAllowedValues, error) {
 	collectionOfPermissions := libregraph.CollectionOfPermissionsWithAllowedValues{}
 	gatewayClient, err := s.gatewaySelector.Next()
 	if err != nil {
@@ -365,9 +365,14 @@ func (s DriveItemPermissionsService) ListPermissions(ctx context.Context, itemID
 	permissionSet := statResponse.GetInfo().GetPermissionSet()
 	allowedActions := unifiedrole.CS3ResourcePermissionsToLibregraphActions(permissionSet)
 
-	collectionOfPermissions = libregraph.CollectionOfPermissionsWithAllowedValues{
-		LibreGraphPermissionsActionsAllowedValues: allowedActions,
-		LibreGraphPermissionsRolesAllowedValues: conversions.ToValueSlice(
+	collectionOfPermissions = libregraph.CollectionOfPermissionsWithAllowedValues{}
+
+	if _, ok := selectedAttrs["@libre.graph.permissions.actions.allowedValues"]; ok || len(selectedAttrs) == 0 {
+		collectionOfPermissions.LibreGraphPermissionsActionsAllowedValues = allowedActions
+	}
+
+	if _, ok := selectedAttrs["@libre.graph.permissions.roles.allowedValues"]; ok || len(selectedAttrs) == 0 {
+		collectionOfPermissions.LibreGraphPermissionsRolesAllowedValues = conversions.ToValueSlice(
 			unifiedrole.GetRolesByPermissions(
 				unifiedrole.GetRoles(unifiedrole.RoleFilterIDs(s.config.UnifiedRoles.AvailableRoles...)),
 				allowedActions,
@@ -375,7 +380,7 @@ func (s DriveItemPermissionsService) ListPermissions(ctx context.Context, itemID
 				listFederatedRoles,
 				false,
 			),
-		),
+		)
 	}
 
 	for i, definition := range collectionOfPermissions.LibreGraphPermissionsRolesAllowedValues {
@@ -384,10 +389,8 @@ func (s DriveItemPermissionsService) ListPermissions(ctx context.Context, itemID
 		collectionOfPermissions.LibreGraphPermissionsRolesAllowedValues[i] = definition
 	}
 
-	if selectRoles {
-		// drop the actions
-		collectionOfPermissions.LibreGraphPermissionsActionsAllowedValues = nil
-		// no need to fetch shares, we are only interested in the roles
+	if len(selectedAttrs) > 0 {
+		// no need to fetch shares, we are only interested allowedActions and/or allowedRoles
 		return collectionOfPermissions, nil
 	}
 
@@ -441,7 +444,7 @@ func (s DriveItemPermissionsService) ListPermissions(ctx context.Context, itemID
 }
 
 // ListSpaceRootPermissions handles ListPermissions request on project spaces
-func (s DriveItemPermissionsService) ListSpaceRootPermissions(ctx context.Context, driveID *storageprovider.ResourceId, selectRoles bool) (libregraph.CollectionOfPermissionsWithAllowedValues, error) {
+func (s DriveItemPermissionsService) ListSpaceRootPermissions(ctx context.Context, driveID *storageprovider.ResourceId, selectedAttrs map[string]struct{}) (libregraph.CollectionOfPermissionsWithAllowedValues, error) {
 	collectionOfPermissions := libregraph.CollectionOfPermissionsWithAllowedValues{}
 	gatewayClient, err := s.gatewaySelector.Next()
 	if err != nil {
@@ -459,7 +462,7 @@ func (s DriveItemPermissionsService) ListSpaceRootPermissions(ctx context.Contex
 	}
 
 	rootResourceID := space.GetRoot()
-	return s.ListPermissions(ctx, rootResourceID, false, selectRoles) // federated roles are not supported for spaces
+	return s.ListPermissions(ctx, rootResourceID, false, selectedAttrs) // federated roles are not supported for spaces
 }
 
 // DeletePermission deletes a permission from a drive item
@@ -769,7 +772,7 @@ func (api DriveItemPermissionsApi) ListSpaceRootPermissions(w http.ResponseWrite
 		return
 	}
 
-	selectRoles, err := api.listPermissionsQuerySelectValues(odataReq.Query)
+	selected, err := api.listPermissionsQuerySelectValues(odataReq.Query)
 	if err != nil {
 		api.logger.Debug().Err(err).Interface("query", r.URL.Query()).Msg("Error parsing ListPermissionRequest: query error")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, err.Error())
@@ -777,7 +780,7 @@ func (api DriveItemPermissionsApi) ListSpaceRootPermissions(w http.ResponseWrite
 	}
 
 	ctx := r.Context()
-	permissions, err := api.driveItemPermissionsService.ListSpaceRootPermissions(ctx, &driveID, selectRoles)
+	permissions, err := api.driveItemPermissionsService.ListSpaceRootPermissions(ctx, &driveID, selected)
 
 	if err != nil {
 		errorcode.RenderError(w, r, err)
@@ -934,20 +937,18 @@ func (api DriveItemPermissionsApi) UpdateSpaceRootPermission(w http.ResponseWrit
 	render.JSON(w, r, &updatedPermission)
 }
 
-func (api DriveItemPermissionsApi) listPermissionsQuerySelectValues(odataQuery *godata.GoDataQuery) (bool, error) {
+func (api DriveItemPermissionsApi) listPermissionsQuerySelectValues(odataQuery *godata.GoDataQuery) (map[string]struct{}, error) {
+	selectedAttrs := map[string]struct{}{}
 	if odataQuery.Select != nil {
 		for _, item := range odataQuery.Select.SelectItems {
-			if len(item.Segments) != 1 {
+			// for now we only support a limitted set of $select attributes
+			if item.Segments[0].Value == "@libre.graph.permissions.roles.allowedValues" || item.Segments[0].Value == "@libre.graph.permissions.actions.allowedValues" {
+				selectedAttrs[item.Segments[0].Value] = struct{}{}
+			} else {
 				api.logger.Debug().Msg("Error parsing ListPermissionRequest: unsupported select item")
-				return false, errorcode.New(errorcode.InvalidRequest, "unsupported select item")
+				return selectedAttrs, errorcode.New(errorcode.InvalidRequest, "unsupported select item")
 			}
-			// for now we only support the select for the roles
-			if item.Segments[0].Value != "@libre.graph.permissions.roles.allowedValues" {
-				api.logger.Debug().Msg("Error parsing ListPermissionRequest: unsupported select item")
-				return false, errorcode.New(errorcode.InvalidRequest, "unsupported select item")
-			}
-			return true, nil
 		}
 	}
-	return false, nil
+	return selectedAttrs, nil
 }

--- a/services/graph/pkg/service/v0/api_driveitem_permissions_test.go
+++ b/services/graph/pkg/service/v0/api_driveitem_permissions_test.go
@@ -385,7 +385,7 @@ var _ = Describe("DriveItemPermissionsService", func() {
 			gatewayClient.On("Stat", mock.Anything, mock.Anything).Return(statResponse, nil)
 			gatewayClient.On("ListShares", mock.Anything, mock.Anything).Return(listSharesResponse, nil)
 			gatewayClient.On("ListPublicShares", mock.Anything, mock.Anything).Return(listPublicSharesResponse, nil)
-			permissions, err := driveItemPermissionsService.ListPermissions(context.Background(), itemID, false, false)
+			permissions, err := driveItemPermissionsService.ListPermissions(context.Background(), itemID, false, map[string]struct{}{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(permissions.LibreGraphPermissionsActionsAllowedValues)).ToNot(BeZero())
 			Expect(len(permissions.LibreGraphPermissionsRolesAllowedValues)).ToNot(BeZero())
@@ -433,7 +433,7 @@ var _ = Describe("DriveItemPermissionsService", func() {
 			gatewayClient.On("ListShares", mock.Anything, mock.Anything).Return(listSharesResponse, nil)
 			gatewayClient.On("GetUser", mock.Anything, mock.Anything).Return(getUserResponse, nil)
 			gatewayClient.On("ListPublicShares", mock.Anything, mock.Anything).Return(listPublicSharesResponse, nil)
-			permissions, err := driveItemPermissionsService.ListPermissions(context.Background(), itemID, false, false)
+			permissions, err := driveItemPermissionsService.ListPermissions(context.Background(), itemID, false, map[string]struct{}{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(permissions.LibreGraphPermissionsActionsAllowedValues)).ToNot(BeZero())
 			Expect(len(permissions.LibreGraphPermissionsRolesAllowedValues)).ToNot(BeZero())
@@ -472,7 +472,7 @@ var _ = Describe("DriveItemPermissionsService", func() {
 			gatewayClient.On("ListShares", mock.Anything, mock.Anything).Return(listSharesResponse, nil)
 			gatewayClient.On("GetUser", mock.Anything, mock.Anything).Return(getUserResponse, nil)
 			gatewayClient.On("ListPublicShares", mock.Anything, mock.Anything).Return(listPublicSharesResponse, nil)
-			permissions, err := service.ListPermissions(context.Background(), itemID, false, false)
+			permissions, err := service.ListPermissions(context.Background(), itemID, false, map[string]struct{}{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(permissions.LibreGraphPermissionsActionsAllowedValues)).ToNot(BeZero())
 			Expect(len(permissions.LibreGraphPermissionsRolesAllowedValues)).ToNot(BeZero())
@@ -508,7 +508,7 @@ var _ = Describe("DriveItemPermissionsService", func() {
 			gatewayClient.On("ListShares", mock.Anything, mock.Anything).Return(listSharesResponse, nil)
 			gatewayClient.On("GetUser", mock.Anything, mock.Anything).Return(getUserResponse, nil)
 			gatewayClient.On("ListPublicShares", mock.Anything, mock.Anything).Return(listPublicSharesResponse, nil)
-			permissions, err := driveItemPermissionsService.ListPermissions(context.Background(), itemID, false, false)
+			permissions, err := driveItemPermissionsService.ListPermissions(context.Background(), itemID, false, map[string]struct{}{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(permissions.LibreGraphPermissionsActionsAllowedValues)).ToNot(BeZero())
 			Expect(len(permissions.LibreGraphPermissionsRolesAllowedValues)).ToNot(BeZero())
@@ -555,7 +555,7 @@ var _ = Describe("DriveItemPermissionsService", func() {
 			gatewayClient.On("ListPublicShares", mock.Anything, mock.Anything).Return(listPublicSharesResponse, nil)
 			statResponse.Info.Id = listSpacesResponse.StorageSpaces[0].Root
 			gatewayClient.On("Stat", mock.Anything, mock.Anything).Return(statResponse, nil)
-			permissions, err := driveItemPermissionsService.ListSpaceRootPermissions(context.Background(), driveId, false)
+			permissions, err := driveItemPermissionsService.ListSpaceRootPermissions(context.Background(), driveId, map[string]struct{}{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(permissions.LibreGraphPermissionsActionsAllowedValues)).ToNot(BeZero())
 		})
@@ -1268,7 +1268,7 @@ var _ = Describe("DriveItemPermissionsApi", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			mockProvider.On("ListPermissions", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-				Return(func(ctx context.Context, itemid *provider.ResourceId, listFederatedRoles, selectRoles bool) (libregraph.CollectionOfPermissionsWithAllowedValues, error) {
+				Return(func(ctx context.Context, itemid *provider.ResourceId, listFederatedRoles bool, selected map[string]struct{}) (libregraph.CollectionOfPermissionsWithAllowedValues, error) {
 					Expect(listFederatedRoles).To(Equal(false))
 					Expect(storagespace.FormatResourceID(itemid)).To(Equal("1$2!3"))
 					return libregraph.CollectionOfPermissionsWithAllowedValues{}, nil

--- a/services/graph/pkg/service/v0/api_driveitem_permissions_test.go
+++ b/services/graph/pkg/service/v0/api_driveitem_permissions_test.go
@@ -20,8 +20,8 @@ import (
 	"github.com/go-chi/chi/v5"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/opencloud-eu/opencloud/services/graph/pkg/config"
 	libregraph "github.com/opencloud-eu/libre-graph-api-go"
+	"github.com/opencloud-eu/opencloud/services/graph/pkg/config"
 	"github.com/stretchr/testify/mock"
 	"github.com/tidwall/gjson"
 	"google.golang.org/grpc"
@@ -555,7 +555,7 @@ var _ = Describe("DriveItemPermissionsService", func() {
 			gatewayClient.On("ListPublicShares", mock.Anything, mock.Anything).Return(listPublicSharesResponse, nil)
 			statResponse.Info.Id = listSpacesResponse.StorageSpaces[0].Root
 			gatewayClient.On("Stat", mock.Anything, mock.Anything).Return(statResponse, nil)
-			permissions, err := driveItemPermissionsService.ListSpaceRootPermissions(context.Background(), driveId)
+			permissions, err := driveItemPermissionsService.ListSpaceRootPermissions(context.Background(), driveId, false)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(permissions.LibreGraphPermissionsActionsAllowedValues)).ToNot(BeZero())
 		})

--- a/services/graph/pkg/service/v0/utils.go
+++ b/services/graph/pkg/service/v0/utils.go
@@ -13,9 +13,9 @@ import (
 	collaboration "github.com/cs3org/go-cs3apis/cs3/sharing/collaboration/v1beta1"
 	ocm "github.com/cs3org/go-cs3apis/cs3/sharing/ocm/v1beta1"
 	storageprovider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	libregraph "github.com/opencloud-eu/libre-graph-api-go"
 	"github.com/opencloud-eu/reva/v2/pkg/storagespace"
 	"github.com/opencloud-eu/reva/v2/pkg/utils"
-	libregraph "github.com/opencloud-eu/libre-graph-api-go"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/opencloud-eu/opencloud/pkg/log"
@@ -71,16 +71,6 @@ func GetDriveAndItemIDParam(r *http.Request, logger *log.Logger) (*storageprovid
 	}
 
 	return &driveID, &itemID, nil
-}
-
-// GetFilterParam returns the $filter query parameter from the request. If you need to parse the filter use godata.ParseRequest
-func GetFilterParam(r *http.Request) string {
-	return r.URL.Query().Get("$filter")
-}
-
-// GetSelectParam returns the $select query parameter from the request. If you need to parse the select filter use godata.ParseRequest
-func GetSelectParam(r *http.Request) string {
-	return r.URL.Query().Get("$select")
 }
 
 // GetGatewayClient returns a gateway client from the gatewaySelector.


### PR DESCRIPTION
This add the possibility to `$select` on `@libre.graph.permissions.actions.allowedValues`.

The request:
`GET /drives/<driveid>/root/permissions?$select=@libre.graph.permissions.actions.allowedValues`

can be used to figure out what permissions the requesting user has on a specific space (e.g. when deciding which action to display in the context menu)

Related Issue #485