### PR TITLE
proxy(sign_url_auth): Allow to verify server signed URLs

### DIFF
--- a/services/ocdav/pkg/command/server.go
+++ b/services/ocdav/pkg/command/server.go
@@ -89,6 +89,7 @@ func Server(cfg *config.Config) *cli.Command {
 					ocdav.WithTraceProvider(traceProvider),
 					ocdav.RegisterTTL(registry.GetRegisterTTL()),
 					ocdav.RegisterInterval(registry.GetRegisterInterval()),
+					ocdav.URLSigningSharedSecret(cfg.URLSigningSharedSecret),
 				}
 
 				s, err := ocdav.Service(opts...)

--- a/services/ocdav/pkg/config/config.go
+++ b/services/ocdav/pkg/config/config.go
@@ -34,8 +34,9 @@ type Config struct {
 
 	MachineAuthAPIKey string `yaml:"machine_auth_api_key" env:"OC_MACHINE_AUTH_API_KEY;OCDAV_MACHINE_AUTH_API_KEY" desc:"Machine auth API key used to validate internal requests necessary for the access to resources from other services." introductionVersion:"1.0.0"`
 
-	Context context.Context `yaml:"-"`
-	Status  Status          `yaml:"-"`
+	URLSigningSharedSecret string          `yaml:"url_signing_shared_secret" env:"OC_URL_SIGNING_SHARED_SECRET" desc:"The shared secret used to sign URLs." introductionVersion:"4.0.0"`
+	Context                context.Context `yaml:"-"`
+	Status                 Status          `yaml:"-"`
 
 	AllowPropfindDepthInfinity bool `yaml:"allow_propfind_depth_infinity" env:"OCDAV_ALLOW_PROPFIND_DEPTH_INFINITY" desc:"Allow the use of depth infinity in PROPFINDS. When enabled, a propfind will traverse through all subfolders. If many subfolders are expected, depth infinity can cause heavy server load and/or delayed response times." introductionVersion:"1.0.0"`
 }

--- a/services/proxy/pkg/config/config.go
+++ b/services/proxy/pkg/config/config.go
@@ -180,9 +180,10 @@ type StaticSelectorConf struct {
 
 // PreSignedURL is the config for the pre-signed url middleware
 type PreSignedURL struct {
-	AllowedHTTPMethods []string     `yaml:"allowed_http_methods"`
-	Enabled            bool         `yaml:"enabled" env:"PROXY_ENABLE_PRESIGNEDURLS" desc:"Allow OCS to get a signing key to sign requests." introductionVersion:"1.0.0"`
-	SigningKeys        *SigningKeys `yaml:"signing_keys"`
+	AllowedHTTPMethods     []string     `yaml:"allowed_http_methods"`
+	Enabled                bool         `yaml:"enabled" env:"PROXY_ENABLE_PRESIGNEDURLS" desc:"Allow OCS to get a signing key to sign requests." introductionVersion:"1.0.0"`
+	SigningKeys            *SigningKeys `yaml:"signing_keys"`
+	JWTSigningSharedSecret string       `yaml:"url_signing_shared_secret" env:"OC_URL_SIGNING_SHARED_SECRET" desc:"The shared secret used to sign URLs." introductionVersion:"4.0.0"`
 }
 
 // SigningKeys is a store configuration.

--- a/services/proxy/pkg/middleware/signed_url_auth.go
+++ b/services/proxy/pkg/middleware/signed_url_auth.go
@@ -254,7 +254,6 @@ func (m SignedURLAuthenticator) Authenticate(r *http.Request) (*http.Request, bo
 		return nil, false
 	}
 
-	// TODO: set user in context
 	m.Logger.Debug().
 		Str("authenticator", "signed_url").
 		Str("path", r.URL.Path).


### PR DESCRIPTION
With the ocdav service being able to provided signed download URLs we need the proxy to be able to verify the signatures.

This should also be a first step towards phasing out the weird ocs based client side signed urls.

Related Tickets: https://github.com/opencloud-eu/opencloud/issues/1104

This is still a bit of a PoC, but should be good enough for providing allowing some traction on: https://github.com/opencloud-eu/web/issues/704

Unfortunately in its current form it is a breaking change (a new configuration key is required) and would require a major version bump again. I'd be interested in suggestions about how we can make this non-breaking in a simple way.

To use this the new config variable `OC_URL_SIGNING_SHARED_SECRET` needs to be set. (Just use some randon string content)