### PR TITLE
ci: fix translation pipeline

### DIFF
--- a/.woodpecker.star
+++ b/.woodpecker.star
@@ -2353,11 +2353,12 @@ def translation_sync(ctx):
                 "image": OC_CI_GOLANG,
                 "commands": [
                     "make l10n-read",
+                    "mkdir tx && cd tx",
                     "curl -o- https://raw.githubusercontent.com/transifex/cli/master/install.sh | bash",
-                    ". ~/.profile",
+                    "export PATH=$PATH:$(pwd) && cd ..",
                     "make l10n-push",
                     "make l10n-pull",
-                    "rm tx",
+                    "rm -rf tx",
                     "make l10n-clean",
                 ],
                 "environment": {


### PR DESCRIPTION
## Description
Download tx command into a subdir to avoid file exists error.
```
tar: can't open 'LICENSE': File exists
  0 4173k    0 27399    0     0  59164      0  0:01:12 --:--:--  0:01:12 59164
curl: (23) Failure writing output to destination, passed 1378 returned 0
```

## Related Issue
- Fixes https://github.com/opencloud-eu/opencloud/issues/2008

## Motivation and Context

## How Has This Been Tested?
- test environment:

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added
