### PR TITLE
[stable-4.0] fix: enforce trailing slash for server url

### DIFF
--- a/services/web/pkg/service/v0/service.go
+++ b/services/web/pkg/service/v0/service.go
@@ -136,6 +136,9 @@ func (p Web) getPayload() (payload []byte, err error) {
 		p.config.Web.Config.Apps = make([]string, 0)
 	}
 
+	// ensure that the server url has a trailing slash
+	p.config.Web.Config.Server = strings.TrimRight(p.config.Web.Config.Server, "/") + "/"
+
 	return json.Marshal(p.config.Web.Config)
 }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `stable-4.0`:
 - [fix: enforce trailing slash for server url](https://github.com/opencloud-eu/opencloud/pull/1995)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)