### PR TITLE
add final step for branch protection

### DIFF
--- a/.woodpecker.star
+++ b/.woodpecker.star
@@ -498,7 +498,8 @@ def main(ctx):
     is_release_pr = (ctx.build.event == "pull_request" and ctx.build.sender == "openclouders" and "🎉 release" in ctx.build.title.lower())
     if is_release_pr:
         return checkVersionPlaceholder() + \
-               licenseCheck(ctx)
+               licenseCheck(ctx) + \
+               notifyMatrixCheckSteps(ctx, getPipelineNames(licenseCheck(ctx) + checkVersionPlaceholder()))
 
     build_release_helpers = \
         readyReleaseGo()
@@ -569,7 +570,7 @@ def main(ctx):
         ),
     )
 
-    pipelines = test_pipelines + build_release_pipelines + genDocsPr(ctx) + notifyMatrixCheckSteps(ctx)
+    pipelines = test_pipelines + build_release_pipelines + genDocsPr(ctx) + notifyMatrixCheckSteps(ctx, getPipelineNames(testPipelines(ctx)))
 
     pipelineSanityChecks(pipelines)
     return savePipelineNumber(ctx) + pipelines
@@ -2283,12 +2284,12 @@ def genDocsPr(ctx):
         ],
     }]
 
-def notifyMatrixCheckSteps(ctx):
+def notifyMatrixCheckSteps(ctx, depends_on):
     result = [{
         "name": "all-checks-finished",
         "skip_clone": True,
         "runs_on": ["success", "failure"],
-        "depends_on": getPipelineNames(testPipelines(ctx)),
+        "depends_on": depends_on,
         "steps": [
             {
                 "name": "notify-matrix",

--- a/tests/acceptance/features/apiGraph/favorites.feature
+++ b/tests/acceptance/features/apiGraph/favorites.feature
@@ -273,7 +273,7 @@ Feature: favorites
       | permissionsRole | Viewer   |
     And user "Brian" has a share "parent" synced
     When user "Brian" marks folder "parent/sub" as favorite from space "Shares" using the Graph API
-    Then the HTTP status code should be "500"
+    Then the HTTP status code should be "201"
     And the JSON data of the response should match
       """
       {


### PR DESCRIPTION
related: https://github.com/opencloud-eu/qa/pull/81

<img width="847" height="85" alt="image" src="https://github.com/user-attachments/assets/23ec673e-ced2-4a17-b9e1-a3babbba79c8" />


Now the `all-check-finished` returns `exit(0)` if all tests pass, or `exit(1)` if any tests fail—we made this step required to protect the branch


