### PR TITLE
tests for collaborativePosixFS

### DIFF
--- a/.woodpecker.star
+++ b/.woodpecker.star
@@ -2057,7 +2057,7 @@ def opencloudServer(storage = "decomposed", accounts_hash_difficulty = 4, depend
         },
         "commands": [
             "apt-get update",
-            "apt-get install -y inotify-tools",
+            "apt-get install -y inotify-tools xattr",
             "%s init --insecure true" % dirs["opencloudBin"],
             "cat $OC_CONFIG_DIR/opencloud.yaml",
             "cp tests/config/woodpecker/app-registry.yaml $OC_CONFIG_DIR/app-registry.yaml",


### PR DESCRIPTION
related https://github.com/opencloud-eu/internal/issues/105

- [ ] ~~Run all tests with the server env `STORAGE_USERS_POSIX_WATCH_FS=true`~~ will be implemented in #1358
- [ ] ~~Run nightly CI without `WATCH_FS` `STORAGE_USERS_POSIX_WATCH_FS=false` -> need setup nightly running first https://github.com/opencloud-eu/qa/issues/41~~ will be implemented in #1358
- [x] Increase the coverage of `collaborativePosixFS.feature`. Tests for:
    - create nested folder
    - create large file 1gb
    - creates 50 files sequentially in a folder
    - creates 100 files in parallel in a folder
    
how to run tests localy on mac: 
- build wrapper: `cd tests/ocwrapper`, `GOARCH=amd64 make build`
- start opencloud in docker `STORAGE_USERS_POSIX_WATCH_FS=true ACTIVITYLOG_WRITE_BUFFER_DURATION=0 LOCAL_TEST=true WITH_WRAPPER=true STORAGE_DRIVER=posix make -C tests/acceptance/docker start-server`
- run tests `OC_WRAPPER_URL=http://opencloud-server:5200 TEST_SERVER_URL=https://opencloud-server:9200 make test-acceptance-api BEHAT_FEATURE=tests/acceptance/features/collaborativePosix/collaborativePosixFS.feature`
    