### PR TITLE
introduce AppURLs helper for atomic backgroud updates

### DIFF
--- a/services/collaboration/pkg/helpers/registration.go
+++ b/services/collaboration/pkg/helpers/registration.go
@@ -7,7 +7,6 @@ import (
 	registryv1beta1 "github.com/cs3org/go-cs3apis/cs3/app/registry/v1beta1"
 	gatewayv1beta1 "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
 	rpcv1beta1 "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
-	"github.com/opencloud-eu/reva/v2/pkg/mime"
 	"github.com/opencloud-eu/reva/v2/pkg/rgrpc/todo/pool"
 
 	"github.com/opencloud-eu/opencloud/pkg/log"
@@ -35,24 +34,9 @@ func RegisterAppProvider(
 	cfg *config.Config,
 	logger log.Logger,
 	gws pool.Selectable[gatewayv1beta1.GatewayAPIClient],
-	appUrls map[string]map[string]string,
+	appUrls *AppURLs,
 ) error {
-	mimeTypesMap := make(map[string]bool)
-	for _, extensions := range appUrls {
-		for ext := range extensions {
-			m := mime.Detect(false, ext)
-			// skip the default
-			if m == "application/octet-stream" {
-				continue
-			}
-			mimeTypesMap[m] = true
-		}
-	}
-
-	mimeTypes := make([]string, 0, len(mimeTypesMap))
-	for m := range mimeTypesMap {
-		mimeTypes = append(mimeTypes, m)
-	}
+	mimeTypes := appUrls.GetMimeTypes()
 
 	logger.Debug().
 		Str("AppName", cfg.App.Name).

--- a/services/collaboration/pkg/server/grpc/option.go
+++ b/services/collaboration/pkg/server/grpc/option.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/opencloud-eu/opencloud/pkg/log"
 	"github.com/opencloud-eu/opencloud/services/collaboration/pkg/config"
+	"github.com/opencloud-eu/opencloud/services/collaboration/pkg/helpers"
 	microstore "go-micro.dev/v4/store"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -14,7 +15,7 @@ type Option func(o *Options)
 
 // Options defines the available options for this package.
 type Options struct {
-	AppURLs       map[string]map[string]string
+	AppURLs       *helpers.AppURLs
 	Name          string
 	Logger        log.Logger
 	Context       context.Context
@@ -35,7 +36,7 @@ func newOptions(opts ...Option) Options {
 }
 
 // AppURLs provides app urls based on mimetypes.
-func AppURLs(val map[string]map[string]string) Option {
+func AppURLs(val *helpers.AppURLs) Option {
 	return func(o *Options) {
 		o.AppURLs = val
 	}

--- a/services/collaboration/pkg/service/grpc/v0/option.go
+++ b/services/collaboration/pkg/service/grpc/v0/option.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/opencloud-eu/opencloud/pkg/log"
 	"github.com/opencloud-eu/opencloud/services/collaboration/pkg/config"
+	"github.com/opencloud-eu/opencloud/services/collaboration/pkg/helpers"
 )
 
 // Option defines a single option function.
@@ -16,7 +17,7 @@ type Option func(o *Options)
 type Options struct {
 	Logger          log.Logger
 	Config          *config.Config
-	AppURLs         map[string]map[string]string
+	AppURLs         *helpers.AppURLs
 	GatewaySelector pool.Selectable[gatewayv1beta1.GatewayAPIClient]
 	Store           microstore.Store
 }
@@ -47,7 +48,7 @@ func Config(val *config.Config) Option {
 }
 
 // AppURLs provides a function to set the AppURLs option.
-func AppURLs(val map[string]map[string]string) Option {
+func AppURLs(val *helpers.AppURLs) Option {
 	return func(o *Options) {
 		o.AppURLs = val
 	}

--- a/services/collaboration/pkg/service/grpc/v0/service_test.go
+++ b/services/collaboration/pkg/service/grpc/v0/service_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/opencloud-eu/opencloud/pkg/log"
 	"github.com/opencloud-eu/opencloud/services/collaboration/mocks"
 	"github.com/opencloud-eu/opencloud/services/collaboration/pkg/config"
+	"github.com/opencloud-eu/opencloud/services/collaboration/pkg/helpers"
 	service "github.com/opencloud-eu/opencloud/services/collaboration/pkg/service/grpc/v0"
 )
 
@@ -80,22 +81,25 @@ var _ = Describe("Discovery", func() {
 		gatewaySelector := mocks.NewSelectable[gatewayv1beta1.GatewayAPIClient](GinkgoT())
 		gatewaySelector.On("Next").Return(gatewayClient, nil)
 
+		appURLs := helpers.NewAppURLs()
+		appURLs.Store(map[string]map[string]string{
+			"view": {
+				".pdf":  "https://cloud.opencloud.test/hosting/wopi/word/view",
+				".djvu": "https://cloud.opencloud.test/hosting/wopi/word/view",
+				".docx": "https://cloud.opencloud.test/hosting/wopi/word/view",
+				".xls":  "https://cloud.opencloud.test/hosting/wopi/cell/view",
+				".xlsb": "https://cloud.opencloud.test/hosting/wopi/cell/view",
+			},
+			"edit": {
+				".docx":    "https://cloud.opencloud.test/hosting/wopi/word/edit",
+				".invalid": "://cloud.opencloud.test/hosting/wopi/cell/edit",
+			},
+		})
+
 		srv, srvTear, _ = service.NewHandler(
 			service.Logger(log.NopLogger()),
 			service.Config(cfg),
-			service.AppURLs(map[string]map[string]string{
-				"view": {
-					".pdf":  "https://cloud.opencloud.test/hosting/wopi/word/view",
-					".djvu": "https://cloud.opencloud.test/hosting/wopi/word/view",
-					".docx": "https://cloud.opencloud.test/hosting/wopi/word/view",
-					".xls":  "https://cloud.opencloud.test/hosting/wopi/cell/view",
-					".xlsb": "https://cloud.opencloud.test/hosting/wopi/cell/view",
-				},
-				"edit": {
-					".docx":    "https://cloud.opencloud.test/hosting/wopi/word/edit",
-					".invalid": "://cloud.opencloud.test/hosting/wopi/cell/edit",
-				},
-			}),
+			service.AppURLs(appURLs),
 			service.GatewaySelector(gatewaySelector),
 		)
 	})


### PR DESCRIPTION
We introduce AppURLs, a wrapper around atomic.Pointer that lets us use a ticker to periodically update the discovered WOPI actions without dying when it is not available on startup.

This allows us to get rid the hard requirement of the web office to be online and even allows us to pick up changes in its configuration automatically.