### PR TITLE
rc-handling was only active for the dryrun, not the real build-and-push

### DIFF
--- a/.woodpecker.star
+++ b/.woodpecker.star
@@ -1704,7 +1704,7 @@ def dockerRelease(ctx, repo, build_type):
                     "repo": "%s,quay.io/%s" % (repo, repo),
                     "platforms": "linux/amd64,linux/arm64",  # we can add remote builders
                     "auto_tag": False if build_type == "daily" else True,
-                    "tag": "daily" if build_type == "daily" else "",
+                    "tag": hard_tag,
                     "default_tag": "daily",
                     "dockerfile": "opencloud/docker/Dockerfile.multiarch",
                     "build_args": build_args,


### PR DESCRIPTION
## Description
fix the check to prevent the latest tag to be set on pre-release tag events
see https://github.com/opencloud-eu/opencloud/pull/1881
the previous pr only set the calculated tag for the dryrun step and missed the build-and-push step

## Motivation and Context
the latest tag should not be set for pre-releases

## How Has This Been Tested?
It only has been tested using static values in a separate repo

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added
