### PR TITLE
allow running auth-bearer as part of the runtime

### DIFF
--- a/opencloud/pkg/runtime/service/service.go
+++ b/opencloud/pkg/runtime/service/service.go
@@ -28,6 +28,7 @@ import (
 	audit "github.com/opencloud-eu/opencloud/services/audit/pkg/command"
 	authapp "github.com/opencloud-eu/opencloud/services/auth-app/pkg/command"
 	authbasic "github.com/opencloud-eu/opencloud/services/auth-basic/pkg/command"
+	authbearer "github.com/opencloud-eu/opencloud/services/auth-bearer/pkg/command"
 	authmachine "github.com/opencloud-eu/opencloud/services/auth-machine/pkg/command"
 	authservice "github.com/opencloud-eu/opencloud/services/auth-service/pkg/command"
 	clientlog "github.com/opencloud-eu/opencloud/services/clientlog/pkg/command"
@@ -328,6 +329,11 @@ func NewService(ctx context.Context, options ...Option) (*Service, error) {
 		cfg.Audit.Context = ctx
 		cfg.Audit.Commons = cfg.Commons
 		return audit.Execute(cfg.Audit)
+	})
+	areg(opts.Config.AuthBearer.Service.Name, func(ctx context.Context, cfg *occfg.Config) error {
+		cfg.AuthBearer.Context = ctx
+		cfg.AuthBearer.Commons = cfg.Commons
+		return authbearer.Execute(cfg.AuthBearer)
 	})
 	areg(opts.Config.Policies.Service.Name, func(ctx context.Context, cfg *occfg.Config) error {
 		cfg.Policies.Context = ctx

--- a/services/auth-bearer/pkg/command/server.go
+++ b/services/auth-bearer/pkg/command/server.go
@@ -70,7 +70,7 @@ func Server(cfg *config.Config) *cli.Command {
 					debug.Config(cfg),
 				)
 				if err != nil {
-					logger.Info().Err(err).Str("server", "debug").Msg("Failed to initialize server")
+					logger.Error().Err(err).Str("server", "debug").Msg("Failed to initialize server")
 					return err
 				}
 


### PR DESCRIPTION
I wondered why this feature failed:
```
  @env-config @issue-10661
  Scenario: check extra services readiness
    Given the following configs have been set:
      | config                 | value        |
      | OC_ADD_RUN_SERVICES  | auth-bearer  |
      | AUTH_BEARER_DEBUG_ADDR | 0.0.0.0:9149 |
    When a user requests these URLs with "GET" and no authentication
      | endpoint                               | service     |
      | http://%base_url_hostname%:9149/readyz | auth-bearer |
    Then the HTTP status code of responses on all endpoints should be "200"
```
The auth-bearer service is not started when `OC_ADD_RUN_SERVICES="auth-bearer"`. This pr changes that.

Maybe we should log an error if the config contains an unknown service?