### PR TITLE
let the runtime always create a cancel context

### DIFF
--- a/opencloud/pkg/runtime/service/service.go
+++ b/opencloud/pkg/runtime/service/service.go
@@ -7,7 +7,6 @@ import (
 	"net"
 	"net/http"
 	"net/rpc"
-	"os/signal"
 	"sort"
 	"strings"
 	"sync"
@@ -360,12 +359,9 @@ func Start(ctx context.Context, o ...Option) error {
 		return err
 	}
 
-	// cancel the context when a signal is received.
-	var cancel context.CancelFunc
-	if ctx == nil {
-		ctx, cancel = signal.NotifyContext(context.Background(), runner.StopSignals...)
-		defer cancel()
-	}
+	// create a context that will be cancelled when too many backoff cycles on one of the services happens
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 
 	// tolerance controls backoff cycles from the supervisor.
 	tolerance := 5


### PR DESCRIPTION
Fixes https://github.com/opencloud-eu/opencloud/issues/1528 

The root command already creates a signal notifier context, all we need to do in the runtine is add a cancel context.