### PR TITLE
adr: Document OIDC client parameter discovery

### DIFF
--- a/docs/adr/0003-oidc-client-config-discovery.md
+++ b/docs/adr/0003-oidc-client-config-discovery.md
@@ -2,7 +2,7 @@
 title: "Discover OIDC Client configuration via WebFinger"
 ---
 
-* Status: pending
+* Status: accepted
 * Deciders: [@TheOneRing @kulmann @rhafer @dragotin]
 * Date: 2026-02-02
 


### PR DESCRIPTION
This basically documents what as discussed in https://github.com/opencloud-eu/opencloud/pull/2072 and https://github.com/opencloud-eu/internal/issues/172

I am mainly adding to this to keep a record of why we're doing it and how.

@kulmann To make all clients use the same mechanism for discovering the oidc parameter it would IMO be good if web could switch to as well. However, looking at the other OIDC related parameters that can be configured in web. I have some questions.

- `WEB_OIDC_METADATA_URL`: This allows to set the URL for the `.well-known/openid-configuration` endpoint. Do we really need that? This should always be the issuer-url as returned in the `http://openid.net/specs/connect/1.0/issuer` relation + `.well-known/openid-configuration`.  The OIDC spec even define is as a `MUST` (https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig). 
- `ResponseType`: We default to `code` here, have we ever encountered the need to set something else? To we need to have this configurable?
- `PostLogoutRedirectURI`: I guess this is really specifc to web? So we should probably keep it in the config.json
