### PR TITLE
bump-version-v2.0.3

### DIFF
--- a/deployments/examples/opencloud_full/.env
+++ b/deployments/examples/opencloud_full/.env
@@ -39,10 +39,10 @@ OPENCLOUD=:opencloud.yml
 # For production releases: "opencloudeu/opencloud"
 # For rolling releases:    "opencloudeu/opencloud-rolling"
 # Defaults to production if not set otherwise
-OC_DOCKER_IMAGE=opencloudeu/opencloud-rolling
+OC_DOCKER_IMAGE=opencloudeu/opencloud
 # The openCloud container version.
 # Defaults to "latest" and points to the latest stable tag.
-OC_DOCKER_TAG=
+OC_DOCKER_TAG=2.0.3
 # Domain of openCloud, where you can find the frontend.
 # Defaults to "cloud.opencloud.test"
 OC_DOMAIN=

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -16,7 +16,7 @@ var (
 	// LatestTag is the latest released version plus the dev meta version.
 	// Will be overwritten by the release pipeline
 	// Needs a manual change for every tagged release
-	LatestTag = "2.0.1+dev"
+	LatestTag = "2.0.3+dev"
 
 	// Date indicates the build date.
 	// This has been removed, it looks like you can only replace static strings with recent go versions


### PR DESCRIPTION
we didn't update version in the last patch release 2.0.2 so I decided not to do that in this. 
as result we got `OpenCloud 2.0.1+f60e36e8d` in the 2.0.3 version

I don't set a tag to do not to trigger readyReleaseGo.
It change version but doesn't delete commitId

@micbar can we merge it and restart https://ci.opencloud.eu/repos/3/pipeline/2214 ? Do you think that would help?