### PR TITLE
Make install.sh work with Linux aarch64

### DIFF
--- a/deployments/examples/bare-metal-simple/install.sh
+++ b/deployments/examples/bare-metal-simple/install.sh
@@ -69,6 +69,10 @@ if [[ $(uname -s) == "Darwin" && $(uname -m) == "arm64" ]]; then
     dlarch="arm64"
 fi
 
+if [[ $(uname -s) == "Linux" && $(uname -m) == "aarch64" ]]; then
+    dlarch="arm64"
+fi
+
 # ...results in the download file
 dlfile="opencloud-${dlversion}-${os}-${dlarch}"
 


### PR DESCRIPTION
My odroid M1 with ubuntu 24.04 reports this: uname -a
 Linux datenheim 6.6.0-odroid-arm64 #1 SMP PREEMPT Mon, 04 Nov 2024 09:52:06 +0000 aarch64 aarch64 aarch64 GNU/Linux
 
Without this patch, install.sh would download the x68_64 binary.

