### PR TITLE
Do not try to log metrics when we failed to get the consumer info

### DIFF
--- a/services/postprocessing/pkg/service/service.go
+++ b/services/postprocessing/pkg/service/service.go
@@ -393,6 +393,7 @@ func monitorMetrics(stream raw.Stream, name string, m *metrics.Metrics, logger l
 			info, err := consumer.Info(ctx)
 			if err != nil {
 				logger.Error().Err(err).Msg("failed to get consumer")
+				continue
 			}
 
 			m.EventsOutstandingAcks.Set(float64(info.NumAckPending))

--- a/services/search/pkg/search/events.go
+++ b/services/search/pkg/search/events.go
@@ -122,6 +122,7 @@ func monitorMetrics(stream raw.Stream, name string, m *metrics.Metrics, logger l
 			info, err := consumer.Info(ctx)
 			if err != nil {
 				logger.Error().Err(err).Msg("failed to get consumer")
+				continue
 			}
 
 			m.EventsOutstandingAcks.Set(float64(info.NumAckPending))


### PR DESCRIPTION
Fixes #1285
