### PR TITLE
🎉 Release 2.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [2.0.4](https://github.com/opencloud-eu/opencloud/releases/tag/v2.0.4) - 2025-07-11
+
+### ❤️ Thanks to all contributors! ❤️
+
+@micbar
+
+### 🐛 Bug Fixes
+
+- [Backport] fix: build_args is now an object [[#1213](https://github.com/opencloud-eu/opencloud/pull/1213)]
+
 ## [2.0.3](https://github.com/opencloud-eu/opencloud/releases/tag/v2.0.3) - 2025-07-10
 
 ### ❤️ Thanks to all contributors! ❤️


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `2.0.4` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `stable-2.0` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [2.0.4](https://github.com/opencloud-eu/opencloud/releases/tag/v2.0.4) - 2025-07-11

### 🐛 Bug Fixes

- [Backport] fix: build_args is now an object [[#1213](https://github.com/opencloud-eu/opencloud/pull/1213)]