### PR TITLE
fix: sanitise markdow code to make docusaurus happy

### DIFF
--- a/services/frontend/README.md
+++ b/services/frontend/README.md
@@ -77,7 +77,7 @@ In OpenCloud, the password policy is always enabled because the max-length restr
 
 With the password policy, mandatory criteria for the password can be defined via the environment variables listed below.
 
-Generally, a password can contain any UTF-8 characters, however some characters are regarded as special since they are not used in ordinary texts. Which characters should be treated as special is defined by "The OWASP® Foundation" [password-special-characters](https://owasp.org/www-community/password-special-characters) (between double quotes): " !"#$%&'()*+,-./:;<=>?@[\]^_`{|}~"
+Generally, a password can contain any UTF-8 characters, however some characters are regarded as special since they are not used in ordinary texts. Which characters should be treated as special is defined by "The OWASP® Foundation" [password-special-characters](https://owasp.org/www-community/password-special-characters) (between double quotes): ```" !"#$%&'()*+,-./:;<=>?@[\]^_`{|}~"```
 
 The validation against the banned passwords list can be configured via a text file with words separated by new lines. If a user tries to set a password listed in the banned passwords list, the password can not be used (is invalid) even if the other mandatory criteria are passed. The admin can define the path of the banned passwords list file. If the file doesn't exist in a location, OpenCloud tries to load a file from the `OC_CONFIG_DIR/OC_PASSWORD_POLICY_BANNED_PASSWORDS_LIST`. An option will be enabled when the file has been loaded successfully.
 

--- a/services/gateway/README.md
+++ b/services/gateway/README.md
@@ -40,9 +40,9 @@ The scheme for this setup is the following. Note that there is, except storage, 
 
 | **envvar** | **default** | **alternative** |
 |------|------|------|
-| OC_GRPC_PROTOCOL or <br> `<service>`_GRPC_PROTOCOL | tcp | unix |
+| OC_GRPC_PROTOCOL or <br /> `<service>`_GRPC_PROTOCOL | tcp | unix |
 | `<service>`_GRPC_ADDR | 127.0.0.1:`<port>` | /var/run/opencloud/`<service>`.sock |
-| GATEWAY_`<service>`_ENDPOINT | eu.opencloud.api.`<service>` | unix:/var/run/opencloud/`<service>`.sock <br> dns: ... <br> kubernetes: ... |
+| GATEWAY_`<service>`_ENDPOINT | eu.opencloud.api.`<service>` | unix:/var/run/opencloud/`<service>`.sock <br /> dns: ... <br /> kubernetes: ... |
 
 ```console
 USERS_GRPC_PROTOCOL=unix"


### PR DESCRIPTION
## Description
This PR fixes the issue that current docusaurus, which is used for building the documentation for docs.opencloud.eu, fails compiling the docs pages

## Motivation and Context
Being able to build current documenation

## How Has This Been Tested?
- created new static docs with the markdown-docs-generator using the fix/doc-code-sanitising branch
- created corresponding PR for the docs repository using the updated doc-updates- branch
- built the docs form that branch
=> no build errors

## Screenshots (if appropriate):

## Types of changes
sanitised markdown codeapp