### PR TITLE
fix: allow 'make dev-docker' with go.work 

### DIFF
--- a/.woodpecker.star
+++ b/.woodpecker.star
@@ -1654,6 +1654,7 @@ def dockerRelease(ctx, repo, build_type):
                 "name": "dryrun",
                 "image": PLUGINS_DOCKER_BUILDX,
                 "settings": {
+                    "context": "..",
                     "dry_run": True,
                     "platforms": "linux/amd64",  # do dry run only on the native platform
                     "repo": "%s,quay.io/%s" % (repo, repo),
@@ -1676,6 +1677,7 @@ def dockerRelease(ctx, repo, build_type):
                 "name": "build-and-push",
                 "image": PLUGINS_DOCKER_BUILDX,
                 "settings": {
+                    "context": "..",
                     "repo": "%s,quay.io/%s" % (repo, repo),
                     "platforms": "linux/amd64,linux/arm64",  # we can add remote builders
                     "auto_tag": False if build_type == "daily" else True,

--- a/opencloud/Makefile
+++ b/opencloud/Makefile
@@ -17,7 +17,7 @@ include ../.make/docs.mk
 
 .PHONY: dev-docker
 dev-docker:
-	docker build -f docker/Dockerfile.multiarch -t opencloudeu/opencloud:dev ..
+	docker build -f docker/Dockerfile.multiarch -t opencloudeu/opencloud:dev ../..
 
 .PHONY: dev-docker-multiarch
 dev-docker-multiarch:
@@ -28,7 +28,7 @@ dev-docker-multiarch:
 	docker buildx rm opencloudbuilder || true
 	docker buildx create --platform linux/arm64,linux/amd64 --name opencloudbuilder
 	docker buildx use opencloudbuilder
-	cd .. && docker buildx build --platform linux/arm64,linux/amd64 --output type=docker --file opencloud/docker/Dockerfile.multiarch --tag opencloudeu/opencloud:dev-multiarch .
+	docker buildx build --platform linux/arm64,linux/amd64 --output type=docker --file docker/Dockerfile.multiarch --tag opencloudeu/opencloud:dev-multiarch ../..
 	docker buildx rm opencloudbuilder
 
 .PHONY: debug-docker

--- a/opencloud/docker/Dockerfile.multiarch
+++ b/opencloud/docker/Dockerfile.multiarch
@@ -6,12 +6,12 @@ ARG STRING
 
 RUN apk add bash make git curl gcc musl-dev libc-dev binutils-gold inotify-tools vips-dev
 
-WORKDIR /opencloud
-RUN --mount=type=bind,target=/opencloud \
+WORKDIR /build
+RUN --mount=type=bind,target=/build,rw \
     --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache \
     GOOS="${TARGETOS:-linux}" GOARCH="${TARGETARCH:-amd64}" ; \
-    make -C opencloud release-linux-docker-${TARGETARCH} ENABLE_VIPS=true DIST=/dist
+    make -C opencloud/opencloud release-linux-docker-${TARGETARCH} ENABLE_VIPS=true DIST=/dist
 
 FROM alpine:3.21
 ARG VERSION


### PR DESCRIPTION
Alternative to: #1527 
