### PR TITLE
delete commit id from release version

### DIFF
--- a/.make/go.mk
+++ b/.make/go.mk
@@ -29,6 +29,8 @@ ifeq ($(VERSION), daily)
 	STRING ?= $(shell git rev-parse --short HEAD)
 else ifeq ($(VERSION),)
 	STRING ?= $(shell git rev-parse --short HEAD)
+else
+	STRING := 
 endif
 
 


### PR DESCRIPTION
related #1166

I believe it helps. If I correct got it 😀

```
// Parsed returns a semver Version
func Parsed() (version *semver.Version) {
	versionToParse := LatestTag
	// use the placeholder version if the tag is empty or when we are creating a daily build
	if Tag != "" && Tag != "daily" {
		versionToParse = Tag
	}
	version, err := semver.NewVersion(versionToParse)
	if err != nil {
		// this should never happen
		return &semver.Version{}
	}
	if String != "" {
		// We have no tagged version but a commitid
		nVersion, err := version.SetMetadata(String)
		if err != nil {
			return &semver.Version{}
		}
		version = &nVersion
	}
	return version
}
```

### For releases:

Tag = "v3.1.0" (from ldflags)
String = "" (empty, no commit hash added) // we set here empty string 
Result: 3.1.0 (clean version)

### For daily builds:

Tag = "daily"
String = "7dh9fd89" (commit hash)
Result: 3.1.0+dev-7dh9fd89 (with commit metadata)