### PR TITLE
fix(thumbnailer): missing font panic

### DIFF
--- a/services/thumbnails/pkg/preprocessor/preprocessor.go
+++ b/services/thumbnails/pkg/preprocessor/preprocessor.go
@@ -143,7 +143,11 @@ Scan: // Label for the scanner loop, so we can break it easily
 		textResult.MergeCommon(DefaultMergeMap)
 
 		for _, sRange := range textResult.ScriptRanges {
-			targetFontFace, _ := t.fontLoader.LoadFaceForScript(sRange.TargetScript)
+			targetFontFace, err := t.fontLoader.LoadFaceForScript(sRange.TargetScript)
+			if err != nil {
+				return nil, err
+			}
+
 			// if the target script is "_unknown" it's expected that the loaded face
 			// uses the default font
 			faceHeight := targetFontFace.Face.Metrics().Height

--- a/services/thumbnails/pkg/preprocessor/preprocessor_test.go
+++ b/services/thumbnails/pkg/preprocessor/preprocessor_test.go
@@ -149,6 +149,17 @@ var _ = Describe("ImageDecoder", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(img).ToNot(BeNil())
 		})
+
+		It("fails if the font is missing", func() {
+			decoder.fontLoader.fontMapData = &FontMapData{
+				FMap: &FontMap{
+					DefaultFont: "/some/unknown/font.otf",
+				},
+			}
+			img, err := decoder.Convert(bytes.NewReader([]byte("This is a test text")))
+			Expect(err).To(HaveOccurred())
+			Expect(img).To(BeNil())
+		})
 	})
 
 	Describe("test ForType", func() {

--- a/services/thumbnails/pkg/service/grpc/v0/service.go
+++ b/services/thumbnails/pkg/service/grpc/v0/service.go
@@ -12,13 +12,14 @@ import (
 	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/pkg/errors"
+	merrors "go-micro.dev/v4/errors"
+	"google.golang.org/grpc/metadata"
+
 	revactx "github.com/opencloud-eu/reva/v2/pkg/ctx"
 	"github.com/opencloud-eu/reva/v2/pkg/rgrpc/todo/pool"
 	"github.com/opencloud-eu/reva/v2/pkg/storagespace"
 	"github.com/opencloud-eu/reva/v2/pkg/utils"
-	"github.com/pkg/errors"
-	merrors "go-micro.dev/v4/errors"
-	"google.golang.org/grpc/metadata"
 
 	"github.com/opencloud-eu/opencloud/pkg/log"
 	thumbnailssvc "github.com/opencloud-eu/opencloud/protogen/gen/opencloud/services/thumbnails/v0"
@@ -169,6 +170,10 @@ func (g Thumbnail) handleCS3Source(ctx context.Context, req *thumbnailssvc.GetTh
 	}
 	pp := preprocessor.ForType(sRes.GetInfo().GetMimeType(), ppOpts)
 	img, err := pp.Convert(r)
+	if err != nil {
+		g.logger.Error().Err(err).Msg("failed to convert image")
+	}
+
 	if img == nil || err != nil {
 		return "", merrors.NotFound(g.serviceID, "could not get image")
 	}


### PR DESCRIPTION
## Description
the thumbnailer service panics if the fontmap contains a path to a font that does not exist, spotting the reason for that is hard because there is no error propagation for that case 

## Related Issue
- Fixes https://github.com/opencloud-eu/opencloud/issues/2015

## Motivation and Context
- let the admin know if the configured font is not found
- fix the panic

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- local installation
- unit tests


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
- [ ] Code changes
- [X] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added
