### PR TITLE
ci: check for version placeholders

### DIFF
--- a/.woodpecker.star
+++ b/.woodpecker.star
@@ -523,6 +523,7 @@ def main(ctx):
         testPipelines(ctx)
 
     build_release_pipelines = \
+        checkVersionPlaceholder() + \
         dockerReleases(ctx) + \
         binaryReleases(ctx)
 
@@ -1816,6 +1817,27 @@ def dockerReleases(ctx):
         pipelines.extend(repo_pipelines)
 
     return pipelines
+
+def checkVersionPlaceholder():
+    return [{
+        "name": "check-version-placeholder",
+        "steps": [
+            {
+                "name": "check-version-placeholder",
+                "image": OC_CI_ALPINE,
+                "commands": [
+                    "grep -r -e '%%NEXT%%' -e '%%NEXT_PRODUCTION_VERSION%%' %s/services %s/pkg > next_version.txt" % (
+                        dirs["base"],
+                        dirs["base"],
+                    ),
+                    'if [ -s next_version.txt ]; then echo "replace version placeholders"; cat next_version.txt; exit 1; fi',
+                ],
+            },
+        ],
+        "when": [
+            event["tag"],
+        ],
+    }]
 
 def dockerRelease(ctx, repo, build_type):
     build_args = {


### PR DESCRIPTION
## Description
check for placeholders `%%NEXT%%` and `%%NEXT_PRODUCTION_VERSION%%`  and fail CI if there are still in the code

## Related Issue
part of https://github.com/opencloud-eu/opencloud/issues/1933#issuecomment-3816466374

## Motivation and Context
make sure the placeholders are replaced with correct versions before the release

## How Has This Been Tested?
:robot: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added
