### PR TITLE
feat: add openFilesInNewTab web config option

### DIFF
--- a/services/web/pkg/config/options.go
+++ b/services/web/pkg/config/options.go
@@ -7,6 +7,7 @@ type Options struct {
 	FeedbackLink           *FeedbackLink       `json:"feedbackLink,omitempty" yaml:"feedbackLink"`
 	RunningOnEOS           bool                `json:"runningOnEos,omitempty" yaml:"runningOnEos" env:"WEB_OPTION_RUNNING_ON_EOS" desc:"Set this option to 'true' if running on an EOS storage backend (https://eos-web.web.cern.ch/eos-web/) to enable its specific features. Defaults to 'false'." introductionVersion:"1.0.0"`
 	CernFeatures           bool                `json:"cernFeatures,omitempty" yaml:"cernFeatures"`
+	OpenFilesInNewTab      bool                `json:"openFilesInNewTab,omitempty" yaml:"openFilesInNewTab" env:"WEB_OPTION_OPEN_FILES_IN_NEW_TAB" desc:"Set this option to 'true' to open files in a new browser tab instead of navigating in the same tab. Defaults to 'false'." introductionVersion:"5.3.0"`
 	Upload                 *Upload             `json:"upload,omitempty" yaml:"upload"`
 	Editor                 *Editor             `json:"editor,omitempty" yaml:"editor"`
 	ContextHelpersReadMore bool                `json:"contextHelpersReadMore,omitempty" yaml:"contextHelpersReadMore" env:"WEB_OPTION_CONTEXTHELPERS_READ_MORE" desc:"Specifies whether the 'Read more' link should be displayed or not." introductionVersion:"1.0.0"`


### PR DESCRIPTION
## Description

Adds server-side support for the new `openFilesInNewTab` web option, 
which allows users to configure files to open in a new browser tab instead 
of opening in the same tab.

Can be set via environment variable `WEB_OPTION_OPEN_FILES_IN_NEW_TAB=true` 
or in the web config YAML/JSON.

Related PR to the frontend change: https://github.com/opencloud-eu/web/pull/2218

## Related Issue

- Fixes https://github.com/opencloud-eu/web/issues/2174 (opened by me)

## Motivation and Context

The "open in new tab" behavior exists behind the `cernFeatures` 
flag, which includes several CERN-specific behaviors together. This change 
makes it as a standalone option so anyone can use it.

## How Has This Been Tested?

- Untested. Minimal addition of 1 line here, and change of 7 lines in web repo.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:

- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added