### PR TITLE
[decomposed] bump-version-v3.3.0

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -16,7 +16,7 @@ var (
 	// LatestTag is the latest released version plus the dev meta version.
 	// Will be overwritten by the release pipeline
 	// Needs a manual change for every tagged release
-	LatestTag = "3.2.0+dev"
+	LatestTag = "3.3.0+dev"
 
 	// Date indicates the build date.
 	// This has been removed, it looks like you can only replace static strings with recent go versions


### PR DESCRIPTION
- run all tests on decomposed storage
- bump v3.3.0 version for upcoming rolling release