### PR TITLE
feat: introduce alias for thumbnail max dimensions and change default

### DIFF
--- a/services/thumbnails/pkg/config/config.go
+++ b/services/thumbnails/pkg/config/config.go
@@ -44,7 +44,7 @@ type Thumbnail struct {
 	FontMapFile           string            `yaml:"font_map_file" env:"THUMBNAILS_TXT_FONTMAP_FILE" desc:"The path to a font file for txt thumbnails." introductionVersion:"1.0.0"`
 	TransferSecret        string            `yaml:"transfer_secret" env:"THUMBNAILS_TRANSFER_TOKEN" desc:"The secret to sign JWT to download the actual thumbnail file." introductionVersion:"1.0.0"`
 	DataEndpoint          string            `yaml:"data_endpoint" env:"THUMBNAILS_DATA_ENDPOINT" desc:"The HTTP endpoint where the actual thumbnail file can be downloaded." introductionVersion:"1.0.0"`
-	MaxInputWidth         int               `yaml:"max_input_width" env:"THUMBNAILS_MAX_INPUT_WIDTH" desc:"The maximum width of an input image which is being processed." introductionVersion:"1.0.0"`
-	MaxInputHeight        int               `yaml:"max_input_height" env:"THUMBNAILS_MAX_INPUT_HEIGHT" desc:"The maximum height of an input image which is being processed." introductionVersion:"1.0.0"`
+	MaxInputWidth         int               `yaml:"max_input_width" env:"THUMBNAILS_MAX_INPUT_WIDTH;THUMBNAILS_MAX_INPUT_DIMENSION" desc:"The maximum width of an input image which is being processed." introductionVersion:"1.0.0"`
+	MaxInputHeight        int               `yaml:"max_input_height" env:"THUMBNAILS_MAX_INPUT_HEIGHT;THUMBNAILS_MAX_INPUT_DIMENSION" desc:"The maximum height of an input image which is being processed." introductionVersion:"1.0.0"`
 	MaxInputImageFileSize string            `yaml:"max_input_image_file_size" env:"THUMBNAILS_MAX_INPUT_IMAGE_FILE_SIZE" desc:"The maximum file size of an input image which is being processed. Usable common abbreviations: [KB, KiB, MB, MiB, GB, GiB, TB, TiB, PB, PiB, EB, EiB], example: 2GB." introductionVersion:"1.0.0"`
 }

--- a/services/thumbnails/pkg/config/defaults/defaultconfig.go
+++ b/services/thumbnails/pkg/config/defaults/defaultconfig.go
@@ -55,8 +55,8 @@ func DefaultConfig() *config.Config {
 			RevaGateway:           shared.DefaultRevaConfig().Address,
 			CS3AllowInsecure:      false,
 			DataEndpoint:          "http://127.0.0.1:9186/thumbnails/data",
-			MaxInputWidth:         7680,
-			MaxInputHeight:        7680,
+			MaxInputWidth:         10000,
+			MaxInputHeight:        10000,
 			MaxInputImageFileSize: "50MB",
 		},
 	}


### PR DESCRIPTION
## Description
Introduced an alias for the thumbnailer max dimensions, because setting max height and max width separately makes no sense at all. Photos in portrait and landscape orientation exist. Makes no sense to have a different max height than max width.
Also adjusted the default value, because 7680px is not enough for a 50MP photo.

## Motivation and Context
- easier config
- better defaults.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)
