### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,6 @@ OC_MODULES = \
 	services/webdav\
 	services/webfinger\
 	opencloud \
-	pkg \
 	protogen
 
 # bin file definitions


### PR DESCRIPTION
This removes pkg from the `OC_MODULES` list, because pkg does not contain a clean command, resulting in an error when running `make clean` from the root.