### PR TITLE
skip collaborativePosix tests in CI

### DIFF
--- a/.woodpecker.star
+++ b/.woodpecker.star
@@ -137,7 +137,8 @@ config = {
             "suites": [
                 "apiGraph",
                 "apiServiceAvailability",
-                "collaborativePosix",
+                # skip tests for collaborativePosix. see https://github.com/opencloud-eu/opencloud/issues/2036
+                #"collaborativePosix",
             ],
             "skip": False,
             "withRemotePhp": [True],


### PR DESCRIPTION
collaborativePosix is flaky. We have decided to temporarily skip them until we fix https://github.com/opencloud-eu/opencloud/issues/2036