### PR TITLE
tests: Avoid static dates when creating shares

### DIFF
--- a/tests/acceptance/bootstrap/SharingNgContext.php
+++ b/tests/acceptance/bootstrap/SharingNgContext.php
@@ -352,7 +352,8 @@ class SharingNgContext implements Context {
 
 		$permissionsRole = $shareInfo['permissionsRole'] ?? null;
 		$permissionsAction = $shareInfo['permissionsAction'] ?? null;
-		$expirationDateTime = $shareInfo["expirationDateTime"] ?? null;
+		$expirationDateTime = (\array_key_exists('expirationDateTime', $shareInfo))
+			? \date(DATE_RFC3339, \strtotime($shareInfo['expirationDateTime'])) : null;
 
 		$response = GraphHelper::sendSharingInvitation(
 			$this->featureContext->getBaseUrl(),
@@ -425,7 +426,8 @@ class SharingNgContext implements Context {
 
 		$permissionsRole = $rows['permissionsRole'] ?? null;
 		$permissionsAction = $rows['permissionsAction'] ?? null;
-		$expirationDateTime = $rows["expirationDateTime"] ?? null;
+		$expirationDateTime = (\array_key_exists('expirationDateTime', $rows))
+			? \date(DATE_RFC3339, \strtotime($rows['expirationDateTime'])) : null;
 
 		return GraphHelper::sendSharingInvitationForDrive(
 			$this->featureContext->getBaseUrl(),

--- a/tests/acceptance/features/apiSharingNgShareInvitation/updateShareInvitations.feature
+++ b/tests/acceptance/features/apiSharingNgShareInvitation/updateShareInvitations.feature
@@ -19,7 +19,7 @@ Feature: Update permission of a share
       | sharee             | Brian                |
       | shareType          | user                 |
       | permissionsRole    | Viewer               |
-      | expirationDateTime | 2025-07-15T14:00:00Z |
+      | expirationDateTime | tomorrow             |
     When user "Alice" updates the last resource share with the following properties using the Graph API:
       | space              | Personal             |
       | resource           | testfile.txt         |
@@ -91,7 +91,7 @@ Feature: Update permission of a share
       | sharee             | Brian                |
       | shareType          | user                 |
       | permissionsRole    | Viewer               |
-      | expirationDateTime | 2025-07-15T14:00:00Z |
+      | expirationDateTime | tomorrow             |
     When user "Alice" updates the last resource share with the following properties using the Graph API:
       | space              | Personal   |
       | resource           | <resource> |
@@ -394,7 +394,7 @@ Feature: Update permission of a share
       | sharee             | grp1                 |
       | shareType          | group                |
       | permissionsRole    | <permissions-role>   |
-      | expirationDateTime | 2025-07-15T14:00:00Z |
+      | expirationDateTime | tomorrow             |
     When user "Alice" updates the last drive share with the following using root endpoint of the Graph API:
       | permissionsRole    | <new-permissions-role> |
       | space              | NewSpace               |
@@ -474,7 +474,7 @@ Feature: Update permission of a share
       | sharee             | grp1                 |
       | shareType          | group                |
       | permissionsRole    | <permissions-role>   |
-      | expirationDateTime | 2025-07-15T14:00:00Z |
+      | expirationDateTime | tomorrow             |
     When user "Alice" updates the last drive share with the following using root endpoint of the Graph API:
       | expirationDateTime |          |
       | space              | NewSpace |
@@ -554,7 +554,7 @@ Feature: Update permission of a share
       | sharee             | grp1                 |
       | shareType          | group                |
       | permissionsRole    | <permissions-role>   |
-      | expirationDateTime | 2025-07-15T14:00:00Z |
+      | expirationDateTime | tomorrow             |
     When user "Alice" updates the last drive share with the following using root endpoint of the Graph API:
       | expirationDateTime | 2200-07-15T14:00:00Z |
       | space              | NewSpace             |
@@ -636,7 +636,7 @@ Feature: Update permission of a share
       | sharee             | grp1                 |
       | shareType          | group                |
       | permissionsRole    | <permissions-role>   |
-      | expirationDateTime | 2025-07-15T14:00:00Z |
+      | expirationDateTime | tomorrow             |
     When user "Alice" updates the last drive share with the following using root endpoint of the Graph API:
       | expirationDateTime |                        |
       | permissionsRole    | <new-permissions-role> |
@@ -717,7 +717,7 @@ Feature: Update permission of a share
       | sharee             | grp1                 |
       | shareType          | group                |
       | permissionsRole    | <permissions-role>   |
-      | expirationDateTime | 2025-07-15T14:00:00Z |
+      | expirationDateTime | tomorrow             |
     When user "Alice" updates the last drive share with the following using root endpoint of the Graph API:
       | expirationDateTime | 2200-07-15T14:00:00Z   |
       | permissionsRole    | <new-permissions-role> |
@@ -799,7 +799,7 @@ Feature: Update permission of a share
       | sharee             | Brian                |
       | shareType          | user                 |
       | permissionsRole    | <permissions-role>   |
-      | expirationDateTime | 2025-07-15T14:00:00Z |
+      | expirationDateTime | tomorrow             |
     When user "Alice" updates the last drive share with the following using root endpoint of the Graph API:
       | permissionsRole    | <new-permissions-role> |
       | space              | NewSpace               |
@@ -875,7 +875,7 @@ Feature: Update permission of a share
       | sharee             | Brian                |
       | shareType          | user                 |
       | permissionsRole    | <permissions-role>   |
-      | expirationDateTime | 2025-07-15T14:00:00Z |
+      | expirationDateTime | tomorrow             |
     When user "Alice" updates the last drive share with the following using root endpoint of the Graph API:
       | expirationDateTime |                        |
       | space              | NewSpace               |
@@ -951,7 +951,7 @@ Feature: Update permission of a share
       | sharee             | Brian                |
       | shareType          | user                 |
       | permissionsRole    | <permissions-role>   |
-      | expirationDateTime | 2025-07-15T14:00:00Z |
+      | expirationDateTime | tomorrow             |
     When user "Alice" updates the last drive share with the following using root endpoint of the Graph API:
       | expirationDateTime | 2200-07-15T14:00:00Z   |
       | permissionsRole    | <new-permissions-role> |
@@ -1033,7 +1033,7 @@ Feature: Update permission of a share
       | sharee             | Brian                |
       | shareType          | user                 |
       | permissionsRole    | <permissions-role>   |
-      | expirationDateTime | 2025-07-15T14:00:00Z |
+      | expirationDateTime | tomorrow             |
     When user "Alice" updates the last drive share with the following using root endpoint of the Graph API:
       | expirationDateTime |                        |
       | permissionsRole    | <new-permissions-role> |
@@ -1110,7 +1110,7 @@ Feature: Update permission of a share
       | sharee             | Brian                |
       | shareType          | user                 |
       | permissionsRole    | <permissions-role>   |
-      | expirationDateTime | 2025-07-15T14:00:00Z |
+      | expirationDateTime | tomorrow             |
     When user "Alice" updates the last drive share with the following using root endpoint of the Graph API:
       | expirationDateTime | 2200-07-15T14:00:00Z   |
       | permissionsRole    | <new-permissions-role> |


### PR DESCRIPTION
The expirationDate for new shares needs to be in the future. Using static dates in the tests means we need to update them every now an then. This adjusts the helpers to allow relative date formats like "+3 days" and "tomorrow" when creating shares.
