### PR TITLE
Enhancement: Introduced support for PrivateLink in WebDAV search responses

### DIFF
--- a/services/webdav/pkg/config/defaults/defaultconfig.go
+++ b/services/webdav/pkg/config/defaults/defaultconfig.go
@@ -39,7 +39,7 @@ func DefaultConfig() *config.Config {
 		Service: config.Service{
 			Name: "webdav",
 		},
-		OpenCloudPublicURL: "https://127.0.0.1:9200",
+		OpenCloudPublicURL: "https://localhost:9200",
 		WebdavNamespace:    "/users/{{.Id.OpaqueId}}",
 		RevaGateway:        shared.DefaultRevaConfig().Address,
 	}


### PR DESCRIPTION
## Description
Add the oc:privatelink field to the webdav search response.

## Related Issue
- Fixes https://github.com/opencloud-eu/opencloud/issues/971

## Motivation and Context
consistency, TBH... someone has to help me to understand why we have a description and the Motivation and Context section, i don't get it.. i always struggle with that... but only if YOU read that... :) 

## How Has This Been Tested?
- web client

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [X] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added
