### PR TITLE
fix(collaboration): re register app providers in a configurable interval

### DIFF
--- a/services/collaboration/pkg/config/cs3api.go
+++ b/services/collaboration/pkg/config/cs3api.go
@@ -1,12 +1,17 @@
 package config
 
-import "github.com/opencloud-eu/opencloud/pkg/shared"
+import (
+	"time"
+
+	"github.com/opencloud-eu/opencloud/pkg/shared"
+)
 
 // CS3Api defines the available configuration in order to access to the CS3 gateway.
 type CS3Api struct {
-	Gateway       Gateway               `yaml:"gateway"`
-	DataGateway   DataGateway           `yaml:"datagateway"`
-	GRPCClientTLS *shared.GRPCClientTLS `yaml:"grpc_client_tls"`
+	Gateway                 Gateway               `yaml:"gateway"`
+	DataGateway             DataGateway           `yaml:"datagateway"`
+	GRPCClientTLS           *shared.GRPCClientTLS `yaml:"grpc_client_tls"`
+	APPRegistrationInterval time.Duration         `yaml:"app_registration_interval" env:"COLLABORATION_CS3API_APP_REGISTRATION_INTERVAL" desc:"The interval at which the app provider registers itself." introductionVersion:"%%NEXT%%"`
 }
 
 // Gateway defines the available configuration for the CS3 API gateway

--- a/services/collaboration/pkg/config/defaults/defaultconfig.go
+++ b/services/collaboration/pkg/config/defaults/defaultconfig.go
@@ -65,6 +65,7 @@ func DefaultConfig() *config.Config {
 			DataGateway: config.DataGateway{
 				Insecure: false,
 			},
+			APPRegistrationInterval: 30 * time.Second,
 		},
 	}
 }


### PR DESCRIPTION
## Description
App providers only register on startup of the collaboration service, this can lead to information loss if open-cloud (app-provider) goes down. The solution is fairly simple, i would LOVE to see an implementation which uses a registry instead... 

## Related Issue
- Fixes https://github.com/opencloud-eu/opencloud/issues/616

## Motivation and Context

## How Has This Been Tested?
- docker deployment

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [X] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added
