### PR TITLE
fix: fix typo in treesize logging

### DIFF
--- a/vendor/github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/tree/propagator/sync.go
+++ b/vendor/github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/tree/propagator/sync.go
@@ -178,7 +178,7 @@ func (p SyncPropagator) propagateItem(ctx context.Context, n *node.Node, sTime t
 			// a negative new treesize. Something must have gone wrong with the accounting.
 			// Reset the current treesize to 0.
 			log.Error().Uint64("treeSize", treeSize).Int64("sizeDiff", sizeDiff).
-				Msg("Error when updating treesize of parent node. Updated treesize < 0. Reestting to 0")
+				Msg("Error when updating treesize of parent node. Updated treesize < 0. Resetting to 0")
 			newSize = 0
 		default:
 			newSize = treeSize - uint64(-sizeDiff)

--- a/vendor/github.com/opencloud-eu/reva/v2/pkg/storage/utils/decomposedfs/tree/propagator/sync.go
+++ b/vendor/github.com/opencloud-eu/reva/v2/pkg/storage/utils/decomposedfs/tree/propagator/sync.go
@@ -189,7 +189,7 @@ func (p SyncPropagator) propagateItem(ctx context.Context, n *node.Node, sTime t
 			// a negative new treesize. Something must have gone wrong with the accounting.
 			// Reset the current treesize to 0.
 			log.Error().Uint64("treeSize", treeSize).Int64("sizeDiff", sizeDiff).
-				Msg("Error when updating treesize of parent node. Updated treesize < 0. Reestting to 0")
+				Msg("Error when updating treesize of parent node. Updated treesize < 0. Resetting to 0")
 			newSize = 0
 		default:
 			newSize = treeSize - uint64(-sizeDiff)


### PR DESCRIPTION
## Description
This PR fixes a typo which I found while reviewing opencloud-eu/reva/pull/411

## Related Issue
- opencloud-eu/reva/pull/411
- opencloud-eu/opencloud/issues/1793

## Motivation and Context
Fixing typo

## How Has This Been Tested?
Not tested yet. Waiting for the build pipeline.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
