### PR TITLE
docs(search): add note about re-indexing when enabling Tika

### DIFF
--- a/services/search/README.md
+++ b/services/search/README.md
@@ -104,6 +104,8 @@ Additionally, the following optional settings can be set:
 
 *   `SEARCH_EXTRACTOR_TIKA_CLEAN_STOP_WORDS=true` (default: `true`): ignore stop words like `I`, `you`, `the` during content extraction.
 
+> **Note:** Enabling Tika does not automatically re-extract content from already indexed files. You need to delete the existing search index and trigger a full re-index. See [Manually Trigger Re-Indexing a Space](#manually-trigger-re-indexing-a-space) for details.
+
 ## Manually Trigger Re-Indexing a Space
 
 The service includes a command-line interface to trigger re-indexing a space:
@@ -117,6 +119,13 @@ It can also be used to re-index all spaces:
 ```shell
 opencloud search index --all-spaces
 ```
+
+> **Note:** The re-index command skips files whose modification time has not changed since they were last indexed. If you changed the extractor type (e.g., from `basic` to `tika`), you need to delete the existing search index first to force a full content re-extraction:
+>
+> ```shell
+> rm -rf $OC_BASE_DATA_PATH/search   # default: /var/lib/opencloud/search
+> opencloud search index --all-spaces
+> ```
 
 ## Metrics
 


### PR DESCRIPTION
## Description

Add notes to the search service README clarifying that:

1. Enabling Tika does not automatically re-extract content from already indexed files
2. The `opencloud search index --all-spaces` command skips files with unchanged modification time
3. Workaround: delete the Bleve search index before re-indexing to force full content extraction

## Related Issue

- Fixes opencloud-eu/opencloud-compose#217

## Motivation and Context

When users enable Tika on an existing instance, they expect full-text search to work for all files. However, `opencloud search index --all-spaces` skips files already in the index (mtime-based check in `services/search/pkg/search/service.go`), so the Tika extractor is never called for previously indexed files. This is undocumented and confusing.

## How Has This Been Tested?

- test environment: Read the source code in `services/search/pkg/search/service.go` (IndexSpace method, mtime skip logic at line ~495)
- test case 1: Verified the skip behavior by tracing the code path: IndexSpace → Walk → mtime check → skip if already indexed
- test case 2: Confirmed no `--force` flag exists in the CLI or protobuf definition (`IndexSpaceRequest`)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:

- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation added
