### PR TITLE
chore: drop gofrs/uuid module usage and use google/uuid

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,6 @@ require (
 	github.com/go-micro/plugins/v4/wrapper/monitoring/prometheus v1.2.0
 	github.com/go-micro/plugins/v4/wrapper/trace/opentelemetry v1.2.0
 	github.com/go-playground/validator/v10 v10.28.0
-	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/golang/protobuf v1.5.4
 	github.com/google/go-cmp v0.7.0
@@ -230,6 +229,7 @@ require (
 	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/goccy/go-yaml v1.18.0 // indirect
 	github.com/gofrs/flock v0.13.0 // indirect
+	github.com/gofrs/uuid v4.4.0+incompatible // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect

--- a/opencloud/pkg/init/init.go
+++ b/opencloud/pkg/init/init.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"path"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"gopkg.in/yaml.v2"
 
 	"github.com/opencloud-eu/opencloud/pkg/generators"
@@ -103,11 +103,11 @@ func CreateConfig(insecure, forceOverwrite, diff bool, configPath, adminPassword
 			}
 		}
 	} else {
-		systemUserID = uuid.Must(uuid.NewV4()).String()
-		adminUserID = uuid.Must(uuid.NewV4()).String()
-		graphApplicationID = uuid.Must(uuid.NewV4()).String()
-		storageUsersMountID = uuid.Must(uuid.NewV4()).String()
-		serviceAccountID = uuid.Must(uuid.NewV4()).String()
+		systemUserID = uuid.NewString()
+		adminUserID = uuid.NewString()
+		graphApplicationID = uuid.NewString()
+		storageUsersMountID = uuid.NewString()
+		serviceAccountID = uuid.NewString()
 
 		idmServicePassword, err = generators.GenerateRandomPassword(passwordLength)
 		if err != nil {

--- a/services/graph/pkg/identity/ldap_education_school.go
+++ b/services/graph/pkg/identity/ldap_education_school.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/go-ldap/ldap/v3"
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	libregraph "github.com/opencloud-eu/libre-graph-api-go"
 	"github.com/opencloud-eu/opencloud/pkg/log"
 	"github.com/opencloud-eu/opencloud/services/graph/pkg/config"
@@ -148,7 +148,7 @@ func (i *LDAP) CreateEducationSchool(ctx context.Context, school libregraph.Educ
 		ar.Attribute(i.educationConfig.schoolAttributeMap.schoolNumber, []string{school.GetSchoolNumber()})
 	}
 	if !i.useServerUUID {
-		ar.Attribute(i.educationConfig.schoolAttributeMap.id, []string{uuid.Must(uuid.NewV4()).String()})
+		ar.Attribute(i.educationConfig.schoolAttributeMap.id, []string{uuid.NewString()})
 	}
 	objectClasses := []string{"organizationalUnit", i.educationConfig.schoolObjectClass, "top"}
 	ar.Attribute("objectClass", objectClasses)

--- a/services/graph/pkg/identity/ldap_group.go
+++ b/services/graph/pkg/identity/ldap_group.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/CiscoM31/godata"
 	"github.com/go-ldap/ldap/v3"
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/libregraph/idm/pkg/ldapdn"
 	libregraph "github.com/opencloud-eu/libre-graph-api-go"
 
@@ -448,7 +448,7 @@ func (i *LDAP) groupToLDAPAttrValues(group libregraph.Group) (map[string][]strin
 	}
 
 	if !i.useServerUUID {
-		attrs["openCloudUUID"] = []string{uuid.Must(uuid.NewV4()).String()}
+		attrs["openCloudUUID"] = []string{uuid.NewString()}
 		attrs["objectClass"] = append(attrs["objectClass"], "openCloudObject")
 	}
 	return attrs, nil

--- a/services/settings/pkg/store/metadata/assignments.go
+++ b/services/settings/pkg/store/metadata/assignments.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	settingsmsg "github.com/opencloud-eu/opencloud/protogen/gen/opencloud/messages/settings/v0"
 	"github.com/opencloud-eu/opencloud/services/settings/pkg/settings"
 	"github.com/opencloud-eu/opencloud/services/settings/pkg/store/defaults"
@@ -20,7 +20,7 @@ func (s *Store) ListRoleAssignments(accountUUID string) ([]*settingsmsg.UserRole
 		if accountUUID == serviceAccountID {
 			return []*settingsmsg.UserRoleAssignment{
 				{
-					Id:          uuid.Must(uuid.NewV4()).String(), // should we hardcode this id too?
+					Id:          uuid.NewString(), // should we hardcode this id too?
 					AccountUuid: accountUUID,
 					RoleId:      defaults.BundleUUIDServiceAccount,
 				},
@@ -136,7 +136,7 @@ func (s *Store) WriteRoleAssignment(accountUUID, roleID string) (*settingsmsg.Us
 	}
 
 	ass := &settingsmsg.UserRoleAssignment{
-		Id:          uuid.Must(uuid.NewV4()).String(),
+		Id:          uuid.NewString(),
 		AccountUuid: accountUUID,
 		RoleId:      roleID,
 	}

--- a/services/settings/pkg/store/metadata/assignments_test.go
+++ b/services/settings/pkg/store/metadata/assignments_test.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	olog "github.com/opencloud-eu/opencloud/pkg/log"
 	"github.com/opencloud-eu/opencloud/pkg/shared"
 	settingsmsg "github.com/opencloud-eu/opencloud/protogen/gen/opencloud/messages/settings/v0"
@@ -95,7 +95,7 @@ func initStore() *Store {
 		cfg:    defaults.DefaultConfig(),
 	}
 	s.cfg.Commons = &shared.Commons{
-		AdminUserID: uuid.Must(uuid.NewV4()).String(),
+		AdminUserID: uuid.NewString(),
 	}
 
 	_ = NewMDC(s)

--- a/services/settings/pkg/store/metadata/bundles.go
+++ b/services/settings/pkg/store/metadata/bundles.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	settingsmsg "github.com/opencloud-eu/opencloud/protogen/gen/opencloud/messages/settings/v0"
 	"github.com/opencloud-eu/opencloud/services/settings/pkg/settings"
 	"github.com/opencloud-eu/opencloud/services/settings/pkg/store/defaults"
@@ -146,7 +146,7 @@ func (s *Store) AddSettingToBundle(bundleID string, setting *settingsmsg.Setting
 	}
 
 	if setting.Id == "" {
-		setting.Id = uuid.Must(uuid.NewV4()).String()
+		setting.Id = uuid.NewString()
 	}
 
 	b.Settings = append(b.Settings, setting)

--- a/services/settings/pkg/store/metadata/bundles_test.go
+++ b/services/settings/pkg/store/metadata/bundles_test.go
@@ -3,7 +3,7 @@ package store
 import (
 	"testing"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	settingsmsg "github.com/opencloud-eu/opencloud/protogen/gen/opencloud/messages/settings/v0"
 	"github.com/stretchr/testify/require"
 )
@@ -102,7 +102,7 @@ var bundleScenarios = []struct {
 }
 
 var (
-	appendTestBundleID = uuid.Must(uuid.NewV4()).String()
+	appendTestBundleID = uuid.NewString()
 
 	appendTestSetting1 = &settingsmsg.Setting{
 		Id:          "append-test-setting-1",

--- a/services/settings/pkg/store/metadata/store.go
+++ b/services/settings/pkg/store/metadata/store.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"sync"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	olog "github.com/opencloud-eu/opencloud/pkg/log"
 	settingsmsg "github.com/opencloud-eu/opencloud/protogen/gen/opencloud/messages/settings/v0"
 	"github.com/opencloud-eu/opencloud/services/settings/pkg/config"
@@ -21,7 +21,7 @@ var (
 	// Name is the default name for the settings store
 	Name                   = "opencloud-settings"
 	managerName            = "metadata"
-	settingsSpaceID        = "f1bdd61a-da7c-49fc-8203-0558109d1b4f" // uuid.Must(uuid.NewV4()).String()
+	settingsSpaceID        = "f1bdd61a-da7c-49fc-8203-0558109d1b4f" // uuid.NewString()
 	rootFolderLocation     = "settings"
 	bundleFolderLocation   = "settings/bundles"
 	accountsFolderLocation = "settings/accounts"
@@ -156,7 +156,7 @@ func (s *Store) initMetadataClient(mdc MetadataClient) error {
 		}
 
 		ass := &settingsmsg.UserRoleAssignment{
-			Id:          uuid.Must(uuid.NewV4()).String(),
+			Id:          uuid.NewString(),
 			AccountUuid: accountUUID,
 			RoleId:      roleID,
 		}
@@ -220,7 +220,7 @@ func (s *Store) userMustHaveAdminRole(accountUUID string, assIDs []string, mdc M
 		}
 
 		ass := &settingsmsg.UserRoleAssignment{
-			Id:          uuid.Must(uuid.NewV4()).String(),
+			Id:          uuid.NewString(),
 			AccountUuid: accountUUID,
 			RoleId:      defaults.BundleUUIDRoleAdmin,
 		}

--- a/services/settings/pkg/store/metadata/values.go
+++ b/services/settings/pkg/store/metadata/values.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	settingsmsg "github.com/opencloud-eu/opencloud/protogen/gen/opencloud/messages/settings/v0"
 	"github.com/opencloud-eu/opencloud/services/settings/pkg/settings"
 	"github.com/opencloud-eu/reva/v2/pkg/errtypes"
@@ -127,7 +127,7 @@ func (s *Store) WriteValue(value *settingsmsg.Value) (*settingsmsg.Value, error)
 	ctx := context.TODO()
 
 	if value.Id == "" {
-		value.Id = uuid.Must(uuid.NewV4()).String()
+		value.Id = uuid.NewString()
 	}
 	b, err := json.Marshal(value)
 	if err != nil {


### PR DESCRIPTION
<!--
Thanks for submitting a change to OpenCloud!

For fixing potential security issues please see https://opencloud.eu/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the main branch which holds the next version of OpenCloud.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
As `google/uuid` is an indirect dependency, by dropping old `gofrs/uuid` just one uuid module is required.

Old `gofrs/uuid` will now be an indirect dependency until `lico` is updated with https://github.com/libregraph/lico/pull/219.


## Motivation and Context
Have just one uuid module

## How Has This Been Tested?
go test ./...


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added
