### PR TITLE
fix: enforce trailing slash for server url

### DIFF
--- a/services/web/pkg/service/v0/service.go
+++ b/services/web/pkg/service/v0/service.go
@@ -136,6 +136,9 @@ func (p Web) getPayload() (payload []byte, err error) {
 		p.config.Web.Config.Apps = make([]string, 0)
 	}
 
+	// ensure that the server url has a trailing slash
+	p.config.Web.Config.Server = strings.TrimRight(p.config.Web.Config.Server, "/") + "/"
+
 	return json.Marshal(p.config.Web.Config)
 }
 


### PR DESCRIPTION
## Description
Enforce a trailing slash for the server url in the config.json

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)
