### PR TITLE
fix: dev-docker build on groupware (Sha512 field in UploadedBlob)

### DIFF
--- a/pkg/jmap/jmap_api_blob.go
+++ b/pkg/jmap/jmap_api_blob.go
@@ -42,6 +42,7 @@ type UploadedBlob struct {
 	BlobId string `json:"blobId"`
 	Size   int    `json:"size,omitzero"`
 	Type   string `json:"type,omitempty"`
+	Sha512 string `json:"sha512,omitempty"`
 }
 
 func (j *Client) UploadBlobStream(accountId string, session *Session, ctx context.Context, logger *log.Logger, acceptLanguage string, contentType string, body io.Reader) (UploadedBlob, Language, Error) {


### PR DESCRIPTION
Fix dev-docker build on groupware (fixed Struct-Definition)