### PR TITLE
fix(proxy): Prevent panic when autoprovsioning user

### DIFF
--- a/services/proxy/pkg/middleware/account_resolver.go
+++ b/services/proxy/pkg/middleware/account_resolver.go
@@ -125,15 +125,15 @@ func (m accountResolver) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 				return
 			}
 			m.logger.Debug().Interface("claims", claims).Msg("Autoprovisioning user")
-			user, err = m.userProvider.CreateUserFromClaims(req.Context(), claims)
+			newuser, err := m.userProvider.CreateUserFromClaims(req.Context(), claims)
 			if err != nil {
 				m.logger.Error().Err(err).Msg("Autoprovisioning user failed")
 				w.WriteHeader(http.StatusInternalServerError)
 				return
 			}
-			user, token, err = m.userProvider.GetUserByClaims(req.Context(), "userid", user.Id.OpaqueId)
+			user, token, err = m.userProvider.GetUserByClaims(req.Context(), "userid", newuser.Id.OpaqueId)
 			if err != nil {
-				m.logger.Error().Err(err).Str("userid", user.Id.OpaqueId).Msg("Error getting token for autoprovisioned user")
+				m.logger.Error().Err(err).Str("userid", newuser.Id.OpaqueId).Msg("Error getting token for autoprovisioned user")
 				w.WriteHeader(http.StatusUnauthorized)
 				return
 			}


### PR DESCRIPTION
After autoprovisioning a user, we need to get a reva token via `auth-machine`. If that fails the code would panic because the logger tried to access the `user` object returned from the GetUserByClaims call. Which is `nil`in case failure.

Fixes #936

