### PR TITLE
fix: only search LDAP group by name

### DIFF
--- a/services/graph/pkg/identity/ldap_group.go
+++ b/services/graph/pkg/identity/ldap_group.go
@@ -83,9 +83,8 @@ func (i *LDAP) GetGroups(ctx context.Context, oreq *godata.GoDataRequest) ([]*li
 	if search != "" {
 		search = ldap.EscapeFilter(search)
 		groupFilter = fmt.Sprintf(
-			"(|(%s=*%s*)(%s=*%s*))",
+			"(%s=*%s*)",
 			i.groupAttributeMap.name, search,
-			i.groupAttributeMap.id, search,
 		)
 	}
 	groupFilter = fmt.Sprintf("(&%s(objectClass=%s)%s)", i.groupFilter, i.groupObjectClass, groupFilter)

--- a/services/graph/pkg/identity/ldap_group_test.go
+++ b/services/graph/pkg/identity/ldap_group_test.go
@@ -305,7 +305,7 @@ func TestGetGroupsSearch(t *testing.T) {
 	// only match if the filter contains the search term unquoted
 	lm.On("Search", mock.MatchedBy(
 		func(req *ldap.SearchRequest) bool {
-			return req.Filter == "(&(objectClass=groupOfNames)(|(cn=*term*)(entryUUID=*term*)))"
+			return req.Filter == "(&(objectClass=groupOfNames)(cn=*term*))"
 		})).
 		Return(&ldap.SearchResult{}, nil)
 	b, _ := getMockedBackend(lm, lconfig, &logger)


### PR DESCRIPTION
## Description
Searching an LDAP group by `entryUUID` does not make a lot of sense.  This change drops that query.

## Related Issue
- Fixes #1673

## Motivation and Context
As described in the related Issue, my LDAP backend, [LLDAP](https://github.com/lldap/lldap) does not support a substring query on `entryUUID`, and actually returns an error that completely breaks my ability to add anyone to a Space.

This is a breaking change if anybody actually depended on this behavior, but as @rhafer pointed out in the related Issue, other LDAP servers like OpenLDAP doesn't support this query either (but fail with no results), so it is dependent upon the LDAP server that is being used.

## How Has This Been Tested?
- `cd services/graph/pkg/identity && go test`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added
