### PR TITLE
fix flaky #2145

### DIFF
--- a/tests/acceptance/TestHelpers/HttpRequestHelper.php
+++ b/tests/acceptance/TestHelpers/HttpRequestHelper.php
@@ -100,7 +100,7 @@ class HttpRequestHelper {
 			$parsedUrl = parse_url($url);
 			$baseUrl = $parsedUrl['scheme'] . '://' . $parsedUrl['host'];
 			$baseUrl .= isset($parsedUrl['port']) ? ':' . $parsedUrl['port'] : '';
-			$testUrl = $baseUrl . "/graph/v1.0/use/$user";
+			$testUrl = $baseUrl . "/graph/v1.0/user/$user";
 			if (OcHelper::isTestingOnReva()) {
 				$url = $baseUrl . "/ocs/v2.php/cloud/users/$user";
 			}


### PR DESCRIPTION
fix flaky test #2145

```
2026/01/14 14:12:35 [ocwrapper] OpenCloud server is ready to accept requests
{"level":"error","service":"proxy","error":"failed to verify access token: 405 Method Not Allowed: ","authenticator":"oidc","path":"/graph/v1.0/use/admin","user_agent":"GuzzleHttp/7","client.address":"","network.peer.address":"172.22.0.3","network.peer.port":"51842","time":"2026-01-14T14:12:35Z","message":"failed to authenticate the request"}
```

This typo prevented us from correctly clearing all tokens and obtaining a new token. 