### PR TITLE
revert #1187  and add a NOOP clean  step to `protogen/Makefile`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,7 @@ OC_MODULES = \
 	services/webdav\
 	services/webfinger\
 	opencloud \
+	pkg \
 	protogen
 
 # bin file definitions

--- a/protogen/Makefile
+++ b/protogen/Makefile
@@ -9,3 +9,7 @@ include ../.make/default.mk
 .PHONY: go-generate
 go-generate: $(MOCKERY)
 	$(MOCKERY)
+
+.PHONY: clean
+clean:
+	$(NOOP)


### PR DESCRIPTION
This PR reverts #1187 and adds a NOOP clean  step to `protogen/Makefile`