### PR TITLE
chore(web): remove unused theming options

### DIFF
--- a/services/web/assets/themes/opencloud-dev/theme.json
+++ b/services/web/assets/themes/opencloud-dev/theme.json
@@ -5,43 +5,6 @@
     "ios": {},
     "web": {
       "defaults": {
-        "appBanner": {},
-        "designTokens": {
-          "breakpoints": {
-            "large-default": "",
-            "large-max": "",
-            "medium-default": "",
-            "medium-max": "",
-            "small-default": "",
-            "small-max": "",
-            "xlarge": "",
-            "xsmall-max": ""
-          },
-          "fontSizes": {
-            "default": "",
-            "large": "",
-            "medium": ""
-          },
-          "sizes": {
-            "form-check-default": "",
-            "height-small": "",
-            "height-table-row": "",
-            "icon-default": "",
-            "max-height-logo": "",
-            "max-width-logo": "",
-            "tiles-default": "",
-            "tiles-resize-step": "",
-            "width-medium": ""
-          },
-          "spacing": {
-            "large": "",
-            "medium": "",
-            "small": "",
-            "xlarge": "",
-            "xsmall": "",
-            "xxlarge": ""
-          }
-        },
         "logo": "themes/opencloud-dev/assets/logo.svg",
         "favicon": "themes/opencloud-dev/assets/favicon.svg"
       },

--- a/services/web/assets/themes/opencloud/theme.json
+++ b/services/web/assets/themes/opencloud/theme.json
@@ -51,43 +51,7 @@
     "web": {
       "defaults": {
         "logo": "themes/opencloud/assets/logo.svg",
-        "favicon": "themes/opencloud/assets/favicon.svg",
-        "designTokens": {
-          "breakpoints": {
-            "xsmall-max": "",
-            "small-default": "",
-            "small-max": "",
-            "medium-default": "",
-            "medium-max": "",
-            "large-default": "",
-            "large-max": "",
-            "xlarge": ""
-          },
-          "fontSizes": {
-            "default": "",
-            "large": "",
-            "medium": ""
-          },
-          "sizes": {
-            "form-check-default": "",
-            "height-small": "",
-            "height-table-row": "",
-            "icon-default": "",
-            "max-height-logo": "",
-            "max-width-logo": "",
-            "width-medium": "",
-            "tiles-default": "",
-            "tiles-resize-step": ""
-          },
-          "spacing": {
-            "xsmall": "",
-            "small": "",
-            "medium": "",
-            "large": "",
-            "xlarge": "",
-            "xxlarge": ""
-          }
-        }
+        "favicon": "themes/opencloud/assets/favicon.svg"
       },
       "themes": [
         {


### PR DESCRIPTION
The theming options `breakpoints`, `spacing`, `fontSizes` and `sizes` have been removed in Web.

see https://github.com/opencloud-eu/web/pull/1161