### PR TITLE
fix(oidc_auth): Fix userinfo cache expiration logic

### DIFF
--- a/services/proxy/pkg/middleware/oidc_auth.go
+++ b/services/proxy/pkg/middleware/oidc_auth.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/golang-jwt/jwt/v5"
 	"github.com/opencloud-eu/opencloud/pkg/log"
 	"github.com/opencloud-eu/opencloud/pkg/oidc"
 	"github.com/pkg/errors"
@@ -68,12 +67,13 @@ func (m *OIDCAuthenticator) getClaims(token string, req *http.Request) (map[stri
 	if len(record) > 0 {
 		if err = msgpack.Unmarshal(record[0].Value, &claims); err == nil {
 			m.Logger.Debug().Interface("claims", claims).Msg("cache hit for userinfo")
-			if ok := verifyExpiresAt(claims, m.TimeFunc()); !ok {
-				return nil, false, jwt.ErrTokenExpired
+			if verifyExpiresAt(claims, m.TimeFunc()) {
+				return claims, false, nil
 			}
-			return claims, false, nil
+			m.Logger.Debug().Msg("cached userinfo claims expired, ignoring cache")
+		} else {
+			m.Logger.Error().Err(err).Msg("failed to unmarshal cached userinfo, ignoring cache")
 		}
-		m.Logger.Error().Err(err).Msg("could not unmarshal userinfo")
 	}
 
 	aClaims, claims, err := m.oidcClient.VerifyAccessToken(req.Context(), token)


### PR DESCRIPTION
When the userinfo claims stored in the usercache is found to be expired,
do not return an error but ignore the cached entry and force a
re-verification of the access token (either via parsing the JWT again or
via a UserInfo lookup).
This is required for setups with non-JWT access tokes where the expiry
date set in the cached claims does not reflect the actual token expiry,
but just the CacheTTL.

Fixes: https://github.com/opencloud-eu/opencloud/issues/1493