### PR TITLE
check status of postprocessing before accesing the file

### DIFF
--- a/tests/acceptance/bootstrap/CliContext.php
+++ b/tests/acceptance/bootstrap/CliContext.php
@@ -696,6 +696,10 @@ class CliContext implements Context {
 	 * @return void
 	 */
 	public function theAdministratorReadsTheFileContent(string $user, string $file): void {
+		// this downloads the file using WebDAV and by that checks if it's still in
+		// postprocessing. So its effectively a check for finished postprocessing
+		$this->featureContext->userDownloadsFileUsingTheAPI($user, $file);
+
 		$userUuid = $this->featureContext->getAttributeOfCreatedUser($user, 'id');
 		$storagePath = $this->getUsersStoragePath();
 		$body = [
@@ -874,6 +878,10 @@ class CliContext implements Context {
 	 * @return void
 	 */
 	public function theAdminChecksTheAttributeOfFileForUser(string $attribute, string $file, string $user): void {
+		// this downloads the file using WebDAV and by that checks if it's still in
+		// postprocessing. So its effectively a check for finished postprocessing
+		$this->featureContext->userDownloadsFileUsingTheAPI($user, $file);
+
 		$userUuid = $this->featureContext->getAttributeOfCreatedUser($user, 'id');
 		$storagePath = $this->getUsersStoragePath();
 		$body = [


### PR DESCRIPTION
## Description
Before checking the file on the POSIX FS, we need to make sure the postprocessing is finished.
This can be done by PROPFIND or GET request. Because parsing the PROPFIND is harder I've just added a GET. The underlying request already waits for the 425 Status code to go away.

## Related Issue
Partly fixes #1747

## Motivation and Context
make test be stable

## How Has This Been Tested?
- :robot:
- run tests locally, they used to fail and now they pass

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added
