### PR TITLE
get hostname of S3 server from var. not secret

### DIFF
--- a/.woodpecker.star
+++ b/.woodpecker.star
@@ -36,6 +36,8 @@ READY_RELEASE_GO = "woodpeckerci/plugin-ready-release-go:latest"
 DEFAULT_PHP_VERSION = "8.2"
 DEFAULT_NODEJS_VERSION = "20"
 
+CACHE_S3_SERVER = "https://s3.ci.opencloud.eu"
+
 dirs = {
     "base": "/woodpecker/src/github.com/opencloud-eu/opencloud",
     "web": "/woodpecker/src/github.com/opencloud-eu/opencloud/webTestRunner",
@@ -671,9 +673,7 @@ def testOpencloud(ctx):
             "name": "scan-result-cache",
             "image": PLUGINS_S3,
             "settings": {
-                "endpoint": {
-                    "from_secret": "cache_s3_server",
-                },
+                "endpoint": CACHE_S3_SERVER,
                 "bucket": "cache",
                 "source": "cache/**/*",
                 "target": "%s/%s" % (repo_slug, ctx.build.commit + "-${CI_PIPELINE_NUMBER}"),
@@ -1453,9 +1453,7 @@ def uploadTracingResult():
             "bucket": {
                 "from_secret": "cache_public_s3_bucket",
             },
-            "endpoint": {
-                "from_secret": "cache_public_s3_server",
-            },
+            "endpoint": CACHE_S3_SERVER,
             "path_style": True,
             "source": "webTestRunner/reports/e2e/playwright/tracing/**/*",
             "strip_prefix": "webTestRunner/reports/e2e/playwright/tracing",
@@ -2273,9 +2271,7 @@ def genericCache(name, action, mounts, cache_path):
         "name": "%s_%s" % (action, name),
         "image": PLUGINS_S3_CACHE,
         "settings": {
-            "endpoint": {
-                "from_secret": "cache_s3_server",
-            },
+            "endpoint": CACHE_S3_SERVER,
             "rebuild": rebuild,
             "restore": restore,
             "mount": mounts,
@@ -2306,9 +2302,7 @@ def genericCachePurge(flush_path):
                     "secret_key": {
                         "from_secret": "cache_s3_secret_key",
                     },
-                    "endpoint": {
-                        "from_secret": "cache_s3_server",
-                    },
+                    "endpoint": CACHE_S3_SERVER,
                     "flush": True,
                     "flush_age": 1,
                     "flush_path": flush_path,


### PR DESCRIPTION
## Description

This value is not really secret and to show the URL of the tracing uploads or any other public artifacts we have to get rid of that secret as woodpecker masks all secret in the logs

## Related Issue

needed for https://github.com/opencloud-eu/qa/issues/24

## Types of changes

<!--- What types of changes does your code introduce? Mark an x in all the applicable boxes: -->

- [ ] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [ ] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [x] Maintenance (like dependency updates or tooling adjustments)
