### PR TITLE
feat(collaboration): add cssVariables to Collabora open-in-app request

### DIFF
--- a/services/collaboration/pkg/service/grpc/v0/service.go
+++ b/services/collaboration/pkg/service/grpc/v0/service.go
@@ -286,6 +286,11 @@ func (s *Service) addQueryToURL(baseURL string, req *appproviderv1beta1.OpenInAp
 
 	if strings.ToLower(s.config.App.Product) == "collabora" {
 		q.Add("closebutton", "false")
+
+		cssVariables := utils.ReadPlainFromOpaque(req.GetOpaque(), "cssVariables")
+		if cssVariables != "" {
+			q.Add("css_variables", cssVariables)
+		}
 	}
 
 	qs := q.Encode()


### PR DESCRIPTION
The idea is to send the css variables as part of `form_parameters` in the `/app/open` request. This way, the web client can use them to style Collabora. This is specified in the Collabora docs for theming: https://sdk.collaboraonline.com/docs/theming.html#content-of-hidden-field-css-variables

Needs https://github.com/opencloud-eu/reva/pull/377 to work.

refs https://github.com/opencloud-eu/web/issues/516