### PR TITLE
[full-ci] disable running ci with watch fs when full-ci

### DIFF
--- a/.woodpecker.star
+++ b/.woodpecker.star
@@ -608,7 +608,7 @@ def testPipelines(ctx):
         pipelines += apiTests(ctx)
 
     enable_watch_fs = [False]
-    if ctx.build.event == "cron" or "full-ci" in ctx.build.title.lower():
+    if ctx.build.event == "cron":
         enable_watch_fs.append(True)
 
     for run_with_watch_fs_enabled in enable_watch_fs:
@@ -994,7 +994,7 @@ def localApiTestPipeline(ctx):
 
     with_remote_php = [True]
     enable_watch_fs = [False]
-    if ctx.build.event == "cron" or "full-ci" in ctx.build.title.lower():
+    if ctx.build.event == "cron":
         with_remote_php.append(False)
         enable_watch_fs.append(True)
 
@@ -1310,7 +1310,7 @@ def apiTests(ctx):
 
     with_remote_php = [True]
     enable_watch_fs = [False]
-    if ctx.build.event == "cron" or "full-ci" in ctx.build.title.lower():
+    if ctx.build.event == "cron":
         with_remote_php.append(False)
         enable_watch_fs.append(True)
 


### PR DESCRIPTION
Tests are very flaky. first we need fix all bugs related `watch fs`. After that enable it again