### PR TITLE
ci: check version placeholder in release PR

### DIFF
--- a/.woodpecker.star
+++ b/.woodpecker.star
@@ -497,7 +497,8 @@ def main(ctx):
 
     is_release_pr = (ctx.build.event == "pull_request" and ctx.build.sender == "openclouders" and "🎉 release" in ctx.build.title.lower())
     if is_release_pr:
-        return licenseCheck(ctx)
+        return checkVersionPlaceholder() + \
+               licenseCheck(ctx)
 
     build_release_helpers = \
         readyReleaseGo()
@@ -523,7 +524,6 @@ def main(ctx):
         testPipelines(ctx)
 
     build_release_pipelines = \
-        checkVersionPlaceholder() + \
         dockerReleases(ctx) + \
         binaryReleases(ctx)
 
@@ -1835,7 +1835,7 @@ def checkVersionPlaceholder():
             },
         ],
         "when": [
-            event["tag"],
+            event["pull_request"],
         ],
     }]
 


### PR DESCRIPTION
## Description
Doing the check whether there are still version placeholders on the tag is too late. So I'm proposing to do this check in the release PR of ready-release-go.
That way the PR cannot be merged and a release created when there are still placeholders

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of https://github.com/opencloud-eu/opencloud/issues/1933

## Motivation and Context
Block the release as long as there are still placeholders in the code

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`wccs`

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added
