### PR TITLE
apiTest-flaky: sync share before checking

### DIFF
--- a/tests/acceptance/features/apiSharingNgShareInvitation/shareInvitations.feature
+++ b/tests/acceptance/features/apiSharingNgShareInvitation/shareInvitations.feature
@@ -23,6 +23,7 @@ Feature: Send a sharing invitations
       | shareType       | user               |
       | permissionsRole | <permissions-role> |
     Then the HTTP status code should be "200"
+    And user "Brian" has a share "<resource>" synced
     And user "Brian" should have a share "<resource>" shared by user "Alice" from space "Personal"
     And the JSON data of the response should match
       """
@@ -113,7 +114,9 @@ Feature: Send a sharing invitations
       | shareType       | group              |
       | permissionsRole | <permissions-role> |
     Then the HTTP status code should be "200"
+    And user "Brian" has a share "<resource>" synced
     And user "Brian" should have a share "<resource>" shared by user "Alice" from space "Personal"
+    And user "Carol" has a share "<resource>" synced
     And user "Carol" should have a share "<resource>" shared by user "Alice" from space "Personal"
     And the JSON data of the response should match
       """
@@ -1998,6 +2001,7 @@ Feature: Send a sharing invitations
       | shareType       | user               |
       | permissionsRole | <permissions-role> |
     Then the HTTP status code should be "200"
+    And user "Brian" has a share "<resource>" synced
     And user "Brian" should have a share "<resource>" shared by user "Alice" from space "NewSpace"
     And the JSON data of the response should match
       """
@@ -2086,7 +2090,9 @@ Feature: Send a sharing invitations
       | shareType       | group              |
       | permissionsRole | <permissions-role> |
     Then the HTTP status code should be "200"
+    And user "Brian" has a share "<resource>" synced
     And user "Brian" should have a share "<resource>" shared by user "Alice" from space "NewSpace"
+    And user "Carol" has a share "<resource>" synced
     And user "Carol" should have a share "<resource>" shared by user "Alice" from space "NewSpace"
     And the JSON data of the response should match
       """
@@ -3122,6 +3128,7 @@ Feature: Send a sharing invitations
       | shareType       | user         |
       | permissionsRole | Viewer       |
     Then the HTTP status code should be "200"
+    And user "Brian" has a share "textfile.txt" synced
     And user "Brian" should have a share "textfile.txt" shared by user "Alice" from space "Personal"
     When user "Alice" sends the following resource share invitation using the Graph API:
       | resource        | textfile.txt |
@@ -3130,6 +3137,7 @@ Feature: Send a sharing invitations
       | shareType       | group        |
       | permissionsRole | Viewer       |
     Then the HTTP status code should be "200"
+    And user "Carol" has a share "textfile.txt" synced
     And user "Carol" should have a share "textfile.txt" shared by user "Alice" from space "Personal"
 
 
@@ -3146,6 +3154,7 @@ Feature: Send a sharing invitations
       | shareType       | group        |
       | permissionsRole | Viewer       |
     Then the HTTP status code should be "200"
+    And user "Brian" has a share "textfile.txt" synced
     And user "Brian" should have a share "textfile.txt" shared by user "Alice" from space "Personal"
 
 
@@ -3166,6 +3175,7 @@ Feature: Send a sharing invitations
       | shareType       | user         |
       | permissionsRole | Viewer       |
     Then the HTTP status code should be "200"
+    And user "Brian" has a share "textfile.txt" synced
     And user "Brian" should have a share "textfile.txt" shared by user "Alice" from space "NewSpace"
     When user "Alice" sends the following resource share invitation using the Graph API:
       | resource        | textfile.txt |
@@ -3174,6 +3184,7 @@ Feature: Send a sharing invitations
       | shareType       | group        |
       | permissionsRole | Viewer       |
     Then the HTTP status code should be "200"
+    And user "Carol" has a share "textfile.txt" synced
     And user "Carol" should have a share "textfile.txt" shared by user "Alice" from space "NewSpace"
 
 
@@ -3193,4 +3204,5 @@ Feature: Send a sharing invitations
       | shareType       | group        |
       | permissionsRole | Viewer       |
     Then the HTTP status code should be "200"
+    And user "Brian" has a share "textfile.txt" synced
     And user "Brian" should have a share "textfile.txt" shared by user "Alice" from space "NewSpace"


### PR DESCRIPTION
### Problem
https://ci.opencloud.eu/repos/3/pipeline/291/168

```
Scenario Outline: send share invitation to group with different roles                            # /woodpecker/src/github.com/opencloud-eu/opencloud/tests/acceptance/features/apiSharingNgShareInvitation/shareInvitations.feature:100
    Given user "Carol" has been created with default attributes                                    # FeatureContext::userHasBeenCreatedWithDefaultAttributes()
    And group "grp1" has been created                                                              # FeatureContext::groupHasBeenCreated()
    And the following users have been added to the following groups                                # FeatureContext::theFollowingUserHaveBeenAddedToTheFollowingGroup()
      | username | groupname |
      | Brian    | grp1      |
      | Carol    | grp1      |
    And user "Alice" has uploaded file with content "to share" to "/textfile1.txt"                 # FeatureContext::userHasUploadedAFileWithContentTo()
    And user "Alice" has created folder "FolderToShare"                                            # FeatureContext::userHasCreatedFolder()
    When user "Alice" sends the following resource share invitation using the Graph API:           # SharingNgContext::userSendsTheFollowingResourceShareInvitationUsingTheGraphApi()
      | resource        | <resource>         |
      | space           | Personal           |
      | sharee          | grp1               |
      | shareType       | group              |
      | permissionsRole | <permissions-role> |
    Then the HTTP status code should be "200"                                                      # FeatureContext::thenTheHTTPStatusCodeShouldBe()
    And user "Brian" should have a share "<resource>" shared by user "Alice" from space "Personal" # SharingNgContext::userShouldHaveShareSharedByUserFromSpace()
    And user "Carol" should have a share "<resource>" shared by user "Alice" from space "Personal" # SharingNgContext::userShouldHaveShareSharedByUserFromSpace()

--------
    Examples:
      | permissions-role | resource       |
      | Viewer           | /textfile1.txt |
      | File Editor      | /textfile1.txt |
      | Viewer           | FolderToShare  |
      | Editor           | FolderToShare  |
      | Uploader         | FolderToShare  |
        Failed step: And user "Brian" should have a share "FolderToShare" shared by user "Alice" from space "Personal"
        Share mountpoint 'FolderToShare' was not found in the drives list.
        Failed asserting that false is identical to true.
```

user Brian hasn't mountpoint 'FolderToShare' because share is async -> need wait
```
==> REQUEST
		GET /graph/v1.0/me/drives
		Content-Type: application/x-www-form-urlencoded

		<== RESPONSE
		200 OK
		X-Xss-Protection: 1; mode=block
		<== RES BODY
		{"value":[{"driveAlias":"personal/brian","driveType":"personal","id":"55163dc3-3a0a-45be-9a97-15316bdae90d$495dac4c-4b4e-464d-9dd0-a981f1b1e331","lastModifiedDateTime":"2025-09-24T06:41:40.958063583Z","name":"Brian Murphy","owner":{"user":{"displayName":"","id":"fc322c91-4971-46a9-9f8c-de881265e8ef"}},"quota":{"remaining":9223372036854775807,"state":"normal","total":0,"used":0},"root":{"eTag":"\"a96f9966db51d255e128966dd839f0c7\"","id":"55163dc3-3a0a-45be-9a97-15316bdae90d$495dac4c-4b4e-464d-9dd0-a981f1b1e331","webDavUrl":"https://opencloud-server:9200/dav/spaces/55163dc3-3a0a-45be-9a97-15316bdae90d$495dac4c-4b4e-464d-9dd0-a981f1b1e331"},"webUrl":"https://opencloud-server:9200/f/55163dc3-3a0a-45be-9a97-15316bdae90d$495dac4c-4b4e-464d-9dd0-a981f1b1e331"},{"driveAlias":"virtual/shares","driveType":"virtual","id":"a0ca6a90-a365-4782-871e-d44447bbc668$a0ca6a90-a365-4782-871e-d44447bbc668","name":"Shares","root":{"eTag":"DECAFC00FEE","id":"a0ca6a90-a365-4782-871e-d44447bbc668$a0ca6a90-a365-4782-871e-d44447bbc668","webDavUrl":"https://opencloud-server:9200/dav/spaces/a0ca6a90-a365-4782-871e-d44447bbc668$a0ca6a90-a365-4782-871e-d44447bbc668"},"webUrl":"https://opencloud-server:9200/f/a0ca6a90-a365-4782-871e-d44447bbc668$a0ca6a90-a365-4782-871e-d44447bbc668"}]}
```


### Solution
added step `And user "Brian" has a share "<resource>" synced` to wait until share will be exist

