### PR TITLE
feat: add defaultAppId option for the web config.json

### DIFF
--- a/services/web/pkg/config/options.go
+++ b/services/web/pkg/config/options.go
@@ -18,6 +18,7 @@ type Options struct {
 	Embed                  *Embed              `json:"embed,omitempty" yaml:"embed"`
 	UserListRequiresFilter bool                `json:"userListRequiresFilter,omitempty" yaml:"userListRequiresFilter" env:"WEB_OPTION_USER_LIST_REQUIRES_FILTER" desc:"Defines whether one or more filters must be set in order to list users in the Web admin settings. Set this option to 'true' if running in an environment with a lot of users and listing all users could slow down performance. Defaults to 'false'." introductionVersion:"1.0.0"`
 	ConcurrentRequests     *ConcurrentRequests `json:"concurrentRequests,omitempty" yaml:"concurrentRequests"`
+	DefaultAppID           string              `json:"defaultAppId,omitempty" yaml:"defaultAppId" env:"WEB_OPTION_DEFAULT_APP_ID" desc:"Defines the entrypoint for the web ui." introductionVersion:"%%NEXT%%"`
 }
 
 // AccountEditLink are the AccountEditLink options


### PR DESCRIPTION
## Description

As of https://github.com/opencloud-eu/web/pull/1081 (need to bump web in opencloud though for this PR to have any effect) we have a `defaultAppId` option for the config.json, which allows to specify a different app than `files` (which is the default in web code base).

## Motivation and Context

Allow users to e.g. start with a link collection from the external sites app as their main entry point.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)