### PR TITLE
test(api): wait for web-office readiness by checking discovery endpoint

### DIFF
--- a/tests/acceptance/TestHelpers/HttpLogger.php
+++ b/tests/acceptance/TestHelpers/HttpLogger.php
@@ -77,7 +77,7 @@ class HttpLogger {
 		}
 
 		$logMessage = "\t\t_______________________________________________________________________\n\n";
-		$logMessage .= "\t\t==> REQUEST [" . self::getDateTime() . "]\n";
+		$logMessage .= "\t\t==> REQUEST [" . self::getCurrentDateTime() . "]\n";
 		$logMessage .= "\t\t$method $path\n";
 		$logMessage .= $query ? "\t\tQUERY: $query\n" : "";
 		$logMessage .= "\t\t$headers";
@@ -105,7 +105,7 @@ class HttpLogger {
 			$headers = $key . ": " . $value[0] . "\n";
 		}
 
-		$logMessage = "\t\t<== RESPONSE [" . self::getDateTime() . "]\n";
+		$logMessage = "\t\t<== RESPONSE [" . self::getCurrentDateTime() . "]\n";
 		$logMessage .= "\t\t$statusCode $statusMessage\n";
 		$logMessage .= "\t\t$headers";
 
@@ -127,7 +127,7 @@ class HttpLogger {
 	 *
 	 * @return string
 	 */
-	public static function getDateTime(): string {
+	public static function getCurrentDateTime(): string {
 		return date('Y-m-d\TG:i:s');
 	}
 }


### PR DESCRIPTION
## Description
- check web-office servers readiness using the discovery endpoints
- add date-time to the request/response log entry

## Related Issue
- Fixes https://github.com/opencloud-eu/opencloud/issues/2110

## Motivation and Context

## How Has this Been Tested?
- test environment:

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added
