### PR TITLE
[full-ci] fix(star): full-ci failed due to wrong syntax

### DIFF
--- a/.woodpecker.star
+++ b/.woodpecker.star
@@ -1479,6 +1479,8 @@ def multiServiceE2ePipeline(ctx):
                     "HEADLESS": True,
                     "RETRY": "1",
                     "REPORT_TRACING": params["reportTracing"],
+                    "PLAYWRIGHT_BROWSERS_PATH": "%s/%s" % (dirs["base"], ".playwright"),
+                    "BROWSER": "chromium",
                 },
                 "commands": [
                     "cd %s/tests/e2e" % dirs["web"],


### PR DESCRIPTION
https://ci.opencloud.eu/repos/3/pipeline/2712/errors