### PR TITLE
fix: remove deprecated web ui feature "OpenAppsInTab"

### DIFF
--- a/services/web/pkg/config/options.go
+++ b/services/web/pkg/config/options.go
@@ -2,7 +2,7 @@ package config
 
 // Options are the option for the web
 type Options struct {
-^	AccountEditLink        *AccountEditLink    `json:"accountEditLink,omitempty" yaml:"accountEditLink"`
+	AccountEditLink        *AccountEditLink    `json:"accountEditLink,omitempty" yaml:"accountEditLink"`
 	DisableFeedbackLink    bool                `json:"disableFeedbackLink,omitempty" yaml:"disableFeedbackLink" env:"WEB_OPTION_DISABLE_FEEDBACK_LINK" desc:"Set this option to 'true' to disable the feedback link in the top bar. Keeping it enabled by setting the value to 'false' or with the absence of the option, allows OpenCloud to get feedback from your user base through a dedicated survey website." introductionVersion:"1.0.0"`
 	FeedbackLink           *FeedbackLink       `json:"feedbackLink,omitempty" yaml:"feedbackLink"`
 	RunningOnEOS           bool                `json:"runningOnEos,omitempty" yaml:"runningOnEos" env:"WEB_OPTION_RUNNING_ON_EOS" desc:"Set this option to 'true' if running on an EOS storage backend (https://eos-web.web.cern.ch/eos-web/) to enable its specific features. Defaults to 'false'." introductionVersion:"1.0.0"`


### PR DESCRIPTION
## Description

The web ui feature "OpenAppsInTab" has been removed a while ago. To avoid a bug report for web ui, because the docs for web still reference the environment variable `WEB_OPTION_OPEN_APPS_IN_TAB` but web ui doesn't know anything about this anymore, this should also be removed in backend.

## Related User Story

The web ui change has been implemented in #owncloud/web/issues/11222 but the feature has never been removed within the backend.

## Motivation and Context

Avoid a bug report for the web ui as it wouldn't react on an activated feature `OpenAppsInTab: true`

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added
