### PR TITLE
feat: re-enable Save As and Export in collabora

### DIFF
--- a/services/collaboration/pkg/connector/fileconnector.go
+++ b/services/collaboration/pkg/connector/fileconnector.go
@@ -1273,8 +1273,6 @@ func (f *FileConnector) CheckFileInfo(ctx context.Context) (*ConnectorResponse, 
 		fileinfo.KeyPostMessageOrigin:            f.cfg.Commons.OpenCloudURL,
 		fileinfo.KeyLicenseCheckForEditIsEnabled: f.cfg.App.LicenseCheckEnable,
 
-		// set to true for Collabora until we have a web embed mode for "Save As" and "Export As"
-		// see the FIXME in ./fileinfo/collabora.go and https://github.com/opencloud-eu/web/issues/422
 		fileinfo.KeyUserCanNotWriteRelative: false,
 	}
 

--- a/services/collaboration/pkg/connector/fileconnector_test.go
+++ b/services/collaboration/pkg/connector/fileconnector_test.go
@@ -1780,7 +1780,7 @@ var _ = Describe("FileConnector", func() {
 				OwnerID:                 "61616262636340637573746f6d496470", // hex of aabbcc@customIdp
 				Size:                    int64(998877),
 				BaseFileName:            "test.txt",
-				UserCanNotWriteRelative: true,
+				UserCanNotWriteRelative: false,
 				DisableExport:           true,
 				DisableCopy:             true,
 				DisablePrint:            true,
@@ -1962,7 +1962,7 @@ var _ = Describe("FileConnector", func() {
 				OwnerID:                 "61616262636340637573746f6d496470", // hex of aabbcc@customIdp
 				Size:                    int64(998877),
 				BaseFileName:            "test.txt",
-				UserCanNotWriteRelative: true,
+				UserCanNotWriteRelative: false,
 				DisableExport:           true,
 				DisableCopy:             true,
 				DisablePrint:            true,

--- a/services/collaboration/pkg/connector/fileinfo/collabora.go
+++ b/services/collaboration/pkg/connector/fileinfo/collabora.go
@@ -99,7 +99,7 @@ func (cinfo *Collabora) SetProperties(props map[string]interface{}) {
 		case KeyUserCanWrite:
 			cinfo.UserCanWrite = value.(bool)
 		case KeyUserCanNotWriteRelative:
-			cinfo.UserCanNotWriteRelative = true // FIXME: set to `value.(bool)` again for https://github.com/opencloud-eu/web/issues/422
+			cinfo.UserCanNotWriteRelative = value.(bool)
 		case KeyUserID:
 			cinfo.UserID = value.(string)
 		case KeyUserFriendlyName:

--- a/tests/acceptance/features/apiCollaboration/checkFileInfo.feature
+++ b/tests/acceptance/features/apiCollaboration/checkFileInfo.feature
@@ -183,7 +183,7 @@ Feature: check file info with different wopi apps
             "const": true
           },
           "UserCanNotWriteRelative": {
-            "const": true
+            "const": false
           },
           "EnableOwnerTermination": {
             "const": true
@@ -581,7 +581,7 @@ Feature: check file info with different wopi apps
             "const": <user-can-write>
           },
           "UserCanNotWriteRelative": {
-            "const": true
+            "const": false
           },
           "EnableOwnerTermination": {
             "const": true
@@ -691,7 +691,7 @@ Feature: check file info with different wopi apps
             "const": true
           },
           "UserCanNotWriteRelative": {
-            "const": true
+            "const": false
           },
           "EnableOwnerTermination": {
             "const": true
@@ -1077,7 +1077,7 @@ Feature: check file info with different wopi apps
             "const": true
           },
           "UserCanNotWriteRelative": {
-            "const": true
+            "const": false
           },
           "EnableOwnerTermination": {
             "const": true
@@ -1424,7 +1424,7 @@ Feature: check file info with different wopi apps
             "const": true
           },
           "UserCanNotWriteRelative": {
-            "const": true
+            "const": false
           },
           "EnableOwnerTermination": {
             "const": true
@@ -1810,7 +1810,7 @@ Feature: check file info with different wopi apps
             "const": <user-can-write>
           },
           "UserCanNotWriteRelative": {
-            "const": true
+            "const": false
           },
           "EnableOwnerTermination": {
             "const": true


### PR DESCRIPTION
## Description

Re-enable the `Save As` and `Export` buttons in the Collabora ui.

Needed for https://github.com/opencloud-eu/web/issues/708 and https://github.com/opencloud-eu/web/issues/422

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added
