### PR TITLE
Make sure to register prometheus collectors only once

### DIFF
--- a/services/postprocessing/pkg/metrics/metrics.go
+++ b/services/postprocessing/pkg/metrics/metrics.go
@@ -11,6 +11,50 @@ var (
 
 	// Subsystem defines the subsystem for the defines metrics.
 	Subsystem = "postprocessing"
+
+	buildInfo = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Subsystem: Subsystem,
+		Name:      "build_info",
+		Help:      "Build information",
+	}, []string{"version"})
+	eventsOutstandingAcks = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Subsystem: Subsystem,
+		Name:      "events_outstanding_acks",
+		Help:      "Number of outstanding acks for events",
+	})
+	eventsUnprocessed = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Subsystem: Subsystem,
+		Name:      "events_unprocessed",
+		Help:      "Number of unprocessed events",
+	})
+	eventsRedelivered = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Subsystem: Subsystem,
+		Name:      "events_redelivered",
+		Help:      "Number of redelivered events",
+	})
+	inProgress = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Subsystem: Subsystem,
+		Name:      "in_progress",
+		Help:      "Number of postprocessing events in progress",
+	})
+	finished = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: Namespace,
+		Subsystem: Subsystem,
+		Name:      "finished",
+		Help:      "Number of finished postprocessing events",
+	}, []string{"status"})
+	duration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: Namespace,
+		Subsystem: Subsystem,
+		Name:      "duration_seconds",
+		Help:      "Duration of postprocessing operations in seconds",
+		Buckets:   []float64{0.1, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300, 600, 1200},
+	}, []string{"status"})
 )
 
 // Metrics defines the available metrics of this service.
@@ -28,49 +72,13 @@ type Metrics struct {
 // New initializes the available metrics.
 func New() *Metrics {
 	m := &Metrics{
-		BuildInfo: promauto.NewGaugeVec(prometheus.GaugeOpts{
-			Namespace: Namespace,
-			Subsystem: Subsystem,
-			Name:      "build_info",
-			Help:      "Build information",
-		}, []string{"version"}),
-		EventsOutstandingAcks: promauto.NewGauge(prometheus.GaugeOpts{
-			Namespace: Namespace,
-			Subsystem: Subsystem,
-			Name:      "events_outstanding_acks",
-			Help:      "Number of outstanding acks for events",
-		}),
-		EventsUnprocessed: promauto.NewGauge(prometheus.GaugeOpts{
-			Namespace: Namespace,
-			Subsystem: Subsystem,
-			Name:      "events_unprocessed",
-			Help:      "Number of unprocessed events",
-		}),
-		EventsRedelivered: promauto.NewGauge(prometheus.GaugeOpts{
-			Namespace: Namespace,
-			Subsystem: Subsystem,
-			Name:      "events_redelivered",
-			Help:      "Number of redelivered events",
-		}),
-		InProgress: promauto.NewGauge(prometheus.GaugeOpts{
-			Namespace: Namespace,
-			Subsystem: Subsystem,
-			Name:      "in_progress",
-			Help:      "Number of postprocessing events in progress",
-		}),
-		Finished: promauto.NewCounterVec(prometheus.CounterOpts{
-			Namespace: Namespace,
-			Subsystem: Subsystem,
-			Name:      "finished",
-			Help:      "Number of finished postprocessing events",
-		}, []string{"status"}),
-		Duration: promauto.NewHistogramVec(prometheus.HistogramOpts{
-			Namespace: Namespace,
-			Subsystem: Subsystem,
-			Name:      "duration_seconds",
-			Help:      "Duration of postprocessing operations in seconds",
-			Buckets:   []float64{0.1, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300, 600, 1200},
-		}, []string{"status"}),
+		BuildInfo:             buildInfo,
+		EventsOutstandingAcks: eventsOutstandingAcks,
+		EventsUnprocessed:     eventsUnprocessed,
+		EventsRedelivered:     eventsRedelivered,
+		InProgress:            inProgress,
+		Finished:              finished,
+		Duration:              duration,
 	}
 
 	return m

--- a/services/search/pkg/metrics/metrics.go
+++ b/services/search/pkg/metrics/metrics.go
@@ -11,6 +11,45 @@ var (
 
 	// Subsystem defines the subsystem for the defines metrics.
 	Subsystem = "search"
+
+	buildInfo = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Subsystem: Subsystem,
+		Name:      "build_info",
+		Help:      "Build information",
+	}, []string{"version"})
+	eventsOutstandingAcks = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Subsystem: Subsystem,
+		Name:      "events_outstanding_acks",
+		Help:      "Number of outstanding acks for events",
+	})
+	eventsUnprocessed = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Subsystem: Subsystem,
+		Name:      "events_unprocessed",
+		Help:      "Number of unprocessed events",
+	})
+	eventsRedelivered = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Subsystem: Subsystem,
+		Name:      "events_redelivered",
+		Help:      "Number of redelivered events",
+	})
+	searchDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: Namespace,
+		Subsystem: Subsystem,
+		Name:      "search_duration_seconds",
+		Help:      "Duration of search operations in seconds",
+		Buckets:   []float64{0.1, 0.5, 1, 2.5, 5, 10, 30, 60},
+	}, []string{"status"})
+	indexDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: Namespace,
+		Subsystem: Subsystem,
+		Name:      "index_duration_seconds",
+		Help:      "Duration of indexing operations in seconds",
+		Buckets:   []float64{0.1, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300, 600, 1200},
+	}, []string{"status"})
 )
 
 // Metrics defines the available metrics of this service.
@@ -27,44 +66,12 @@ type Metrics struct {
 // New initializes the available metrics.
 func New() *Metrics {
 	m := &Metrics{
-		BuildInfo: promauto.NewGaugeVec(prometheus.GaugeOpts{
-			Namespace: Namespace,
-			Subsystem: Subsystem,
-			Name:      "build_info",
-			Help:      "Build information",
-		}, []string{"version"}),
-		EventsOutstandingAcks: promauto.NewGauge(prometheus.GaugeOpts{
-			Namespace: Namespace,
-			Subsystem: Subsystem,
-			Name:      "events_outstanding_acks",
-			Help:      "Number of outstanding acks for events",
-		}),
-		EventsUnprocessed: promauto.NewGauge(prometheus.GaugeOpts{
-			Namespace: Namespace,
-			Subsystem: Subsystem,
-			Name:      "events_unprocessed",
-			Help:      "Number of unprocessed events",
-		}),
-		EventsRedelivered: promauto.NewGauge(prometheus.GaugeOpts{
-			Namespace: Namespace,
-			Subsystem: Subsystem,
-			Name:      "events_redelivered",
-			Help:      "Number of redelivered events",
-		}),
-		SearchDuration: promauto.NewHistogramVec(prometheus.HistogramOpts{
-			Namespace: Namespace,
-			Subsystem: Subsystem,
-			Name:      "search_duration_seconds",
-			Help:      "Duration of search operations in seconds",
-			Buckets:   []float64{0.1, 0.5, 1, 2.5, 5, 10, 30, 60},
-		}, []string{"status"}),
-		IndexDuration: promauto.NewHistogramVec(prometheus.HistogramOpts{
-			Namespace: Namespace,
-			Subsystem: Subsystem,
-			Name:      "index_duration_seconds",
-			Help:      "Duration of indexing operations in seconds",
-			Buckets:   []float64{0.1, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300, 600, 1200},
-		}, []string{"status"}),
+		BuildInfo:             buildInfo,
+		EventsOutstandingAcks: eventsOutstandingAcks,
+		EventsUnprocessed:     eventsUnprocessed,
+		EventsRedelivered:     eventsRedelivered,
+		SearchDuration:        searchDuration,
+		IndexDuration:         indexDuration,
 	}
 
 	return m


### PR DESCRIPTION
This fixes `duplicate metrics collector registration attempted` errors when a service gets restarted.