### PR TITLE
[full-ci][tests-only] fix restore browsers cache workflow

### DIFF
--- a/.woodpecker.star
+++ b/.woodpecker.star
@@ -2702,6 +2702,7 @@ def generateWebPnpmCache(ctx):
 def cacheBrowsers(ctx):
     e2e_trigger = [
         event["base"],
+        event["cron"],
         {
             "event": "pull_request",
             "path": {
@@ -2727,8 +2728,10 @@ def cacheBrowsers(ctx):
     }]
 
     webPnpmCacheSteps = restoreWebPnpmCache(extra_commands = [
+        "cd %s" % dirs["web"],
         ". ./.woodpecker.env",
         "if $BROWSER_CACHE_FOUND; then exit 0; fi",
+        "cd %s" % dirs["base"],
     ])
 
     browser_cache_steps = [
@@ -2739,9 +2742,9 @@ def cacheBrowsers(ctx):
                 "PLAYWRIGHT_BROWSERS_PATH": ".playwright",
             },
             "commands": [
+                "cd %s" % dirs["web"],
                 ". ./.woodpecker.env",
                 "if $BROWSER_CACHE_FOUND; then exit 0; fi",
-                "cd %s" % dirs["web"],
                 "pnpm exec playwright install --with-deps",
                 "pnpm exec playwright install --list",
                 "tar -czf %s .playwright" % dirs["playwrightBrowsersArchive"],
@@ -2752,9 +2755,9 @@ def cacheBrowsers(ctx):
             "image": MINIO_MC,
             "environment": MINIO_MC_ENV,
             "commands": [
+                "cd %s" % dirs["web"],
                 ". ./.woodpecker.env",
                 "if $BROWSER_CACHE_FOUND; then exit 0; fi",
-                "cd %s" % dirs["web"],
                 "playwright_version=$(bash tests/woodpecker/script.sh get_playwright_version)",
                 "mc alias set s3 $MC_HOST $AWS_ACCESS_KEY_ID $AWS_SECRET_ACCESS_KEY",
                 "mc cp -r -a %s s3/$CACHE_BUCKET/web/browsers-cache/$playwright_version/" % dirs["playwrightBrowsersArchive"],


### PR DESCRIPTION
<!--
Thanks for submitting a change to OpenCloud!

For fixing potential security issues please see https://opencloud.eu/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the main branch which holds the next version of OpenCloud.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
This PR fixes the browsers cache restoration workflow that was failing due as the variable `$BROWSER_CACHE_FOUND` was being sourced from the wrong `.woodpecker.env` and always return nothing.(it had to be from the `opencloud/web` repo's `.woodpecker.env`). So, just added the `cd` command to the right directory.
Also, added `cron` event tigger for nightlies in `cache-browsers` workflow.

Also, the playwright version was updated from `1.55.0` to `1.55.1`. See: https://github.com/opencloud-eu/web/commit/b30644a0978fe8936924891ac5cab5d1e6a94348

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/opencloud-eu/opencloud/issues/1614

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- :robot: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added
