### PR TITLE
fix: markdown links formatting

### DIFF
--- a/pkg/markdown/markdown.go
+++ b/pkg/markdown/markdown.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"regexp"
 	"strings"
 )
 
@@ -77,7 +78,7 @@ func (md MD) WriteToc(w io.Writer) (int64, error) {
 			// main title not in toc
 			continue
 		}
-		link := fmt.Sprintf("#%s", strings.ToLower(strings.Replace(h.Header, " ", "-", -1)))
+		link := fmt.Sprintf("#%s", toAnchor(h.Header))
 		s := fmt.Sprintf("%s* [%s](%s)\n", strings.Repeat("  ", h.Level-2), h.Header, link)
 		n, err := w.Write([]byte(s))
 		if err != nil {
@@ -136,4 +137,13 @@ func headingFromString(s string) Heading {
 		Level:  len(levs),
 		Header: strings.TrimPrefix(con, " "),
 	}
+}
+
+func toAnchor(header string) string {
+	// Remove everything except letters, numbers, and spaces
+	reg := regexp.MustCompile(`[^a-zA-Z0-9 ]+`)
+	anchor := reg.ReplaceAllString(header, "")
+	// Replace spaces with hyphens and convert to lowercase
+	anchor = strings.ReplaceAll(anchor, " ", "-")
+	return strings.ToLower(anchor)
 }


### PR DESCRIPTION
<!--
Thanks for submitting a change to OpenCloud!

For fixing potential security issues please see https://opencloud.eu/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the main branch which holds the next version of OpenCloud.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->

Fix rendering of anchor links in markdown TOCs

Seen in:

```
WARNING] Docusaurus found broken anchors!

Please check the pages of your site in the list below, and make sure you don't reference any anchor that does not exist.
Note: it's possible to ignore broken anchors with the 'onBrokenAnchors' Docusaurus configuration, and let the build pass.

Exhaustive list of all broken anchors found:
- Broken anchor on source page path = /de/docs/next/dev/server/services/app-registry/information:
   -> linking to #mime-type-configuration-/-creation-allow-list (resolved as: /de/docs/next/dev/server/services/app-registry/information#mime-type-configuration-/-creation-allow-list)
- Broken anchor on source page path = /de/docs/next/dev/server/services/auth-app/information:
   -> linking to #via-cli-(developer-only) (resolved as: /de/docs/next/dev/server/services/auth-app/information#via-cli-(developer-only))
- Broken anchor on source page path = /de/docs/next/dev/server/services/auth-basic/information:
   -> linking to #the-%60auth%60-service-family (resolved as: /de/docs/next/dev/server/services/auth-basic/information#the-%60auth%60-service-family)
- Broken anchor on source page path = /de/docs/next/dev/server/services/auth-bearer/information:
   -> linking to #the-%60auth%60-service-family (resolved as: /de/docs/next/dev/server/services/auth-bearer/information#the-%60auth%60-service-family)
[SUCCESS] Generated static files in "build/de".
[INFO] Use `npm run serve` command to test your build locally.
- Broken anchor on source page path = /de/docs/next/dev/server/services/auth-service/information:
   -> linking to #the-%60auth%60-service-family (resolved as: /de/docs/next/dev/server/services/auth-service/information#the-%60auth%60-service-family)
- Broken anchor on source page path = /de/docs/next/dev/server/services/policies/information:
   -> linking to #event-service-(postprocessing) (resolved as: /de/docs/next/dev/server/services/policies/information#event-service-(postprocessing))
- Broken anchor on source page path = /de/docs/next/dev/server/services/proxy/information:
   -> linking to #1 (resolved as: /de/docs/next/dev/server/services/proxy/information#1)
   -> linking to #2 (resolved as: /de/docs/next/dev/server/services/proxy/information#2)
- Broken anchor on source page path = /de/docs/next/dev/server/services/search/information:
   -> linking to #content-analysis-/-extraction (resolved as: /de/docs/next/dev/server/services/search/information#content-analysis-/-extraction)
- Broken anchor on source page path = /de/docs/dev/server/services/app-registry/information:
   -> linking to #mime-type-configuration-/-creation-allow-list (resolved as: /de/docs/dev/server/services/app-registry/information#mime-type-configuration-/-creation-allow-list)
- Broken anchor on source page path = /de/docs/dev/server/services/auth-app/information:
   -> linking to #via-cli-(developer-only) (resolved as: /de/docs/dev/server/services/auth-app/information#via-cli-(developer-only))
- Broken anchor on source page path = /de/docs/dev/server/services/auth-basic/information:
   -> linking to #the-%60auth%60-service-family (resolved as: /de/docs/dev/server/services/auth-basic/information#the-%60auth%60-service-family)
- Broken anchor on source page path = /de/docs/dev/server/services/auth-bearer/information:
   -> linking to #the-%60auth%60-service-family (resolved as: /de/docs/dev/server/services/auth-bearer/information#the-%60auth%60-service-family)
- Broken anchor on source page path = /de/docs/dev/server/services/auth-service/information:
   -> linking to #the-%60auth%60-service-family (resolved as: /de/docs/dev/server/services/auth-service/information#the-%60auth%60-service-family)
- Broken anchor on source page path = /de/docs/dev/server/services/policies/information:
   -> linking to #event-service-(postprocessing) (resolved as: /de/docs/dev/server/services/policies/information#event-service-(postprocessing))
- Broken anchor on source page path = /de/docs/dev/server/services/proxy/information:
   -> linking to #1 (resolved as: /de/docs/dev/server/services/proxy/information#1)
   -> linking to #2 (resolved as: /de/docs/dev/server/services/proxy/information#2)
- Broken anchor on source page path = /de/docs/dev/server/services/search/information:
   -> linking to #content-analysis-/-extraction (resolved as: /de/docs/dev/server/services/search/information#content-analysis-/-extraction)
```

### Before

`* [Content analysis / Extraction](#content-analysis-/-extraction)`

### After

`* [Content analysis / Extraction](#content-analysis--extraction)`

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added
