### PR TITLE
Add DeepWiki badge to README to enable weekly documentation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![status-badge](https://ci.opencloud.eu/api/badges/3/status.svg)](https://ci.opencloud.eu/repos/3)
  [![Matrix](https://img.shields.io/matrix/opencloud%3Amatrix.org?logo=matrix)](https://app.element.io/#/room/#opencloud:matrix.org)
  [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+ [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/opencloud-eu/opencloud)
 
 # Server Backend
 


### PR DESCRIPTION
## Description  
This pull request adds the [DeepWiki](https://www.deepwiki.com) badge to the README of the OpenCloud repository.

The badge does more than just link to conversational documentation – by adding it, we authorize DeepWiki to automatically refresh the documentation weekly, ensuring it stays up-to-date with the latest changes in the main branch.

## Related Issue  
No existing issue – this is a minor documentation improvement.

## Motivation and Context  
Keeping documentation up to date is essential for maintainability and onboarding. By adding the DeepWiki badge, we enable weekly syncs between the repository and DeepWiki’s AI-powered documentation platform. This helps contributors and users get accurate, current, and easily accessible project information.