### PR TITLE
enhancement(proxy): add read deadline and filter chain middleware

### DIFF
--- a/services/proxy/pkg/command/server.go
+++ b/services/proxy/pkg/command/server.go
@@ -6,11 +6,23 @@ import (
 	"fmt"
 	"net/http"
 	"os/signal"
+	"slices"
 	"time"
 
 	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
 	chimiddleware "github.com/go-chi/chi/v5/middleware"
 	"github.com/justinas/alice"
+	"github.com/opencloud-eu/reva/v2/pkg/events"
+	"github.com/opencloud-eu/reva/v2/pkg/events/stream"
+	"github.com/opencloud-eu/reva/v2/pkg/rgrpc/todo/pool"
+	"github.com/opencloud-eu/reva/v2/pkg/signedurl"
+	"github.com/opencloud-eu/reva/v2/pkg/store"
+	"github.com/urfave/cli/v2"
+	"go-micro.dev/v4/selector"
+	microstore "go-micro.dev/v4/store"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel/trace"
+
 	"github.com/opencloud-eu/opencloud/pkg/config/configlog"
 	"github.com/opencloud-eu/opencloud/pkg/generators"
 	"github.com/opencloud-eu/opencloud/pkg/log"
@@ -35,16 +47,6 @@ import (
 	"github.com/opencloud-eu/opencloud/services/proxy/pkg/staticroutes"
 	"github.com/opencloud-eu/opencloud/services/proxy/pkg/user/backend"
 	"github.com/opencloud-eu/opencloud/services/proxy/pkg/userroles"
-	"github.com/opencloud-eu/reva/v2/pkg/events"
-	"github.com/opencloud-eu/reva/v2/pkg/events/stream"
-	"github.com/opencloud-eu/reva/v2/pkg/rgrpc/todo/pool"
-	"github.com/opencloud-eu/reva/v2/pkg/signedurl"
-	"github.com/opencloud-eu/reva/v2/pkg/store"
-	"github.com/urfave/cli/v2"
-	"go-micro.dev/v4/selector"
-	microstore "go-micro.dev/v4/store"
-	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
-	"go.opentelemetry.io/otel/trace"
 )
 
 // Server is the entrypoint for the server command.
@@ -332,6 +334,35 @@ func loadMiddlewares(logger log.Logger, cfg *config.Config,
 	}
 
 	return alice.New(
+		middleware.FilterChain(func(_ http.ResponseWriter, r *http.Request) ([]middleware.Constructor, error) {
+			isTUSUpload := slices.Contains([]string{http.MethodPatch, http.MethodPost}, r.Method) && r.Header.Get("tus-resumable") != ""
+
+			// fixMe:
+			// reva decomposedFs finalizeUpload > node > CalculateChecksums sha1h, md5h, and adler32h calculation is slow.
+			// The hashing duration after the final chunk is uploaded, may take longer than the configured read upload deadline,
+			// especially for larger files (>10GB) or on slow machines.
+			//
+			// If the hashing takes longer than the configured upload timeout the upload gets invalidated.
+			//
+			// Ideas:
+			//   - Calculate checksums asynchronously to avoid blocking
+			//   - Detect the final chunk upload and skip ReadDeadline for that request,
+			//     upload-offset + chunk size == total bytes uploaded,
+			//     but how to get the expected total size without having any state?
+			//
+			// Currently isFinalUpload is hardcoded to false, so the ReadDeadline applies to ALL TUS uploads.
+			// Decrease the high cfg.HTTP.Timeout.Upload.Read default value once this is solved.
+			isFinalUpload := false
+
+			var chain []middleware.Constructor
+
+			//noinspection GoBoolExpressions
+			if isTUSUpload && !isFinalUpload {
+				chain = append(chain, middleware.ReadDeadline(cfg.HTTP.Timeout.Upload.Read, logger))
+			}
+
+			return chain, nil
+		}, logger),
 		chimiddleware.RealIP,
 		chimiddleware.RequestID,
 		// first make sure we log all requests and redirect to https if necessary

--- a/services/proxy/pkg/config/defaults/defaultconfig.go
+++ b/services/proxy/pkg/config/defaults/defaultconfig.go
@@ -35,6 +35,18 @@ func DefaultConfig() *config.Config {
 			TLSCert:   path.Join(defaults.BaseDataPath(), "proxy", "server.crt"),
 			TLSKey:    path.Join(defaults.BaseDataPath(), "proxy", "server.key"),
 			TLS:       true,
+			Timeout: config.HTTPTimeout{
+				Upload: config.HTTPTimeoutUpload{
+					// Set a relatively high number here to give large uploads time to breathe.
+					// The timeout does not apply to the total request lifespan,
+					// it gets refreshed after each sequential body read.
+					//
+					// the default value is 2 * nginx default proxy_read_timeout
+					//
+					// - 0 or -1 means no timeout at all;
+					Read: 120 * time.Second,
+				},
+			},
 		},
 		Service: config.Service{
 			Name: "proxy",

--- a/services/proxy/pkg/config/http.go
+++ b/services/proxy/pkg/config/http.go
@@ -1,11 +1,24 @@
 package config
 
+import (
+	"time"
+)
+
 // HTTP defines the available http configuration.
 type HTTP struct {
-	Addr      string `yaml:"addr" env:"PROXY_HTTP_ADDR" desc:"The bind address of the HTTP service." introductionVersion:"1.0.0"`
-	Root      string `yaml:"root" env:"PROXY_HTTP_ROOT" desc:"Subdirectory that serves as the root for this HTTP service." introductionVersion:"1.0.0"`
-	Namespace string `yaml:"-"`
-	TLSCert   string `yaml:"tls_cert" env:"PROXY_TRANSPORT_TLS_CERT" desc:"Path/File name of the TLS server certificate (in PEM format) for the external http services. If not defined, the root directory derives from $OC_BASE_DATA_PATH/proxy." introductionVersion:"1.0.0"`
-	TLSKey    string `yaml:"tls_key" env:"PROXY_TRANSPORT_TLS_KEY" desc:"Path/File name for the TLS certificate key (in PEM format) for the server certificate to use for the external http services. If not defined, the root directory derives from $OC_BASE_DATA_PATH/proxy." introductionVersion:"1.0.0"`
-	TLS       bool   `yaml:"tls" env:"PROXY_TLS" desc:"Enable/Disable HTTPS for external HTTP services. Must be set to 'true' if the built-in IDP service an no reverse proxy is used. See the text description for details." introductionVersion:"1.0.0"`
+	Addr      string      `yaml:"addr" env:"PROXY_HTTP_ADDR" desc:"The bind address of the HTTP service." introductionVersion:"1.0.0"`
+	Root      string      `yaml:"root" env:"PROXY_HTTP_ROOT" desc:"Subdirectory that serves as the root for this HTTP service." introductionVersion:"1.0.0"`
+	Namespace string      `yaml:"-"`
+	TLSCert   string      `yaml:"tls_cert" env:"PROXY_TRANSPORT_TLS_CERT" desc:"Path/File name of the TLS server certificate (in PEM format) for the external http services. If not defined, the root directory derives from $OC_BASE_DATA_PATH/proxy." introductionVersion:"1.0.0"`
+	TLSKey    string      `yaml:"tls_key" env:"PROXY_TRANSPORT_TLS_KEY" desc:"Path/File name for the TLS certificate key (in PEM format) for the server certificate to use for the external http services. If not defined, the root directory derives from $OC_BASE_DATA_PATH/proxy." introductionVersion:"1.0.0"`
+	TLS       bool        `yaml:"tls" env:"PROXY_TLS" desc:"Enable/Disable HTTPS for external HTTP services. Must be set to 'true' if the built-in IDP service an no reverse proxy is used. See the text description for details." introductionVersion:"1.0.0"`
+	Timeout   HTTPTimeout `yaml:"timeout" desc:"Configure various HTTP timeout settings for request handling." introductionVersion:"%%NEXT%%"`
+}
+
+type HTTPTimeout struct {
+	Upload HTTPTimeoutUpload `yaml:"upload" desc:"Upload related timeout settings" introductionVersion:"%%NEXT%%"`
+}
+
+type HTTPTimeoutUpload struct {
+	Read time.Duration `yaml:"read" env:"PROXY_HTTP_TIMEOUT_UPLOAD_READ" desc:"The duration after which a upload request read will time out." introductionVersion:"%%NEXT%%"`
 }

--- a/services/proxy/pkg/middleware/deadline.go
+++ b/services/proxy/pkg/middleware/deadline.go
@@ -1,0 +1,101 @@
+package middleware
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/opencloud-eu/opencloud/pkg/log"
+)
+
+// deadlineReadCloser wraps an io.ReadCloser to enforce a read deadline.
+// It uses an http.ResponseController to set deadlines dynamically during reads.
+type deadlineReadCloser struct {
+	// timeout duration defines the interval for extending the read deadline.
+	timeout    time.Duration
+	inner      io.ReadCloser
+	controller *http.ResponseController
+	logger     log.Logger
+}
+
+// NewDeadlineReadCloser creates a new deadline-enforcing ReadCloser.
+func NewDeadlineReadCloser(inner io.ReadCloser, rc *http.ResponseController, timeout time.Duration, logger log.Logger) (io.ReadCloser, error) {
+	if inner == nil || rc == nil {
+		return nil, errors.New("inner reader and controller must not be nil")
+	}
+
+	if err := rc.SetReadDeadline(time.Now().Add(timeout)); err != nil {
+		return nil, err
+	}
+
+	return &deadlineReadCloser{
+		inner:      inner,
+		controller: rc,
+		timeout:    timeout,
+		logger:     logger,
+	}, nil
+}
+
+// Read proxies the Read to the inner io.ReadCloser,
+// each Read cycle extends the deadline based on the configured timeout.
+func (drc *deadlineReadCloser) Read(p []byte) (int, error) {
+	n, err := drc.inner.Read(p)
+
+	// don't consider errors to give the downstream operation time to recover eventually
+	if n > 0 {
+		deadline := time.Now().Add(drc.timeout)
+		// refresh the connection readDeadline after each read
+		if setErr := drc.controller.SetReadDeadline(deadline); setErr != nil {
+			// Failing means that the wrapped writer does not implement the SetReadDeadline interface.
+			// This should not happen because NewDeadlineReadCloser already checks the compatibility,
+			// even if it errors, it's not a problem, and reading should continue.
+			drc.logger.Error().Err(setErr).
+				Time("deadline", deadline).
+				Dur("timeout", drc.timeout).
+				Msg("failed to set read deadline")
+		}
+	}
+
+	return n, err
+}
+
+// Close proxies the Close call to its inner io.ReadCloser
+func (drc *deadlineReadCloser) Close() error {
+	return drc.inner.Close()
+}
+
+// ReadDeadline creates middleware to enforce a read deadline for each incoming HTTP request body.
+// If the provided timeout is less than or equal to zero, or the body is nil, it returns a noopHandler.
+// The read deadline gets refreshed on every successful read of the request body.
+func ReadDeadline(timeout time.Duration, logger log.Logger) Constructor {
+	if timeout <= 0 {
+		return NopConstructor
+	}
+
+	mwLogger := middlewareLogger(logger, "ReadDeadline")
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Body == nil {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			rLogger := requestLogger(mwLogger, r)
+
+			// If the controlled body can't be created, return early and pass the request and response down the line
+			controlledBody, err := NewDeadlineReadCloser(r.Body, http.NewResponseController(w), timeout, rLogger)
+			if err != nil {
+				rLogger.Error().Err(err).
+					Dur("timeout", timeout).
+					Msg("failed to create reader")
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			r.Body = controlledBody
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/services/proxy/pkg/middleware/deadline_test.go
+++ b/services/proxy/pkg/middleware/deadline_test.go
@@ -1,0 +1,132 @@
+package middleware_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/opencloud-eu/opencloud/pkg/log"
+	"github.com/opencloud-eu/opencloud/services/proxy/pkg/middleware"
+)
+
+//
+// ─── TESTS ─────────────────────────────────────────────────────────────
+//
+
+func TestReadDeadline(t *testing.T) {
+	tests := []struct {
+		name       string
+		handler    http.Handler
+		middleware middleware.Constructor
+		request    func(*httptest.Server) (*http.Request, error)
+		evaluate   func(*testing.T, *http.Response, error)
+	}{
+		{
+			name: "OK",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, err := io.Copy(w, r.Body)
+				if err != nil {
+					http.Error(w, http.StatusText(http.StatusRequestTimeout), http.StatusRequestTimeout)
+					return
+				}
+			}),
+			middleware: middleware.ReadDeadline(15*time.Millisecond, log.NopLogger()),
+			request: func(srv *httptest.Server) (*http.Request, error) {
+				return http.NewRequest("POST", srv.URL, &slowReader{inner: strings.NewReader("body"), delay: 10 * time.Millisecond})
+			},
+			evaluate: func(t *testing.T, response *http.Response, err error) {
+				assert.NotNil(t, response)
+				assert.NoError(t, err)
+				assert.Equal(t, http.StatusOK, response.StatusCode)
+
+				b, err := io.ReadAll(response.Body)
+				assert.NoError(t, err)
+				assert.Equal(t, string(b), "body")
+			},
+		},
+		{
+			name: "Pass through without timeout",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, err := io.Copy(w, r.Body)
+				if err != nil {
+					http.Error(w, http.StatusText(http.StatusRequestTimeout), http.StatusRequestTimeout)
+					return
+				}
+			}),
+			middleware: middleware.ReadDeadline(0, log.NopLogger()),
+			request: func(srv *httptest.Server) (*http.Request, error) {
+				return http.NewRequest("POST", srv.URL, &slowReader{inner: strings.NewReader("body"), delay: 10 * time.Millisecond})
+			},
+			evaluate: func(t *testing.T, response *http.Response, err error) {
+				assert.NotNil(t, response)
+				assert.NoError(t, err)
+				assert.Equal(t, http.StatusOK, response.StatusCode)
+
+				b, err := io.ReadAll(response.Body)
+				assert.NoError(t, err)
+				assert.Equal(t, string(b), "body")
+			},
+		},
+		{
+			name: "ReadDeadline exceeded",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, err := io.Copy(w, r.Body)
+				if err != nil {
+					http.Error(w, http.StatusText(http.StatusRequestTimeout), http.StatusRequestTimeout)
+					return
+				}
+			}),
+			middleware: middleware.ReadDeadline(5*time.Millisecond, log.NopLogger()),
+			request: func(srv *httptest.Server) (*http.Request, error) {
+				return http.NewRequest("POST", srv.URL, &slowReader{inner: strings.NewReader("test"), delay: 10 * time.Millisecond})
+			},
+			evaluate: func(t *testing.T, response *http.Response, err error) {
+				assert.NotNil(t, response)
+				assert.NoError(t, err)
+				assert.Equal(t, http.StatusRequestTimeout, response.StatusCode)
+
+				b, err := io.ReadAll(response.Body)
+				assert.NoError(t, err)
+				assert.Equal(t, string(b), http.StatusText(http.StatusRequestTimeout)+"\n")
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(tc.middleware(tc.handler))
+			defer srv.Close()
+
+			req, err := tc.request(srv)
+			assert.NoError(t, err)
+
+			resp, err := (&http.Client{}).Do(req)
+			defer func() {
+				if err != nil {
+					assert.NoError(t, resp.Body.Close())
+				}
+			}()
+
+			tc.evaluate(t, resp, err)
+		})
+	}
+}
+
+//
+// ─── HELPERS ───────────────────────────────────────────────────────────
+//
+
+type slowReader struct {
+	inner io.Reader
+	delay time.Duration
+}
+
+func (r *slowReader) Read(p []byte) (n int, err error) {
+	time.Sleep(r.delay)
+	return r.inner.Read(p)
+}

--- a/services/proxy/pkg/middleware/filter.go
+++ b/services/proxy/pkg/middleware/filter.go
@@ -1,0 +1,35 @@
+package middleware
+
+import (
+	"net/http"
+	"slices"
+
+	"github.com/justinas/alice"
+
+	"github.com/opencloud-eu/opencloud/pkg/log"
+)
+
+// FilterChain builds a dynamic middleware chain by invoking the factory with
+// (w, r) and applies the returned constructors.
+// Errors in the factory halt the chain; the caller is responsible for failing and must set status and body on w.
+func FilterChain(constructorFactory func(w http.ResponseWriter, r *http.Request) ([]Constructor, error), logger log.Logger) Constructor {
+	mwLogger := middlewareLogger(logger, "Probe")
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			chain, err := constructorFactory(w, r)
+			if err != nil {
+				rLogger := requestLogger(mwLogger, r)
+				rLogger.Error().Err(err).Msg("probe failed")
+				return
+			}
+
+			// remove invalid middlewares from the chain
+			clean := slices.DeleteFunc(chain, func(c Constructor) bool {
+				return c == nil
+			})
+
+			alice.New(clean...).Then(next).ServeHTTP(w, r)
+		})
+	}
+}

--- a/services/proxy/pkg/middleware/filter_test.go
+++ b/services/proxy/pkg/middleware/filter_test.go
@@ -1,0 +1,178 @@
+package middleware_test
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/opencloud-eu/opencloud/pkg/log"
+	"github.com/opencloud-eu/opencloud/services/proxy/pkg/middleware"
+)
+
+func TestFilterChain(t *testing.T) {
+	tests := []struct {
+		name           string
+		defaultHandler http.Handler
+		middleware     middleware.Constructor
+		request        func(*httptest.Server) (*http.Request, error)
+		evaluate       func(*testing.T, *http.Response, error)
+	}{
+		{
+			name: "it uses the default handler without a return",
+			defaultHandler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte("defaultHandler"))
+			}),
+			middleware: middleware.FilterChain(func(_ http.ResponseWriter, r *http.Request) ([]middleware.Constructor, error) {
+				return nil, nil
+			}, log.NopLogger()),
+			request: func(srv *httptest.Server) (*http.Request, error) {
+				return http.NewRequest("POST", srv.URL, strings.NewReader("body"))
+			},
+			evaluate: func(t *testing.T, response *http.Response, err error) {
+				assert.NotNil(t, response)
+				assert.NoError(t, err)
+				assert.Equal(t, http.StatusOK, response.StatusCode)
+
+				b, err := io.ReadAll(response.Body)
+				assert.NoError(t, err)
+				assert.Equal(t, string(b), "defaultHandler")
+			},
+		},
+		{
+			name: "it ignores nil constructors",
+			defaultHandler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte("defaultHandler"))
+			}),
+			middleware: middleware.FilterChain(func(_ http.ResponseWriter, r *http.Request) ([]middleware.Constructor, error) {
+				return []middleware.Constructor{
+					nil,
+					nil,
+					nil,
+					nil,
+					nil,
+					nil,
+					func(next http.Handler) http.Handler {
+						return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+							_, _ = w.Write([]byte("mw1"))
+							next.ServeHTTP(w, r)
+						})
+					},
+					nil,
+					nil,
+					nil,
+					func(next http.Handler) http.Handler {
+						return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+							_, _ = w.Write([]byte("mw2"))
+							next.ServeHTTP(w, r)
+						})
+					},
+					nil,
+					nil,
+					nil,
+				}, nil
+			}, log.NopLogger()),
+			request: func(srv *httptest.Server) (*http.Request, error) {
+				return http.NewRequest("POST", srv.URL, strings.NewReader("body"))
+			},
+			evaluate: func(t *testing.T, response *http.Response, err error) {
+				assert.NotNil(t, response)
+				assert.NoError(t, err)
+				assert.Equal(t, http.StatusOK, response.StatusCode)
+
+				b, err := io.ReadAll(response.Body)
+				assert.NoError(t, err)
+				assert.Equal(t, string(b), "mw1mw2defaultHandler")
+			},
+		},
+		{
+			name: "it uses the returned handlers",
+			defaultHandler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte("defaultHandler"))
+			}),
+			middleware: middleware.FilterChain(func(_ http.ResponseWriter, r *http.Request) ([]middleware.Constructor, error) {
+				return []middleware.Constructor{
+					func(next http.Handler) http.Handler {
+						return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+							_, _ = w.Write([]byte("mw1"))
+							next.ServeHTTP(w, r)
+						})
+					},
+					func(next http.Handler) http.Handler {
+						return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+							_, _ = w.Write([]byte("mw2"))
+							next.ServeHTTP(w, r)
+						})
+					},
+				}, nil
+			}, log.NopLogger()),
+			request: func(srv *httptest.Server) (*http.Request, error) {
+				return http.NewRequest("POST", srv.URL, strings.NewReader("body"))
+			},
+			evaluate: func(t *testing.T, response *http.Response, err error) {
+				assert.NotNil(t, response)
+				assert.NoError(t, err)
+				assert.Equal(t, http.StatusOK, response.StatusCode)
+
+				b, err := io.ReadAll(response.Body)
+				assert.NoError(t, err)
+				assert.Equal(t, string(b), "mw1mw2defaultHandler")
+			},
+		},
+		{
+			name: "it stops calling other middlewares if the factory fails short",
+			defaultHandler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte("defaultHandler"))
+			}),
+			middleware: middleware.FilterChain(func(w http.ResponseWriter, r *http.Request) ([]middleware.Constructor, error) {
+				status := http.StatusInternalServerError
+				http.Error(w, http.StatusText(status), status)
+
+				return []middleware.Constructor{
+					func(next http.Handler) http.Handler {
+						return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+							_, _ = w.Write([]byte("mw1"))
+							next.ServeHTTP(w, r)
+						})
+					},
+				}, errors.New(http.StatusText(status))
+			}, log.NopLogger()),
+			request: func(srv *httptest.Server) (*http.Request, error) {
+				return http.NewRequest("POST", srv.URL, strings.NewReader("body"))
+			},
+			evaluate: func(t *testing.T, response *http.Response, err error) {
+				assert.NotNil(t, response)
+				assert.NoError(t, err)
+				assert.Equal(t, http.StatusInternalServerError, response.StatusCode)
+
+				b, err := io.ReadAll(response.Body)
+				assert.NoError(t, err)
+				assert.Equal(t, string(bytes.TrimSpace(b)), http.StatusText(http.StatusInternalServerError))
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(tc.middleware(tc.defaultHandler))
+			defer srv.Close()
+
+			req, err := tc.request(srv)
+			assert.NoError(t, err)
+
+			resp, err := (&http.Client{}).Do(req)
+			defer func() {
+				if err != nil {
+					assert.NoError(t, resp.Body.Close())
+				}
+			}()
+
+			tc.evaluate(t, resp, err)
+		})
+	}
+}

--- a/services/proxy/pkg/middleware/middleware.go
+++ b/services/proxy/pkg/middleware/middleware.go
@@ -1,0 +1,30 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/justinas/alice"
+
+	"github.com/opencloud-eu/opencloud/pkg/log"
+)
+
+// Constructor wraps an http.Handler with middleware logic
+type Constructor = alice.Constructor
+
+// NopConstructor is a middleware that passes through the given http.Handler without modifying it.
+var NopConstructor Constructor = func(h http.Handler) http.Handler { return h }
+
+// middlewareLogger adds the middleware context to the logger
+func middlewareLogger(logger log.Logger, middleware string) log.Logger {
+	return log.Logger{Logger: logger.With().Str("middleware", middleware).Logger()}
+}
+
+// requestLogger builds a logger that contains detailed request information
+func requestLogger(base log.Logger, r *http.Request) log.Logger {
+	return log.Logger{Logger: base.With().
+		Str("proto", r.Proto).
+		Str("remote-addr", r.RemoteAddr).
+		Str("method", r.Method).
+		Str("path", r.URL.Path).
+		Logger()}
+}


### PR DESCRIPTION
## Description
as described [here](https://github.com/opencloud-eu/opencloud/issues/1643) openCloud does not close dangling uploads which can result in unnecessary unclosed connections.

Usually openCloud is used behind a proxy such as nginx which has timout settings for such cases, e.g.:

- proxy_connect_timeout
- proxy_send_timeout
- proxy_read_timeout
- send_timeout

which works and fixes that!

Anyway in my opinion openCloud should also have such options just in case.

As a starting-point the PR introduces such tools and already fixes it for the described upload case [here](https://github.com/opencloud-eu/opencloud/issues/1643).

The difference to the nginx timeout is that this implementation refreshes the timeout after each read of the request body which is specially helpful for large uploads with probably many chunks!

In a nutshell it contains the following tools:

- a middleware that allows to inspect and apply middleware chains per request 
- a middleware that sets a deadline for uploads and refreshes that after each read cycle

unfortunately the last uploaded chunk could take some time to finish because we have to calculate the checksum here and if the file is large the calculation will take some time, thats the reason behind the long upload deadline default value (120s).

as discussed today @butonic and @rhafer we maybe can send the checksum calculation to the background and not as part of the last upload chunk request! NOT PART OF THIS PR!

## Related Issue
- Fixes https://github.com/opencloud-eu/opencloud/issues/1643

## Motivation and Context
close unused or dangling requests

## How Has This Been Tested?
```bash
#!/usr/bin/env bash

echo 1
LOCATION=$(curl -k -I -s -o /dev/null -w '%header{location}' -XPOST 'https://localhost:9200/remote.php/dav/spaces/281457a5-5279-47d7-b55e-9f514c2df42b%24b6b9f660-e084-4dda-9689-76b75777381e' -uadmin:admin -H"Tus-Resumable: 1.0.0" -H"Upload-Length: 10" -H"Upload-Metadata: filename ZmlsZS50eHQ=" -H"Content-Type: application/offset+octet-stream")
echo 2
echo "$LOCATION"
echo "========================="
echo `date`: PATCH start
echo "========================="
curl -vk -XPATCH "$LOCATION" -H'Content-Type: application/offset+octet-stream' -H'Content-Length: 10' -H'Upload-Offset: 0' -H'Tus-Resumable: 1.0.0' -d"012345678"
echo "========================="
echo `date`: PATCH end
echo "========================="
echo 3
```

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [X] Code changes
- [X] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added
