### PR TITLE
fix issue-2146

### DIFF
--- a/tests/acceptance/bootstrap/WebDav.php
+++ b/tests/acceptance/bootstrap/WebDav.php
@@ -1325,6 +1325,20 @@ trait WebDav {
 		if ($statusCode === 404 || $statusCode === 405) {
 			return;
 		}
+		// After MOVE the source path might still be visible for a short time
+		// We wait 1 second and retry once to avoid flaky failures.
+		if ($statusCode === 207) {
+			sleep(1);
+			$response = $this->listFolder(
+				$user,
+				$path,
+				'0',
+				null,
+				null,
+				$type
+			);
+			$statusCode = $response->getStatusCode();
+		}
 		if ($statusCode === 207) {
 			$responseXmlObject = HttpRequestHelper::getResponseXml(
 				$response,


### PR DESCRIPTION
fix #2146 

Sometimes after moving folder it still be visible for a short time. 
```
When user "Alice" moves folder "folderB" to "folderA/folderB" using the WebDAV API - ✅️ 201
		_______________________________________________________________________

		==> REQUEST
		MOVE /remote.php/webdav/folderB
		X-Request-ID: coreApiShareManagementToShares/moveShareInsideAnotherShare.feature:60-50

		<== RESPONSE
		201 Created
		X-Xss-Protection: 1; mode=block
### Then the HTTP status code should be "201"
### And as "Alice" folder "/folderB" should not exist
		_______________________________________________________________________

		==> REQUEST
		PROPFIND /remote.php/webdav/folderB
		X-Request-ID: coreApiShareManagementToShares/moveShareInsideAnotherShare.feature:60-52
		==> REQ BODY
		<?xml version="1.0"?>
				<d:propfind
				   xmlns:d="DAV:"
				   xmlns:oc="[http://owncloud.org/ns"](http://owncloud.org/ns%22)
				   xmlns:ocs="[http://open-collaboration-services.org/ns"](http://open-collaboration-services.org/ns%22)
				   >
				    <d:prop><d:getetag/><d:resourcetype/></d:prop>
				</d:propfind>

		<== RESPONSE
		207 Multi-Status
		X-Xss-Protection: 1; mode=block
		<== RES BODY
		<d:multistatus xmlns:s="[http://sabredav.org/ns"](http://sabredav.org/ns%22) xmlns:d="DAV:" xmlns:oc="[http://owncloud.org/ns"><d:response><d:href>/remote.php/webdav/folderB/</d:href><d:propstat><d:prop><d:getetag>"30cb468040e85593a018bad164810beb"</d:getetag><d:resourcetype><d:collection/></d:resourcetype>
```

### Solution: if the folder still exists (207 status code), wait 1 second and retry the PROPFIND request once
