### PR TITLE
fix service name in suture logs

### DIFF
--- a/opencloud/pkg/runtime/service/service.go
+++ b/opencloud/pkg/runtime/service/service.go
@@ -124,7 +124,7 @@ func NewService(ctx context.Context, options ...Option) (*Service, error) {
 		if s.Services[priority] == nil {
 			s.Services[priority] = make(serviceFuncMap)
 		}
-		s.Services[priority][name] = NewSutureServiceBuilder(exec)
+		s.Services[priority][name] = NewSutureServiceBuilder(name, exec)
 	}
 
 	// nats is in priority group 0. It needs to start before all other services
@@ -316,7 +316,7 @@ func NewService(ctx context.Context, options ...Option) (*Service, error) {
 
 	// populate optional services
 	areg := func(name string, exec func(context.Context, *occfg.Config) error) {
-		s.Additional[name] = NewSutureServiceBuilder(exec)
+		s.Additional[name] = NewSutureServiceBuilder(name, exec)
 	}
 	areg(opts.Config.Antivirus.Service.Name, func(ctx context.Context, cfg *occfg.Config) error {
 		cfg.Antivirus.Context = ctx

--- a/opencloud/pkg/runtime/service/sutureservice.go
+++ b/opencloud/pkg/runtime/service/sutureservice.go
@@ -10,15 +10,17 @@ import (
 // SutureService allows for the settings command to be embedded and supervised by a suture supervisor tree.
 type SutureService struct {
 	exec func(ctx context.Context) error
+	name string
 }
 
 // NewSutureServiceBuilder creates a new suture service
-func NewSutureServiceBuilder(f func(context.Context, *occfg.Config) error) func(*occfg.Config) suture.Service {
+func NewSutureServiceBuilder(name string, f func(context.Context, *occfg.Config) error) func(*occfg.Config) suture.Service {
 	return func(cfg *occfg.Config) suture.Service {
 		return SutureService{
 			exec: func(ctx context.Context) error {
 				return f(ctx, cfg)
 			},
+			name: name,
 		}
 	}
 }
@@ -26,4 +28,9 @@ func NewSutureServiceBuilder(f func(context.Context, *occfg.Config) error) func(
 // Serve to fullfil Server interface
 func (s SutureService) Serve(ctx context.Context) error {
 	return s.exec(ctx)
+}
+
+// String to fullfil fmt.Stringer interface, used to log the service name
+func (s SutureService) String() string {
+	return s.name
 }


### PR DESCRIPTION
turns
```json
{
  "level":"error",
  "service":"opencloud",
  "event":"opencloud: Failed service 'service.SutureService{exec:(func(context.Context) error)(0x56499fbd6060)}' (1.000000 failures of 5.000000), restarting: true, ...
```

into
```json
{
  "level":"error",
  "service":"opencloud",
  "event":"opencloud: Failed service 'nats' (1.000000 failures of 5.000000), restarting: true, ...
```
