### PR TITLE
Sanitize web config only once

### DIFF
--- a/services/web/pkg/config/defaults/defaultconfig.go
+++ b/services/web/pkg/config/defaults/defaultconfig.go
@@ -153,25 +153,30 @@ func Sanitize(cfg *config.Config) {
 		cfg.Web.Config.OpenIDConnect.MetadataURL = strings.TrimRight(cfg.Web.Config.OpenIDConnect.Authority, "/") + "/.well-known/openid-configuration"
 	}
 	// remove AccountEdit parent if no value is set
-	if cfg.Web.Config.Options.AccountEditLink.Href == "" {
+	if cfg.Web.Config.Options.AccountEditLink != nil &&
+		cfg.Web.Config.Options.AccountEditLink.Href == "" {
 		cfg.Web.Config.Options.AccountEditLink = nil
 	}
 	// remove Editor parent if no value is set
-	if !cfg.Web.Config.Options.Editor.AutosaveEnabled {
+	if cfg.Web.Config.Options.Editor != nil &&
+		!cfg.Web.Config.Options.Editor.AutosaveEnabled {
 		cfg.Web.Config.Options.Editor = nil
 	}
 	// remove FeedbackLink parent if no value is set
-	if cfg.Web.Config.Options.FeedbackLink.Href == "" &&
+	if cfg.Web.Config.Options.FeedbackLink != nil &&
+		cfg.Web.Config.Options.FeedbackLink.Href == "" &&
 		cfg.Web.Config.Options.FeedbackLink.AriaLabel == "" &&
 		cfg.Web.Config.Options.FeedbackLink.Description == "" {
 		cfg.Web.Config.Options.FeedbackLink = nil
 	}
 	// remove Upload parent if no value is set
-	if cfg.Web.Config.Options.Upload.CompanionURL == "" {
+	if cfg.Web.Config.Options.Upload != nil &&
+		cfg.Web.Config.Options.Upload.CompanionURL == "" {
 		cfg.Web.Config.Options.Upload = nil
 	}
 	// remove Embed parent if no value is set
-	if cfg.Web.Config.Options.Embed.Enabled == "" &&
+	if cfg.Web.Config.Options.Embed != nil &&
+		cfg.Web.Config.Options.Embed.Enabled == "" &&
 		cfg.Web.Config.Options.Embed.Target == "" &&
 		cfg.Web.Config.Options.Embed.MessagesOrigin == "" &&
 		cfg.Web.Config.Options.Embed.DelegateAuthentication &&


### PR DESCRIPTION
## Description
Suture restarts failing service by executing the respective command. Cobra tries to execute PreRunE one more time that triggers config sanitization for already sanitized config.  
Checking against an empty string triggers panic.

## Related Issue
- Fixes #2271


## Motivation and Context
It makes the world a better place to live and fixes the panic if the port 9200 is already taken.

P.S. Execute `web.Execute(cfg.Web)` command produces `Usage:` message in CLI on every restart on opencloud/pkg/runtime/service/service.go:264 so there are 5 such messages in console but that's completely different story. 

## How Has This Been Tested?
- test environment:
- test case 1:
```
nc -l 9200 &
./opencloud server
```

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added
