### PR TITLE
enable release-go plugin in stable-4.0 branch

### DIFF
--- a/.woodpecker.star
+++ b/.woodpecker.star
@@ -74,11 +74,11 @@ OC_FED_DOMAIN = "%s:10200" % FED_OC_SERVER_NAME
 event = {
     "base": {
         "event": ["push", "manual"],
-        "branch": "main",
+        "branch": "stable-*",
     },
     "cron": {
         "event": "cron",
-        "branch": "main",
+        "branch": "stable-*",
     },
     "pull_request": {
         "event": "pull_request",


### PR DESCRIPTION
I noticed that if I merge PR to `stable-4.0` readyReleaseGo doesn't create `Release PR` because "when": was "main"

```
def readyReleaseGo():
    return [{
        "name": "ready-release-go",
        "steps": [
            {
                "name": "release-helper",
                "image": READY_RELEASE_GO,
                "settings": {
                    "git_email": "devops@opencloud.eu",
                    "forge_type": "github",
                    "forge_token": {
                        "from_secret": "github_token",
                    },
                },
            },
        ],
        "when": [event["base"]],
    }]

```