### PR TITLE
add logic to skip latest tag for pre-releases

### DIFF
--- a/.woodpecker.star
+++ b/.woodpecker.star
@@ -1654,6 +1654,16 @@ def dockerRelease(ctx, repo, build_type):
         "VERSION": "%s" % (ctx.build.ref.replace("refs/tags/", "") if ctx.build.event == "tag" else "daily"),
     }
 
+    # if no additional tag is given, the build-plugin adds latest
+    hard_tag = "daily"
+    if ctx.build.event == "tag":
+        tag_version = ctx.build.ref.replace("refs/tags/", "")
+        tag_parts = tag_version.split("-")
+
+        # if a tag has something appended with "-" i.e. alpha, beta, rc1...
+        # set the entire string as tag, else leave empty to autotag with latest
+        hard_tag = tag_version if len(tag_parts) > 1 else ""
+
     depends_on = getPipelineNames(getGoBinForTesting(ctx))
 
     if ctx.build.event == "tag":
@@ -1672,7 +1682,7 @@ def dockerRelease(ctx, repo, build_type):
                     "platforms": "linux/amd64",  # do dry run only on the native platform
                     "repo": "%s,quay.io/%s" % (repo, repo),
                     "auto_tag": False if build_type == "daily" else True,
-                    "tag": "daily" if build_type == "daily" else "",
+                    "tag": hard_tag,
                     "default_tag": "daily",
                     "dockerfile": "opencloud/docker/Dockerfile.multiarch",
                     "build_args": build_args,


### PR DESCRIPTION
## Description
add a simple check to prevent the latest tag to be set on pre-release tag events

## Motivation and Context
the latest tag should not be set for pre-releases

## How Has This Been Tested?
It only has been tested using static values in a separate repo

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added
