### PR TITLE
feat(init): support environment variables for all generated secrets

### DIFF
--- a/opencloud/pkg/init/functions.go
+++ b/opencloud/pkg/init/functions.go
@@ -8,6 +8,8 @@ import (
 	"os/exec"
 	"path"
 	"time"
+
+	"github.com/opencloud-eu/opencloud/pkg/generators"
 )
 
 func checkConfigPath(configPath string) error {
@@ -105,4 +107,11 @@ func writePatch(configPath string, yamlOutput []byte) error {
 	}
 	fmt.Printf("diff written to %s\n", patchPath)
 	return nil
+}
+
+func secretFromEnvOrRandom(envVar string, length int) (string, error) {
+	if v := os.Getenv(envVar); v != "" {
+		return v, nil
+	}
+	return generators.GenerateRandomPassword(length)
 }

--- a/opencloud/pkg/init/init.go
+++ b/opencloud/pkg/init/init.go
@@ -109,55 +109,55 @@ func CreateConfig(insecure, forceOverwrite, diff bool, configPath, adminPassword
 		storageUsersMountID = uuid.NewString()
 		serviceAccountID = uuid.NewString()
 
-		idmServicePassword, err = generators.GenerateRandomPassword(passwordLength)
+		idmServicePassword, err = secretFromEnvOrRandom("IDM_SVC_PASSWORD", passwordLength)
 		if err != nil {
 			return fmt.Errorf("could not generate random password for idm: %s", err)
 		}
-		idpServicePassword, err = generators.GenerateRandomPassword(passwordLength)
+		idpServicePassword, err = secretFromEnvOrRandom("IDM_IDPSVC_PASSWORD", passwordLength)
 		if err != nil {
 			return fmt.Errorf("could not generate random password for idp: %s", err)
 		}
 		ocAdminServicePassword = adminPassword
 		if ocAdminServicePassword == "" {
-			ocAdminServicePassword, err = generators.GenerateRandomPassword(passwordLength)
+			ocAdminServicePassword, err = secretFromEnvOrRandom("INITIAL_ADMIN_PASSWORD", passwordLength)
 			if err != nil {
 				return fmt.Errorf("could not generate random password for opencloud admin: %s", err)
 			}
 		}
 
-		revaServicePassword, err = generators.GenerateRandomPassword(passwordLength)
+		revaServicePassword, err = secretFromEnvOrRandom("IDM_REVASVC_PASSWORD", passwordLength)
 		if err != nil {
 			return fmt.Errorf("could not generate random password for reva: %s", err)
 		}
-		tokenManagerJwtSecret, err = generators.GenerateRandomPassword(passwordLength)
+		tokenManagerJwtSecret, err = secretFromEnvOrRandom("OC_JWT_SECRET", passwordLength)
 		if err != nil {
 			return fmt.Errorf("could not generate random password for tokenmanager: %s", err)
 		}
-		collaborationWOPISecret, err = generators.GenerateRandomPassword(passwordLength)
+		collaborationWOPISecret, err = secretFromEnvOrRandom("COLLABORATION_WOPI_SECRET", passwordLength)
 		if err != nil {
 			return fmt.Errorf("could not generate random wopi secret for collaboration service: %s", err)
 		}
-		machineAuthAPIKey, err = generators.GenerateRandomPassword(passwordLength)
+		machineAuthAPIKey, err = secretFromEnvOrRandom("OC_MACHINE_AUTH_API_KEY", passwordLength)
 		if err != nil {
 			return fmt.Errorf("could not generate random password for machineauthsecret: %s", err)
 		}
-		systemUserAPIKey, err = generators.GenerateRandomPassword(passwordLength)
+		systemUserAPIKey, err = secretFromEnvOrRandom("SYSTEM_USER_API_KEY", passwordLength)
 		if err != nil {
 			return fmt.Errorf("could not generate random system user API key: %s", err)
 		}
-		revaTransferSecret, err = generators.GenerateRandomPassword(passwordLength)
+		revaTransferSecret, err = secretFromEnvOrRandom("OC_TRANSFER_SECRET", passwordLength)
 		if err != nil {
 			return fmt.Errorf("could not generate random password for revaTransferSecret: %s", err)
 		}
-		urlSigningSecret, err = generators.GenerateRandomPassword(passwordLength)
+		urlSigningSecret, err = secretFromEnvOrRandom("OC_URL_SIGNING_SECRET", passwordLength)
 		if err != nil {
 			return fmt.Errorf("could not generate random secret for urlSigningSecret: %s", err)
 		}
-		thumbnailsTransferSecret, err = generators.GenerateRandomPassword(passwordLength)
+		thumbnailsTransferSecret, err = secretFromEnvOrRandom("THUMBNAILS_TRANSFER_SECRET", passwordLength)
 		if err != nil {
 			return fmt.Errorf("could not generate random password for thumbnailsTransferSecret: %s", err)
 		}
-		serviceAccountSecret, err = generators.GenerateRandomPassword(passwordLength)
+		serviceAccountSecret, err = secretFromEnvOrRandom("OC_SERVICE_ACCOUNT_SECRET", passwordLength)
 		if err != nil {
 			return fmt.Errorf("could not generate random secret for serviceAccountSecret: %s", err)
 		}


### PR DESCRIPTION
## Summary

`opencloud init` now checks for environment variables before generating random passwords for internal secrets. This is fully backward-compatible — when no ENV var is set, behavior is identical to today.

Closes #2483

## Changes

- `opencloud/pkg/init/functions.go`: add `secretFromEnvOrRandom` helper
- `opencloud/pkg/init/init.go`: use helper for all 12 generated secrets

## Motivation

In containerized deployments, pod restarts with an empty config directory generate new random secrets. The IDM service passwords written during init then no longer match what LDAP expects at runtime, causing bind failures and broken authentication.

This change lets orchestrators inject stable secrets via ENV vars, eliminating the need for config volume persistence.

## Supported ENV vars

`IDM_SVC_PASSWORD`, `IDM_REVASVC_PASSWORD`, `IDM_IDPSVC_PASSWORD`, `OC_ADMIN_PASSWORD`, `OC_JWT_SECRET`, `OC_MACHINE_AUTH_API_KEY`, `OC_TRANSFER_SECRET`, `OC_SERVICE_ACCOUNT_SECRET`, `COLLABORATION_WOPI_SECRET`, `SYSTEM_USER_API_KEY`, `OC_URL_SIGNING_SECRET`, `THUMBNAILS_TRANSFER_SECRET`

## Testing

- Built custom Docker image with this patch
- Deployed to Kubernetes with all 12 secrets injected via K8s Secrets → ENV vars
- Verified OIDC login, Graph API, WebDAV upload/download, PROPFIND — all pass
- **Restart resilience**: deleted pod, confirmed all auth and operations work after restart without config persistence