### PR TITLE
Add openCloudEducationExternalId to user

### DIFF
--- a/devtools/deployments/shared/config/ldap/schemas/20_opencloud_education_schema.ldif
+++ b/devtools/deployments/shared/config/ldap/schemas/20_opencloud_education_schema.ldif
@@ -32,7 +32,7 @@ olcObjectClasses: ( openCloudOid:1.2.3 NAME 'openCloudEducationUser'
   DESC 'OpenCloud education user objectclass'
   SUP openCloudUser
   AUXILIARY
-  MAY ( userClass $ openCloudMemberOfSchool ) )
+  MAY ( openCloudEducationExternalId $ userClass $ openCloudMemberOfSchool ) )
 olcObjectClasses: ( openCloudOid:1.2.4 NAME 'openCloudEducationClass'
   DESC 'OpenCloud education class objectclass'
   SUP openCloudObject


### PR DESCRIPTION
This allows education users to have an externalId that can be used to deprovision them later