### PR TITLE
[full-ci][tests-only] test: add test to check mismatch offset during TUS upload

### DIFF
--- a/tests/acceptance/features/coreApiWebdavUploadTUS/lowLevelUpload.feature
+++ b/tests/acceptance/features/coreApiWebdavUploadTUS/lowLevelUpload.feature
@@ -50,10 +50,25 @@ Feature: low level tests for upload of chunks
       | Upload-Metadata | filename ZmlsZS50eHQ= |
     When user "Alice" sends a chunk to the last created TUS Location with offset "0" and data "123" using the WebDAV API
     And user "Alice" sends a chunk to the last created TUS Location with offset "3" and data "4567890" using the WebDAV API
-    And the user waits for "2" seconds for postprocessing to finish
-    And user "Alice" sends a chunk to the last created TUS Location with offset "3" and data "0000000" using the WebDAV API
+    And user "Alice" sends a chunk to the last created TUS Location with offset "3" and data "0000000" with retry on offset mismatch using the WebDAV API
     Then the HTTP status code should be "404"
     And the content of file "/file.txt" for user "Alice" should be "1234567890"
+    Examples:
+      | dav-path-version |
+      | old              |
+      | new              |
+      | spaces           |
+
+
+  Scenario Outline: send last chunk with mismatch offset
+    Given using <dav-path-version> DAV path
+    And user "Alice" has created a new TUS resource on the WebDAV API with these headers:
+      | Upload-Length   | 10                    |
+      #    ZmlsZS50eHQ= is the base64 encode of file.txt
+      | Upload-Metadata | filename ZmlsZS50eHQ= |
+    When user "Alice" sends a chunk to the last created TUS Location with offset "0" and data "123" using the WebDAV API
+    And user "Alice" sends a chunk to the last created TUS Location with offset "2" and data "34567890" using the WebDAV API
+    Then the HTTP status code should be "409"
     Examples:
       | dav-path-version |
       | old              |


### PR DESCRIPTION
## Description
Changes:
- retry on offset mismtach (409) while sending the last chunk twice
- add test to check mismatch offset error

## Related Issue
- Fixes https://github.com/opencloud-eu/opencloud/issues/1636
- part of https://github.com/opencloud-eu/qa/issues/50

## Motivation and Context

## How Has This Been Tested?
- test environment:

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation added
