### PR TITLE
fix(web): add activities to default apps list

### DIFF
--- a/services/web/pkg/config/defaults/defaultconfig.go
+++ b/services/web/pkg/config/defaults/defaultconfig.go
@@ -98,7 +98,7 @@ func DefaultConfig() *config.Config {
 					ResponseType: "code",
 					Scope:        "openid profile email",
 				},
-				Apps: []string{"files", "search", "text-editor", "pdf-viewer", "external", "admin-settings", "epub-reader", "preview", "app-store"},
+				Apps: []string{"files", "search", "text-editor", "pdf-viewer", "external", "admin-settings", "epub-reader", "preview", "app-store", "activities"},
 				Options: config.Options{
 					ContextHelpersReadMore: true,
 					AccountEditLink:        &config.AccountEditLink{},


### PR DESCRIPTION
## Description

Adds `activities` to the default web apps list in `defaultconfig.go`.

## Related Issue

- Fixes https://github.com/opencloud-eu/opencloud/issues/2089

## Motivation and Context

The `web-app-activities` is bundled in OpenCloud Web but not loaded by default because `activities` is missing from the `Apps` array. The backend `activitylog` service runs by default, but users cannot access the global activities view.

## How Has This Been Tested?

- test environment: opencloud-compose with OpenCloud 4.1.0, Web 4.3.0
- test case 1: Verified `activities` appears in `/config.json` apps array after config override
- test case 2: Activities app visible in app menu after restart

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added
