### PR TITLE
Drop the "InProgress" metric

### DIFF
--- a/services/postprocessing/pkg/metrics/metrics.go
+++ b/services/postprocessing/pkg/metrics/metrics.go
@@ -36,12 +36,6 @@ var (
 		Name:      "events_redelivered",
 		Help:      "Number of redelivered events",
 	})
-	inProgress = promauto.NewGauge(prometheus.GaugeOpts{
-		Namespace: Namespace,
-		Subsystem: Subsystem,
-		Name:      "in_progress",
-		Help:      "Number of postprocessing events in progress",
-	})
 	finished = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: Namespace,
 		Subsystem: Subsystem,
@@ -64,7 +58,6 @@ type Metrics struct {
 	EventsOutstandingAcks prometheus.Gauge
 	EventsUnprocessed     prometheus.Gauge
 	EventsRedelivered     prometheus.Gauge
-	InProgress            prometheus.Gauge
 	Finished              *prometheus.CounterVec
 	Duration              *prometheus.HistogramVec
 }
@@ -76,7 +69,6 @@ func New() *Metrics {
 		EventsOutstandingAcks: eventsOutstandingAcks,
 		EventsUnprocessed:     eventsUnprocessed,
 		EventsRedelivered:     eventsRedelivered,
-		InProgress:            inProgress,
 		Finished:              finished,
 		Duration:              duration,
 	}

--- a/services/postprocessing/pkg/service/service.go
+++ b/services/postprocessing/pkg/service/service.go
@@ -159,7 +159,6 @@ func (pps *PostprocessingService) processEvent(e raw.Event) error {
 			ImpersonatingUser: ev.ImpersonatingUser,
 			StartTime:         time.Now(),
 		}
-		pps.metrics.InProgress.Inc()
 		next = pp.Init(ev)
 	case events.PostprocessingStepFinished:
 		if ev.UploadID == "" {
@@ -210,7 +209,6 @@ func (pps *PostprocessingService) processEvent(e raw.Event) error {
 			}
 		})
 	case events.UploadReady:
-		pps.metrics.InProgress.Dec()
 		// the upload failed - let's keep it around for a while - but mark it as finished
 		pp, err = pps.getPP(pps.store, ev.UploadID)
 		if err != nil {


### PR DESCRIPTION
It didn't really make sense in multi-node setups because items could be started and finished on different nodes.

/cc @micbar 