### PR TITLE
Show edition in opencloud version command

### DIFF
--- a/opencloud/pkg/command/version.go
+++ b/opencloud/pkg/command/version.go
@@ -33,6 +33,7 @@ func VersionCommand(cfg *config.Config) *cli.Command {
 		Category: "info",
 		Action: func(c *cli.Context) error {
 			fmt.Println("Version: " + version.GetString())
+			fmt.Printf("Edition: %s\n", version.Edition)
 			fmt.Printf("Compiled: %s\n", version.Compiled())
 
 			if c.Bool(_skipServiceListingFlagName) {


### PR DESCRIPTION
related #2001

added `Edition` to output when we call `opencloud/bin/opencloud version`     

<img width="874" height="174" alt="Screenshot 2025-12-12 at 14 20 05" src="https://github.com/user-attachments/assets/9b507a26-e7b2-4772-9cf2-f3ac6c119c49" />
         