### PR TITLE
[full-ci][tests-only] test: add hook failures to the test failures list

### DIFF
--- a/tests/acceptance/scripts/run.sh
+++ b/tests/acceptance/scripts/run.sh
@@ -279,14 +279,16 @@ function run_behat_tests() {
 		fi
 	fi
 
-	FAILED_SCENARIO_PATHS_COLORED=`awk '/Failed scenarios:/',0 ${TEST_LOG_FILE} | grep -a feature`
+	FAILED_SCENARIO_PATHS_COLORED=`awk '/Failed (scenarios|hooks):/',0 ${TEST_LOG_FILE} | grep -a feature`
 	# There will be some ANSI escape codes for color in the FEATURE_COLORED var.
 	# Strip them out so we can pass just the ordinary feature details to Behat.
 	# Also strip everything after ".feature:XX", including text such as "(on line xx)" added by Behat indicating the failing step's line number.
 	# Thanks to https://en.wikipedia.org/wiki/Tee_(command) and
 	# https://stackoverflow.com/questions/23416278/how-to-strip-ansi-escape-sequences-from-a-variable
 	# for ideas.
-	FAILED_SCENARIO_PATHS=$(echo "${FAILED_SCENARIO_PATHS_COLORED}" | sed "s/\x1b[^m]*m//g" | sed 's/\(\.feature:[0-9]\+\).*/\1/')
+	FAILED_SCENARIO_PATHS=$(echo "${FAILED_SCENARIO_PATHS_COLORED}" | sed "s/\x1b[^m]*m//g" | sed "s/AfterScenario \"//g" | sed 's/\(\.feature:[0-9]\+\).*/\1/')
+	# remove duplicate scenario paths
+	FAILED_SCENARIO_PATHS=$(echo "$FAILED_SCENARIO_PATHS" | awk '!seen[$0]++')
 
 	# If something else went wrong, and there were no failed scenarios,
 	# then the awk, grep, sed command sequence above ends up with an empty string.


### PR DESCRIPTION
## Description
Whenever any of the test hooks fail, add them to the list of test failures so that the whole scenario is reported as failed at the end of the test run.

## Related Issue
```feature
    Examples:
      | dav-path-version |
      | old              |
      | new              |
      | spaces           |
      │
      ╳  Syntax error (JsonException)
      │
      └─ @AfterScenario # FeatureContext::cleanDataAfterTests()
```
- hook failures not reported as failure
- CI: https://ci.opencloud.rocks/repos/3/pipeline/322/133

## How Has This Been Tested?
- test environment:

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added
