### PR TITLE
[decomposed] bump-version-v3.2.0

### DIFF
--- a/.woodpecker.env
+++ b/.woodpecker.env
@@ -1,3 +1,3 @@
 # The test runner source for UI tests
-WEB_COMMITID=6216b6e39758976bdb83e7f2b729b537f8af15fd
+WEB_COMMITID=e060701fc4ef5449a482e501b69e2b5cbf873466
 WEB_BRANCH=main

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -16,7 +16,7 @@ var (
 	// LatestTag is the latest released version plus the dev meta version.
 	// Will be overwritten by the release pipeline
 	// Needs a manual change for every tagged release
-	LatestTag = "3.1.0+dev"
+	LatestTag = "3.2.0+dev"
 
 	// Date indicates the build date.
 	// This has been removed, it looks like you can only replace static strings with recent go versions


### PR DESCRIPTION
- run all tests on decomposed storage
- bump v3.2.0 version for upcoming rolling release
- update web commit after fixing https://github.com/opencloud-eu/web/pull/982