### PR TITLE
Tracing improvements

### DIFF
--- a/services/proxy/pkg/command/server.go
+++ b/services/proxy/pkg/command/server.go
@@ -343,6 +343,8 @@ func loadMiddlewares(logger log.Logger, cfg *config.Config,
 	}
 
 	return alice.New(
+		chimiddleware.RealIP,
+		chimiddleware.RequestID,
 		// first make sure we log all requests and redirect to https if necessary
 		otelhttp.NewMiddleware("proxy",
 			otelhttp.WithTracerProvider(traceProvider),
@@ -353,8 +355,6 @@ func loadMiddlewares(logger log.Logger, cfg *config.Config,
 		middleware.Tracer(traceProvider),
 		pkgmiddleware.TraceContext,
 		middleware.Instrumenter(metrics),
-		chimiddleware.RealIP,
-		chimiddleware.RequestID,
 		middleware.AccessLog(logger),
 		middleware.ContextLogger(logger),
 		middleware.HTTPSRedirect,

--- a/services/proxy/pkg/command/server.go
+++ b/services/proxy/pkg/command/server.go
@@ -370,6 +370,7 @@ func loadMiddlewares(logger log.Logger, cfg *config.Config,
 		),
 		middleware.AccountResolver(
 			middleware.Logger(logger),
+			middleware.TraceProvider(traceProvider),
 			middleware.UserProvider(userProvider),
 			middleware.UserRoleAssigner(roleAssigner),
 			middleware.SkipUserInfo(cfg.OIDC.SkipUserInfo),
@@ -380,17 +381,20 @@ func loadMiddlewares(logger log.Logger, cfg *config.Config,
 		),
 		middleware.SelectorCookie(
 			middleware.Logger(logger),
+			middleware.TraceProvider(traceProvider),
 			middleware.PolicySelectorConfig(*cfg.PolicySelector),
 		),
 		middleware.Policies(
 			cfg.PoliciesMiddleware.Query,
 			middleware.Logger(logger),
+			middleware.TraceProvider(traceProvider),
 			middleware.WithRevaGatewaySelector(gatewaySelector),
 			middleware.PoliciesProviderService(policiesProviderClient),
 		),
 		// finally, trigger home creation when a user logs in
 		middleware.CreateHome(
 			middleware.Logger(logger),
+			middleware.TraceProvider(traceProvider),
 			middleware.WithRevaGatewaySelector(gatewaySelector),
 			middleware.RoleQuotas(cfg.RoleQuotas),
 		),

--- a/services/proxy/pkg/middleware/selector_cookie.go
+++ b/services/proxy/pkg/middleware/selector_cookie.go
@@ -1,12 +1,14 @@
 package middleware
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/opencloud-eu/opencloud/pkg/log"
 	"github.com/opencloud-eu/opencloud/pkg/oidc"
 	"github.com/opencloud-eu/opencloud/services/proxy/pkg/config"
 	"github.com/opencloud-eu/opencloud/services/proxy/pkg/proxy/policy"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // SelectorCookie provides a middleware which
@@ -14,11 +16,13 @@ func SelectorCookie(optionSetters ...Option) func(next http.Handler) http.Handle
 	options := newOptions(optionSetters...)
 	logger := options.Logger
 	policySelector := options.PolicySelector
+	tracer := getTraceProvider(options).Tracer("proxy.middleware.selector_cookie")
 
 	return func(next http.Handler) http.Handler {
 		return &selectorCookie{
 			next:           next,
 			logger:         logger,
+			tracer:         tracer,
 			policySelector: policySelector,
 		}
 	}
@@ -27,12 +31,17 @@ func SelectorCookie(optionSetters ...Option) func(next http.Handler) http.Handle
 type selectorCookie struct {
 	next           http.Handler
 	logger         log.Logger
+	tracer         trace.Tracer
 	policySelector config.PolicySelector
 }
 
 func (m selectorCookie) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	ctx, span := m.tracer.Start(req.Context(), fmt.Sprintf("%s %s", req.Method, req.URL.Path), trace.WithSpanKind(trace.SpanKindServer))
+	req = req.WithContext(ctx)
+	defer span.End()
 	if m.policySelector.Regex == nil && m.policySelector.Claims == nil {
 		// only set selector cookie for regex and claim selectors
+		span.End()
 		m.next.ServeHTTP(w, req)
 		return
 	}
@@ -65,5 +74,6 @@ func (m selectorCookie) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		http.SetCookie(w, &cookie)
 	}
 
+	defer span.End()
 	m.next.ServeHTTP(w, req)
 }


### PR DESCRIPTION
This PR has some smaller improvement for tracing

- use otelchi middleware in the graph service
- avoid unneeded extra span just for the request id attribute, by just adding it to the otelhttp created span
- create spans for the various proxy middlewares.

I am still somewhat unhappy with how the span for the middlewares are created. Each middleware's span is the child span for the middleware that is before it in the chain. I'd prefer if they were just childs of the top-level span created by the otel framework. I might be missing something obvious, but it seems really clumsy to create the spans that way because of the way how they are passed via context.