### PR TITLE
use correct endpoint in nats check

### DIFF
--- a/services/proxy/pkg/server/debug/server.go
+++ b/services/proxy/pkg/server/debug/server.go
@@ -22,7 +22,7 @@ func Server(opts ...Option) (*http.Server, error) {
 		WithCheck("web reachability", checks.NewHTTPCheck(options.Config.HTTP.Addr))
 
 	readyHandlerConfiguration := healthHandlerConfiguration.
-		WithCheck("nats reachability", checks.NewNatsCheck(options.Config.Events.Cluster))
+		WithCheck("nats reachability", checks.NewNatsCheck(options.Config.Events.Endpoint))
 
 	var configDumpFunc http.HandlerFunc = configDump(options.Config)
 	return debug.NewService(

--- a/tests/acceptance/expected-failures-localAPI-on-decomposed-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-decomposed-storage.md
@@ -189,7 +189,7 @@
 - [apiSharingNg1/propfindShares.feature:149](https://github.com/opencloud-eu/opencloud/blob/main/tests/acceptance/features/apiSharingNg1/propfindShares.feature#L149)
 
 #### [Readiness check for some services returns 500 status code](https://github.com/owncloud/ocis/issues/10661)
-- [apiServiceAvailability/serviceAvailabilityCheck.feature:116](https://github.com/opencloud-eu/opencloud/blob/main/tests/acceptance/features/apiServiceAvailability/serviceAvailabilityCheck.feature#L116)
+
 - [apiServiceAvailability/serviceAvailabilityCheck.feature:125](https://github.com/opencloud-eu/opencloud/blob/main/tests/acceptance/features/apiServiceAvailability/serviceAvailabilityCheck.feature#L125)
 
 #### [Skip tests for different languages](https://github.com/opencloud-eu/opencloud/issues/183)

--- a/tests/acceptance/expected-failures-localAPI-on-posix-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-posix-storage.md
@@ -189,7 +189,7 @@
 - [apiSharingNg1/propfindShares.feature:149](https://github.com/opencloud-eu/opencloud/blob/main/tests/acceptance/features/apiSharingNg1/propfindShares.feature#L149)
 
 #### [Readiness check for some services returns 500 status code](https://github.com/owncloud/ocis/issues/10661)
-- [apiServiceAvailability/serviceAvailabilityCheck.feature:116](https://github.com/opencloud-eu/opencloud/blob/main/tests/acceptance/features/apiServiceAvailability/serviceAvailabilityCheck.feature#L116)
+
 - [apiServiceAvailability/serviceAvailabilityCheck.feature:125](https://github.com/opencloud-eu/opencloud/blob/main/tests/acceptance/features/apiServiceAvailability/serviceAvailabilityCheck.feature#L125)
 
 #### [Skip tests for different languages](https://github.com/opencloud-eu/opencloud/issues/183)


### PR DESCRIPTION
this fixes these errors
```json
{"level":"error","service":"proxy","error":"'nats reachability': could not connect to nats server: dial tcp: lookup opencloud-cluster on 10.43.0.10:53: no such host","time":"2025-09-22T13:36:22Z","line":"github.com/opencloud-eu/opencloud/pkg/handlers/checker.go:107","message":"check failed"}
```