### PR TITLE
Always enable favorites, remove FRONTEND_ENABLE_FAVORITES flag

### DIFF
--- a/services/frontend/pkg/config/config.go
+++ b/services/frontend/pkg/config/config.go
@@ -25,7 +25,6 @@ type Config struct {
 
 	SkipUserGroupsInToken bool `yaml:"skip_user_groups_in_token" env:"FRONTEND_SKIP_USER_GROUPS_IN_TOKEN" desc:"Disables the loading of user's group memberships from the reva access token." introductionVersion:"1.0.0"`
 
-	EnableFavorites                bool   `yaml:"enable_favorites" env:"FRONTEND_ENABLE_FAVORITES" desc:"Enables the support for favorites in the clients." introductionVersion:"1.0.0"`
 	MaxQuota                       uint64 `yaml:"max_quota" env:"OC_SPACES_MAX_QUOTA;FRONTEND_MAX_QUOTA" desc:"Set the global max quota value in bytes. A value of 0 equals unlimited. The value is provided via capabilities." introductionVersion:"1.0.0"`
 	UploadMaxChunkSize             int    `yaml:"upload_max_chunk_size" env:"FRONTEND_UPLOAD_MAX_CHUNK_SIZE" desc:"Sets the max chunk sizes in bytes for uploads via the clients." introductionVersion:"1.0.0"`
 	UploadHTTPMethodOverride       string `yaml:"upload_http_method_override" env:"FRONTEND_UPLOAD_HTTP_METHOD_OVERRIDE" desc:"Advise TUS to replace PATCH requests by POST requests." introductionVersion:"1.0.0"`

--- a/services/frontend/pkg/config/defaults/defaultconfig.go
+++ b/services/frontend/pkg/config/defaults/defaultconfig.go
@@ -81,7 +81,6 @@ func DefaultConfig() *config.Config {
 		},
 		Reva:                     shared.DefaultRevaConfig(),
 		PublicURL:                "https://localhost:9200",
-		EnableFavorites:          false,
 		UploadMaxChunkSize:       1e+7,
 		UploadHTTPMethodOverride: "",
 		DefaultUploadProtocol:    "tus",

--- a/services/frontend/pkg/revaconfig/config.go
+++ b/services/frontend/pkg/revaconfig/config.go
@@ -63,7 +63,7 @@ func FrontendConfigFromStruct(cfg *config.Config, logger log.Logger) (map[string
 		"tags":              true,
 		"archivers":         archivers,
 		"app_providers":     appProviders,
-		"favorites":         cfg.EnableFavorites,
+		"favorites":         true,
 		"full_text_search":  cfg.FullTextSearch,
 	}
 


### PR DESCRIPTION
## Description
After #2454, favorites still arent' announced unless a feature flag is being set. From my understanding, this can be dropped in favor of just announcing the availabilty/capability of handling favorites?

## Related Issue
- See web issue tracker

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!-- Tick the checkboxes when done. -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added
