### PR TITLE
remove obsolete tracing config vom audit service

### DIFF
--- a/services/audit/pkg/config/config.go
+++ b/services/audit/pkg/config/config.go
@@ -39,11 +39,3 @@ type Auditlog struct {
 	FilePath     string `yaml:"filepath" env:"AUDIT_FILEPATH" desc:"Filepath of the logfile. Mandatory if LOG_TO_FILE is set to 'true'." introductionVersion:"1.0.0"`
 	Format       string `yaml:"format" env:"AUDIT_FORMAT" desc:"Log format. Supported values are '' (empty) and 'json'. Using 'json' is advised, '' (empty) renders the 'minimal' format. See the text description for more details." introductionVersion:"1.0.0"`
 }
-
-// Tracing defines the available tracing configuration.
-type Tracing struct {
-	Enabled   bool   `yaml:"enabled" env:"OC_TRACING_ENABLED;AUDIT_TRACING_ENABLED" desc:"Activates tracing." introductionVersion:"1.0.0"`
-	Type      string `yaml:"type" env:"OC_TRACING_TYPE;AUDIT_TRACING_TYPE" desc:"The type of tracing. Defaults to '', which is the same as 'jaeger'. Allowed tracing types are 'jaeger' and '' as of now." introductionVersion:"1.0.0"`
-	Endpoint  string `yaml:"endpoint" env:"OC_TRACING_ENDPOINT;AUDIT_TRACING_ENDPOINT" desc:"The endpoint of the tracing agent." introductionVersion:"1.0.0"`
-	Collector string `yaml:"collector" env:"OC_TRACING_COLLECTOR;AUDIT_TRACING_COLLECTOR" desc:"The HTTP endpoint for sending spans directly to a collector, i.e. http://jaeger-collector:14268/api/traces. Only used if the tracing endpoint is unset." introductionVersion:"1.0.0"`
-}


### PR DESCRIPTION
We have removed an obsolte tracing config we forgot in the audit service.