### PR TITLE
Adjust .woodpecker.star to make linter happy

### DIFF
--- a/.woodpecker.star
+++ b/.woodpecker.star
@@ -2192,7 +2192,7 @@ def translation_sync(ctx):
             {
                 "event": "cron",
                 "cron": "translation-sync",
-            }
+            },
         ],
     }]
 


### PR DESCRIPTION
The CI is currently failing because of the starlark linter: https://ci.opencloud.eu/repos/3/pipeline/2268/270

The problem was introduced with: https://github.com/opencloud-eu/opencloud/pull/1215/files#diff-0d2cb487e7e8bfe77cea5a2347a1987e5c8864b49ffdc1a75543dba849928a74R2195

Not sure why the CI didn't pick it up back then.

This should fix it.