### PR TITLE
[full-ci] getting personal space by userId instead of userName

### DIFF
--- a/tests/acceptance/TestHelpers/GraphHelper.php
+++ b/tests/acceptance/TestHelpers/GraphHelper.php
@@ -476,7 +476,7 @@ class GraphHelper {
 	 * @param string $xRequestId
 	 * @param string $byUser
 	 * @param string $userPassword
-	 * @param string|null $user
+	 * @param string|null $userIdOrName User ID or username to get drive information for
 	 *
 	 * @return ResponseInterface
 	 * @throws GuzzleException
@@ -486,9 +486,9 @@ class GraphHelper {
 		string $xRequestId,
 		string $byUser,
 		string $userPassword,
-		?string $user = null
+		?string $userIdOrName = null
 	): ResponseInterface {
-		$url = self::getFullUrl($baseUrl, 'users/' . $user . '?%24select=&%24expand=drive');
+		$url = self::getFullUrl($baseUrl, 'users/' . $userIdOrName . '?%24select=&%24expand=drive');
 		return HttpRequestHelper::get(
 			$url,
 			$xRequestId,

--- a/tests/acceptance/bootstrap/CliContext.php
+++ b/tests/acceptance/bootstrap/CliContext.php
@@ -516,7 +516,7 @@ class CliContext implements Context {
 	 * @return void
 	 */
 	public function theAdministratorCreatesFolder(string $folder, string $user): void {
-		$userUuid = $this->featureContext->getUserIdByUserName($user);
+		$userUuid = $this->featureContext->getAttributeOfCreatedUser($user, 'id');
 		$storagePath = $this->getUsersStoragePath();
 		$fullPath = "$storagePath/$userUuid/$folder";
 
@@ -537,7 +537,7 @@ class CliContext implements Context {
 	 * @return void
 	 */
 	public function theAdministratorCheckUsersFolder(string $user): void {
-		$userUuid = $this->featureContext->getUserIdByUserName($user);
+		$userUuid = $this->featureContext->getAttributeOfCreatedUser($user, 'id');
 		$storagePath = $this->getUsersStoragePath();
 		$body = [
 		  "command" => "ls -la $storagePath/$userUuid",
@@ -556,7 +556,7 @@ class CliContext implements Context {
 	 * @return void
 	 */
 	public function theAdministratorCreatesFile(string $file, string $content, string $user): void {
-		$userUuid = $this->featureContext->getUserIdByUserName($user);
+		$userUuid = $this->featureContext->getAttributeOfCreatedUser($user, 'id');
 		$storagePath = $this->getUsersStoragePath();
 		$fullPath = "$storagePath/$userUuid/$file";
 		$safeContent = escapeshellarg($content);
@@ -593,7 +593,7 @@ class CliContext implements Context {
 	 * @return void
 	 */
 	public function theAdministratorCreatesLargeFileWithSize(string $file, string $size, string $user): void {
-		$userUuid = $this->featureContext->getUserIdByUserName($user);
+		$userUuid = $this->featureContext->getAttributeOfCreatedUser($user, 'id');
 		$storagePath = $this->getUsersStoragePath();
 
 		$size = strtolower($size);
@@ -624,7 +624,7 @@ class CliContext implements Context {
 	 * @return void
 	 */
 	public function theAdministratorCreatesFilesSequentially(int $count, string $dir, string $user): void {
-		$userUuid = $this->featureContext->getUserIdByUserName($user);
+		$userUuid = $this->featureContext->getAttributeOfCreatedUser($user, 'id');
 		$storagePath = $this->getUsersStoragePath() . "/$userUuid/$dir";
 		$cmd = '';
 		for ($i = 1; $i <= $count; $i++) {
@@ -649,7 +649,7 @@ class CliContext implements Context {
 	 * @return void
 	 */
 	public function theAdministratorCreatesFilesInParallel(int $count, string $dir, string $user): void {
-		$userUuid = $this->featureContext->getUserIdByUserName($user);
+		$userUuid = $this->featureContext->getAttributeOfCreatedUser($user, 'id');
 		$storagePath = $this->getUsersStoragePath() . "/$userUuid/$dir";
 		$cmd = "mkdir -p $storagePath; ";
 		for ($i = 1; $i <= $count; $i++) {
@@ -675,7 +675,7 @@ class CliContext implements Context {
 	 * @return void
 	 */
 	public function theAdministratorChangesFileContent(string $content, string $file, string $user): void {
-		$userUuid = $this->featureContext->getUserIdByUserName($user);
+		$userUuid = $this->featureContext->getAttributeOfCreatedUser($user, 'id');
 		$storagePath = $this->getUsersStoragePath();
 		$safeContent = escapeshellarg($content);
 		$body = [
@@ -696,7 +696,7 @@ class CliContext implements Context {
 	 * @return void
 	 */
 	public function theAdministratorReadsTheFileContent(string $user, string $file): void {
-		$userUuid = $this->featureContext->getUserIdByUserName($user);
+		$userUuid = $this->featureContext->getAttributeOfCreatedUser($user, 'id');
 		$storagePath = $this->getUsersStoragePath();
 		$body = [
 		  "command" => "cat $storagePath/$userUuid/$file",
@@ -715,7 +715,7 @@ class CliContext implements Context {
 	 * @return void
 	 */
 	public function theAdministratorCopiesFileToFolder(string $user, string $file, string $folder): void {
-		$userUuid = $this->featureContext->getUserIdByUserName($user);
+		$userUuid = $this->featureContext->getAttributeOfCreatedUser($user, 'id');
 		$storagePath = $this->getUsersStoragePath();
 
 		$source = "$storagePath/$userUuid/$file";
@@ -739,7 +739,7 @@ class CliContext implements Context {
 	 * @return void
 	 */
 	public function theAdministratorRenamesFile(string $user, string $file, string $newName): void {
-		$userUuid = $this->featureContext->getUserIdByUserName($user);
+		$userUuid = $this->featureContext->getAttributeOfCreatedUser($user, 'id');
 		$storagePath = $this->getUsersStoragePath();
 
 		$source = "$storagePath/$userUuid/$file";
@@ -763,7 +763,7 @@ class CliContext implements Context {
 	 * @return void
 	 */
 	public function theAdministratorMovesFileToFolder(string $user, string $file, string $folder): void {
-		$userUuid = $this->featureContext->getUserIdByUserName($user);
+		$userUuid = $this->featureContext->getAttributeOfCreatedUser($user, 'id');
 		$storagePath = $this->getUsersStoragePath();
 
 		$source = "$storagePath/$userUuid/$file";
@@ -786,7 +786,7 @@ class CliContext implements Context {
 	 * @return void
 	 */
 	public function theAdministratorDeletesFile(string $file, string $user): void {
-		$userUuid = $this->featureContext->getUserIdByUserName($user);
+		$userUuid = $this->featureContext->getAttributeOfCreatedUser($user, 'id');
 		$storagePath = $this->getUsersStoragePath();
 
 		$body = [
@@ -806,7 +806,7 @@ class CliContext implements Context {
 	 * @return void
 	 */
 	public function theAdministratorDeletesFolder(string $folder, string $user): void {
-		$userUuid = $this->featureContext->getUserIdByUserName($user);
+		$userUuid = $this->featureContext->getAttributeOfCreatedUser($user, 'id');
 		$storagePath = $this->getUsersStoragePath();
 
 		$body = [
@@ -827,7 +827,7 @@ class CliContext implements Context {
 	 * @return void
 	 */
 	public function theAdministratorCopiesFileToSpace(string $user, string $file, string $space): void {
-		$userUuid = $this->featureContext->getUserIdByUserName($user);
+		$userUuid = $this->featureContext->getAttributeOfCreatedUser($user, 'id');
 		$usersStoragePath = $this->getUsersStoragePath();
 		$projectsStoragePath = $this->getProjectsStoragePath();
 		$spaceId = $this->spacesContext->getSpaceIdByName($this->featureContext->getAdminUsername(), $space);
@@ -874,7 +874,7 @@ class CliContext implements Context {
 	 * @return void
 	 */
 	public function theAdminChecksTheAttributeOfFileForUser(string $attribute, string $file, string $user): void {
-		$userUuid = $this->featureContext->getUserIdByUserName($user);
+		$userUuid = $this->featureContext->getAttributeOfCreatedUser($user, 'id');
 		$storagePath = $this->getUsersStoragePath();
 		$body = [
 			"command" => "xattr -p -slz " . escapeshellarg($attribute) . " $storagePath/$userUuid/$file",

--- a/tests/acceptance/bootstrap/FeatureContext.php
+++ b/tests/acceptance/bootstrap/FeatureContext.php
@@ -2333,9 +2333,9 @@ class FeatureContext extends BehatVariablesContext {
 			[
 				"code" => "%user_id%",
 				"function" => [
-					$this, "getUserIdByUserName"
+					$this, "getAttributeOfCreatedUser"
 				],
-					"parameter" => [$userName]
+					"parameter" => [$userName, 'id']
 				],
 			[
 				"code" => "%group_id%",
@@ -2511,8 +2511,8 @@ class FeatureContext extends BehatVariablesContext {
 				[
 				"code" => "%user_id%",
 				"function" =>
-				[$this, "getUserIdByUserName"],
-				"parameter" => [$userName]
+				[$this, "getAttributeOfCreatedUser"],
+				"parameter" => [$userName, 'id']
 				],
 				[
 				"code" => "%group_id%",
@@ -2866,30 +2866,6 @@ class FeatureContext extends BehatVariablesContext {
 			$body = '';
 		}
 		return $body;
-	}
-
-	/**
-	 * The method returns userId
-	 *
-	 * @param string $userName
-	 *
-	 * @return string
-	 * @throws Exception|GuzzleException
-	 */
-	public function getUserIdByUserName(string $userName): string {
-		$response = GraphHelper::getUser(
-			$this->getBaseUrl(),
-			$this->getStepLineRef(),
-			$this->getAdminUsername(),
-			$this->getAdminPassword(),
-			$userName
-		);
-		$data = \json_decode($response->getBody()->getContents(), true, 512, JSON_THROW_ON_ERROR);
-		if (isset($data["id"])) {
-			return $data["id"];
-		} else {
-			throw new Exception(__METHOD__ . " accounts-list is empty");
-		}
 	}
 
 	/**

--- a/tests/acceptance/bootstrap/GraphContext.php
+++ b/tests/acceptance/bootstrap/GraphContext.php
@@ -353,7 +353,7 @@ class GraphContext implements Context {
 	 * @throws GuzzleException
 	 */
 	public function theUserDeletesAUserUsingTheGraphAPI(string $byUser, string $user): void {
-		$userId = $this->featureContext->getUserIdByUserName($user);
+		$userId = $this->featureContext->getAttributeOfCreatedUser($user, 'id');
 		$this->featureContext->setResponse($this->deleteUserByUserIdUsingTheGraphApi($userId, $byUser));
 	}
 
@@ -2455,7 +2455,7 @@ class GraphContext implements Context {
 	 */
 	public function getAssignedRole(string $user): ResponseInterface {
 		$userId = $this->featureContext->getAttributeOfCreatedUser($user, 'id')
-		?: $this->featureContext->getUserIdByUserName($user);
+		?: $this->featureContext->getAttributeOfCreatedUser($user, 'id');
 		return (
 			GraphHelper::getAssignedRole(
 				$this->featureContext->getBAseUrl(),
@@ -2844,7 +2844,7 @@ class GraphContext implements Context {
 	 * @throws JsonException
 	 */
 	public function theUserHasChangedItsOwnUsernameTo(string $byUser, string $userName): void {
-		$userId = $this->featureContext->getUserIdByUserName($byUser);
+		$userId = $this->featureContext->getAttributeOfCreatedUser($byUser, 'id');
 		$response = GraphHelper::editUser(
 			$this->featureContext->getBaseUrl(),
 			$this->featureContext->getStepLineRef(),

--- a/tests/acceptance/bootstrap/GraphContext.php
+++ b/tests/acceptance/bootstrap/GraphContext.php
@@ -2991,7 +2991,7 @@ class GraphContext implements Context {
 	 *
 	 * @return void
 	 */
-	public function userListsTheActivitiesOfSpaceUsingTheGraphApi(string $user, string $spaceName): void {
+	public function userListsTheActivitiesOfProjectSpaceUsingTheGraphApi(string $user, string $spaceName): void {
 		$spaceId = ($this->featureContext->spacesContext->getSpaceByName($user, $spaceName))["id"];
 		$response = GraphHelper::getActivities(
 			$this->featureContext->getBaseUrl(),
@@ -2999,6 +2999,25 @@ class GraphContext implements Context {
 			$user,
 			$this->featureContext->getPasswordForUser($user),
 			$spaceId
+		);
+		$this->featureContext->setResponse($response);
+	}
+
+	/**
+	 * @When user :user lists the activities of personal space using the Graph API
+	 *
+	 * @param string $user
+	 *
+	 * @return void
+	 */
+	public function userListsTheActivitiesOfPersonalSpaceUsingTheGraphApi(string $user): void {
+		$space = $this->featureContext->spacesContext->getPersonalSpace($user);
+		$response = GraphHelper::getActivities(
+			$this->featureContext->getBaseUrl(),
+			$this->featureContext->getStepLineRef(),
+			$user,
+			$this->featureContext->getPasswordForUser($user),
+			$space["id"]
 		);
 		$this->featureContext->setResponse($response);
 	}

--- a/tests/acceptance/bootstrap/GraphContext.php
+++ b/tests/acceptance/bootstrap/GraphContext.php
@@ -2453,8 +2453,7 @@ class GraphContext implements Context {
 	 * @throws GuzzleException
 	 */
 	public function getAssignedRole(string $user): ResponseInterface {
-		$userId = $this->featureContext->getAttributeOfCreatedUser($user, 'id')
-		?: $this->featureContext->getAttributeOfCreatedUser($user, 'id');
+		$userId = $this->featureContext->getAttributeOfCreatedUser($user, 'id');
 		return (
 			GraphHelper::getAssignedRole(
 				$this->featureContext->getBAseUrl(),

--- a/tests/acceptance/bootstrap/GraphContext.php
+++ b/tests/acceptance/bootstrap/GraphContext.php
@@ -688,15 +688,14 @@ class GraphContext implements Context {
 			$rows["displayName"]
 		);
 
-		// add created user to list except for the user with an empty name
-		// because request /graph/v1.0/users/emptyUserName exits with 200
-		// and we cannot check that the user with empty name doesn't exist
-		if (!empty($rows["userName"])) {
+		$responseData = \json_decode($response->getBody()->getContents(), true, 512, JSON_THROW_ON_ERROR);
+		if ($response->getStatusCode() === 201) {
 			$this->featureContext->addUserToCreatedUsersList(
 				$rows["userName"],
 				$rows["password"],
 				$rows["displayName"],
-				$rows["email"]
+				$rows["email"],
+				$responseData['id']
 			);
 		}
 		$this->featureContext->setResponse($response);

--- a/tests/acceptance/bootstrap/SpacesContext.php
+++ b/tests/acceptance/bootstrap/SpacesContext.php
@@ -225,7 +225,7 @@ class SpacesContext implements Context {
 	 * @throws GuzzleException
 	 * @throws JsonException
 	 */
-	public function getPersonalSpace(string $user): string {
+	public function getPersonalSpace(string $user): array {
 		$resource = GraphHelper::getUserWithDriveInformation(
 			$this->featureContext->getBaseUrl(),
 			$this->featureContext->getStepLineRef(),
@@ -1082,7 +1082,7 @@ class SpacesContext implements Context {
 			"No space with name $spaceName found"
 		);
 		$permissions = $spaceAsArray["root"]["permissions"];
-		$userId = $this->featureContext->getUserIdByUserName($grantedUser);
+		$userId = $this->featureContext->getAttributeOfCreatedUser($grantedUser, 'id');
 
 		$userRole = "";
 		foreach ($permissions as $permission) {
@@ -4679,7 +4679,7 @@ class SpacesContext implements Context {
 			"No space with name $spaceName found"
 		);
 		$recipientType === 'user' ?
-		$recipientId = $this->featureContext->getUserIdByUserName($recipient)
+		$recipientId = $this->featureContext->getAttributeOfCreatedUser($recipient, 'id')
 		: $recipientId = $this->featureContext->getGroupIdByGroupName($recipient);
 		$foundRoleInResponse = false;
 		foreach ($spaceAsArray['root']['permissions'] as $permission) {

--- a/tests/acceptance/bootstrap/SpacesContext.php
+++ b/tests/acceptance/bootstrap/SpacesContext.php
@@ -219,6 +219,31 @@ class SpacesContext implements Context {
 	}
 
 	/**
+	 * @param string $user
+	 *
+	 * @return string
+	 * @throws GuzzleException
+	 * @throws JsonException
+	 */
+	public function getPersonalSpace(string $user): string {
+		$resource = GraphHelper::getUserWithDriveInformation(
+			$this->featureContext->getBaseUrl(),
+			$this->featureContext->getStepLineRef(),
+			$user,
+			$this->featureContext->getPasswordForUser($user),
+			$this->featureContext->getAttributeOfCreatedUser($user, 'id'),
+			$this->featureContext->getStepLineRef()
+		);
+
+		$space = json_decode($resource->getBody()->getContents(), true);
+		Assert::assertIsArray($space);
+		Assert::assertArrayHasKey('drive', $space, "Drive information not found for user '$user'");
+		Assert::assertArrayHasKey('id', $space['drive'], "Drive ID not found for user '$user'");
+
+		return $space["drive"];
+	}
+
+	/**
 	 * The method finds available spaces to the user and returns the spaceId by spaceName
 	 *
 	 * @param string $user
@@ -1520,6 +1545,32 @@ class SpacesContext implements Context {
 	}
 
 	/**
+	 * @param string $user
+	 * @param string $targetUser
+	 * @param array $bodyData
+	 *
+	 * @return ResponseInterface
+	 * @throws GuzzleException
+	 * @throws JsonException
+	 */
+	public function updatePersonalSpace(
+		string $user,
+		string $targetUser,
+		array $bodyData,
+	): ResponseInterface {
+		$body = json_encode($bodyData, JSON_THROW_ON_ERROR);
+		$space = $this->getPersonalSpace($targetUser);
+		return GraphHelper::updateSpace(
+			$this->featureContext->getBaseUrl(),
+			$user,
+			$this->featureContext->getPasswordForUser($user),
+			$body,
+			$space["id"],
+			$this->featureContext->getStepLineRef()
+		);
+	}
+
+	/**
 	 * @When /^user "([^"]*)" (?:changes|tries to change) the name of the "([^"]*)" space to "([^"]*)"$/
 	 * @When /^user "([^"]*)" (?:changes|tries to change) the name of the "([^"]*)" space to "([^"]*)" owned by user "([^"]*)"$/
 	 *
@@ -1620,11 +1671,10 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" has changed the quota of the personal space of "([^"]*)" space to "([^"]*)"$/
-	 * @Given /^user "([^"]*)" has changed the quota of the "([^"]*)" space to "([^"]*)"$/
+	 * @Given /^user "([^"]*)" has changed the quota of the personal space of user "([^"]*)" space to "([^"]*)"$/
 	 *
 	 * @param string $user
-	 * @param string $spaceName
+	 * @param string $targetUser
 	 * @param int $newQuota
 	 *
 	 * @return void
@@ -1633,11 +1683,11 @@ class SpacesContext implements Context {
 	 */
 	public function userHasChangedTheQuotaOfTheSpaceTo(
 		string $user,
-		string $spaceName,
+		string $targetUser,
 		int $newQuota
 	): void {
 		$bodyData = ["quota" => ["total" => $newQuota]];
-		$response = $this->updateSpace($user, $spaceName, $bodyData);
+		$response = $this->updatePersonalSpace($user, $targetUser, $bodyData);
 		$this->featureContext->theHTTPStatusCodeShouldBe(
 			200,
 			"Expected response status code should be 200",

--- a/tests/acceptance/features/apiActivities/activities.feature
+++ b/tests/acceptance/features/apiActivities/activities.feature
@@ -294,7 +294,7 @@ Feature: check activities
     And user "Alice" has created folder "/FOLDER"
     And user "Alice" has deleted file "textfile.txt"
     And user "Alice" has deleted folder "FOLDER"
-    When user "Alice" lists the activities of space "Personal" using the Graph API
+    When user "Alice" lists the activities of personal space using the Graph API
     Then the HTTP status code should be "200"
     And the JSON data of the response should match
       """

--- a/tests/acceptance/features/apiGraph/userGDPRExport.feature
+++ b/tests/acceptance/features/apiGraph/userGDPRExport.feature
@@ -411,7 +411,7 @@ Feature: user GDPR (General Data Protection Regulation) report
 
 
   Scenario: generate a GDPR report after the admin updates the quota of personal space
-    Given user "Admin" has changed the quota of the personal space of "Alice Hansen" space to "10000"
+    Given user "Admin" has changed the quota of the personal space of user "Alice" space to "10000"
     When user "Alice" exports her GDPR report to "/.personal_data_export.json" using the Graph API
     And user "Alice" downloads the content of GDPR report ".personal_data_export.json"
     Then the HTTP status code of responses on each endpoint should be "202, 200" respectively

--- a/tests/acceptance/features/apiSpaces/changeSpaces.feature
+++ b/tests/acceptance/features/apiSpaces/changeSpaces.feature
@@ -516,7 +516,7 @@ Feature: Change data of space
 
   Scenario Outline: user can't upload resource greater than set quota
     Given the administrator has assigned the role "<user-role>" to user "Alice" using the Graph API
-    And user "Admin" has changed the quota of the personal space of "Alice Hansen" space to "15"
+    And user "Admin" has changed the quota of the personal space of user "Alice" space to "15"
     When user "Alice" uploads a file inside space "Alice Hansen" with content "file is more than 15 bytes" to "file.txt" using the WebDAV API
     Then the HTTP status code should be "507"
     And for user "Alice" the space "Personal" should not contain these entries:

--- a/tests/acceptance/features/apiSpaces/quota.feature
+++ b/tests/acceptance/features/apiSpaces/quota.feature
@@ -105,7 +105,7 @@ Feature: State of the quota
 
 
   Scenario Outline: check the relative amount of quota of personal space
-    Given user "Admin" has changed the quota of the personal space of "Alice Hansen" space to "10000"
+    Given user "Admin" has changed the quota of the personal space of user "Alice" space to "10000"
     And user "Alice" has uploaded file "<file-upload>" to "/demo.txt"
     When the user "Alice" requests these endpoints with "GET" with basic auth
       | endpoint    |
@@ -138,7 +138,7 @@ Feature: State of the quota
 
 
   Scenario: user can restore a file version even if there is not enough quota to do so
-    Given user "Admin" has changed the quota of the "Alice Hansen" space to "30"
+    Given user "Admin" has changed the quota of the personal space of user "Alice" space to "30"
     And user "Alice" has uploaded file with content "file is less than 30 bytes" to "/file.txt"
     And user "Alice" has uploaded file with content "reduceContent" to "/file.txt"
     And user "Alice" has uploaded file with content "some content" to "newFile.txt"

--- a/tests/acceptance/features/apiSpacesShares/shareOperations.feature
+++ b/tests/acceptance/features/apiSpacesShares/shareOperations.feature
@@ -331,7 +331,7 @@ Feature: sharing
       | shareType       | user     |
       | permissionsRole | Editor   |
     And user "Brian" has a share "FOLDER" synced
-    And user "Admin" has changed the quota of the personal space of "Alice Hansen" space to "1"
+    And user "Admin" has changed the quota of the personal space of user "Alice" space to "1"
     When user "Brian" uploads a file inside space "Shares" with content "new description" to "/FOLDER/textfile.txt" using the WebDAV API
     Then the HTTP status code should be "507"
     And as "Alice" file "/FOLDER/textfile.txt" should not exist
@@ -348,7 +348,7 @@ Feature: sharing
       | shareType       | group    |
       | permissionsRole | Editor   |
     And user "Brian" has a share "FOLDER" synced
-    And user "Admin" has changed the quota of the personal space of "Alice Hansen" space to "1"
+    And user "Admin" has changed the quota of the personal space of user "Alice" space to "1"
     When user "Brian" uploads a file inside space "Shares" with content "new description" to "/FOLDER/textfile.txt" using the WebDAV API
     Then the HTTP status code should be "507"
     And as "Alice" file "/FOLDER/textfile.txt" should not exist
@@ -363,7 +363,7 @@ Feature: sharing
       | shareType       | user     |
       | permissionsRole | Uploader |
     And user "Brian" has a share "FOLDER" synced
-    And user "Admin" has changed the quota of the personal space of "Alice Hansen" space to "1"
+    And user "Admin" has changed the quota of the personal space of user "Alice" space to "1"
     When user "Brian" uploads a file inside space "Shares" with content "new description" to "/FOLDER/textfile.txt" using the WebDAV API
     Then the HTTP status code should be "507"
     And as "Alice" file "/FOLDER/textfile.txt" should not exist
@@ -380,7 +380,7 @@ Feature: sharing
       | shareType       | group    |
       | permissionsRole | Uploader |
     And user "Brian" has a share "FOLDER" synced
-    And user "Admin" has changed the quota of the personal space of "Alice Hansen" space to "10"
+    And user "Admin" has changed the quota of the personal space of user "Alice" space to "10"
     When user "Brian" uploads a file inside space "Shares" with content "new descriptionfgshsywhhh" to "/FOLDER/textfile.txt" using the WebDAV API
     Then the HTTP status code should be "507"
     And as "Alice" file "/FOLDER/textfile.txt" should not exist

--- a/tests/acceptance/features/coreApiShareOperationsToShares2/uploadToShare.feature
+++ b/tests/acceptance/features/coreApiShareOperationsToShares2/uploadToShare.feature
@@ -167,7 +167,7 @@ Feature: sharing
   Scenario Outline: check quota of owners parent directory of a shared file
     Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes
-    And user "Admin" has changed the quota of the personal space of "Brian Murphy" space to "0"
+    And user "Admin" has changed the quota of the personal space of user "Brian" space to "0"
     And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/myfile.txt"
     And user "Alice" has sent the following resource share invitation:
       | resource        | myfile.txt  |
@@ -204,7 +204,7 @@ Feature: sharing
       | shareType       | user     |
       | permissionsRole | Editor   |
     And user "Brian" has a share "FOLDER" synced
-    And user "Admin" has changed the quota of the personal space of "Alice Hansen" space to "1"
+    And user "Admin" has changed the quota of the personal space of user "Alice" space to "1"
     When user "Brian" uploads file "filesForUpload/textfile.txt" to "/Shares/FOLDER/myfile.txt" using the WebDAV API
     Then the HTTP status code should be "507"
     And as "Alice" file "/FOLDER/myfile.txt" should not exist
@@ -228,7 +228,7 @@ Feature: sharing
       | shareType       | group    |
       | permissionsRole | Editor   |
     And user "Brian" has a share "FOLDER" synced
-    And user "Admin" has changed the quota of the personal space of "Alice Hansen" space to "1"
+    And user "Admin" has changed the quota of the personal space of user "Alice" space to "1"
     When user "Brian" uploads file "filesForUpload/textfile.txt" to "/Shares/FOLDER/myfile.txt" using the WebDAV API
     Then the HTTP status code should be "507"
     And as "Alice" file "/FOLDER/myfile.txt" should not exist
@@ -250,7 +250,7 @@ Feature: sharing
       | shareType       | user     |
       | permissionsRole | Uploader |
     And user "Brian" has a share "FOLDER" synced
-    And user "Admin" has changed the quota of the personal space of "Alice Hansen" space to "1"
+    And user "Admin" has changed the quota of the personal space of user "Alice" space to "1"
     When user "Brian" uploads file "filesForUpload/textfile.txt" to "/Shares/FOLDER/myfile.txt" using the WebDAV API
     Then the HTTP status code should be "507"
     And as "Alice" file "/FOLDER/myfile.txt" should not exist
@@ -274,7 +274,7 @@ Feature: sharing
       | shareType       | group    |
       | permissionsRole | Uploader |
     And user "Brian" has a share "FOLDER" synced
-    And user "Admin" has changed the quota of the personal space of "Alice Hansen" space to "1"
+    And user "Admin" has changed the quota of the personal space of user "Alice" space to "1"
     When user "Brian" uploads file "filesForUpload/textfile.txt" to "/Shares/FOLDER/myfile.txt" using the WebDAV API
     Then the HTTP status code should be "507"
     And as "Alice" file "/FOLDER/myfile.txt" should not exist

--- a/tests/acceptance/features/coreApiSharePublicLink2/uploadToPublicLinkShare.feature
+++ b/tests/acceptance/features/coreApiSharePublicLink2/uploadToPublicLinkShare.feature
@@ -86,7 +86,7 @@ Feature: upload to a public link share
       | space           | Personal |
       | permissionsRole | edit     |
       | password        | %public% |
-    And user "Admin" has changed the quota of the personal space of "Alice Hansen" space to "1"
+    And user "Admin" has changed the quota of the personal space of user "Alice" space to "1"
     When the public uploads file "test.txt" with password "%public%" and content "test2" using the public WebDAV API
     Then the HTTP status code should be "507"
 
@@ -98,7 +98,7 @@ Feature: upload to a public link share
       | space           | Personal   |
       | permissionsRole | createOnly |
       | password        | %public%   |
-    And user "Admin" has changed the quota of the personal space of "Alice Hansen" space to "1"
+    And user "Admin" has changed the quota of the personal space of user "Alice" space to "1"
     When the public uploads file "test.txt" with password "%public%" and content "test2" using the public WebDAV API
     Then the HTTP status code should be "507"
 

--- a/tests/acceptance/features/coreApiWebdavProperties/getQuota.feature
+++ b/tests/acceptance/features/coreApiWebdavProperties/getQuota.feature
@@ -36,8 +36,8 @@ Feature: get quota
   Scenario Outline: retrieving folder quota of shared folder with quota when no quota is set for recipient
     Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes
-    And user "Admin" has changed the quota of the personal space of "Alice Hansen" space to "0"
-    And user "Admin" has changed the quota of the personal space of "Brian Murphy" space to "10000"
+    And user "Admin" has changed the quota of the personal space of user "Alice" space to "0"
+    And user "Admin" has changed the quota of the personal space of user "Brian" space to "10000"
     And user "Brian" has created folder "/testquota"
     And user "Brian" has uploaded file "/testquota/Brian.txt" of size 1000 bytes
     And user "Brian" has sent the following resource share invitation:
@@ -61,7 +61,7 @@ Feature: get quota
   @issue-8197
   Scenario Outline: retrieving folder quota when quota is set and a file was uploaded
     Given using <dav-path-version> DAV path
-    And user "Admin" has changed the quota of the personal space of "Alice Hansen" space to "10000"
+    And user "Admin" has changed the quota of the personal space of user "Alice" space to "10000"
     And user "Alice" has uploaded file "/prueba.txt" of size 1000 bytes
     When user "Alice" gets the following properties of folder "/" using the WebDAV API
       | propertyName            |
@@ -78,7 +78,7 @@ Feature: get quota
   Scenario Outline: retrieving folder quota when quota is set and a file was received
     Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes
-    And user "Admin" has changed the quota of the personal space of "Brian Murphy" space to "10000"
+    And user "Admin" has changed the quota of the personal space of user "Brian" space to "10000"
     And user "Alice" has uploaded file "/Alice.txt" of size 93 bytes
     And user "Alice" has sent the following resource share invitation:
       | resource        | Alice.txt   |


### PR DESCRIPTION
- Removed `getUserIdByUserName()` → replaced with `getAttributeOfCreatedUser($user, 'id')`, which reduces the number of requests to `/graph/v1.0/users`.

- Added `getPersonalSpace()`, which retrieves a space by `userId` (instead of by name) via `/graph/v1.0/users/{userId}?%24select=&%24expand=drive`, ensuring the correct personal space is found even in case of duplicates (e.g., soft-deleted users).
