### PR TITLE
bump-web-5.0.0

### DIFF
--- a/.woodpecker.env
+++ b/.woodpecker.env
@@ -1,4 +1,4 @@
 # The test runner source for UI tests
-WEB_COMMITID=3120ea384c7a9d1f1ea0c328965951fc06d66900
+WEB_COMMITID=d5f9ddb7878c20ca6db54b6f097e611c996de728
 WEB_BRANCH=main
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -34,7 +34,7 @@ var (
 	// LatestTag is the latest released version plus the dev meta version.
 	// Will be overwritten by the release pipeline
 	// Needs a manual change for every tagged release
-	LatestTag = "4.1.0+dev"
+	LatestTag = "5.0.0+dev"
 
 	// Date indicates the build date.
 	// This has been removed, it looks like you can only replace static strings with recent go versions

--- a/services/web/Makefile
+++ b/services/web/Makefile
@@ -1,6 +1,6 @@
 SHELL := bash
 NAME := web
-WEB_ASSETS_VERSION = v4.3.0
+WEB_ASSETS_VERSION = v5.0.0
 WEB_ASSETS_BRANCH = main
 
 ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI


### PR DESCRIPTION
- Bump web to v5.0.0 for the upcoming rolling release.
- bump opencloud version