### PR TITLE
[full-ci] api-test: check that report contains favorites

### DIFF
--- a/tests/acceptance/features/apiContract/propfind.feature
+++ b/tests/acceptance/features/apiContract/propfind.feature
@@ -124,6 +124,7 @@ Feature: Propfind test
   @issue-1523
   Scenario: propfind response contains a restored folder with correct name
     Given user "Alice" has created a folder "folderMain" in space "Personal"
+    And user "Alice" has marked folder "folderMain" as favorite from space "Personal"
     And user "Alice" has deleted folder "folderMain"
     And user "Alice" has created a folder "folderMain" in space "Personal"
     When user "Alice" restores the folder with original path "/folderMain" to "/folderMain (1)" using the trashbin API
@@ -136,6 +137,7 @@ Feature: Propfind test
       | oc:name        | folderMain        |
       | oc:permissions | RDNVCKZP          |
       | oc:size        | 0                 |
+      | oc:favorite    | 0                 |
     And as user "Alice" the PROPFIND response should contain a resource "folderMain (1)" with these key and value pairs:
       | key            | value             |
       | oc:fileid      | %file_id_pattern% |
@@ -143,3 +145,4 @@ Feature: Propfind test
       | oc:name        | folderMain (1)    |
       | oc:permissions | RDNVCKZP          |
       | oc:size        | 0                 |
+      | oc:favorite    | 1                 |

--- a/tests/acceptance/features/apiContract/sharesReport.feature
+++ b/tests/acceptance/features/apiContract/sharesReport.feature
@@ -62,6 +62,7 @@ Feature: REPORT request to Shares space
       | oc:privatelink     | %base_url%/f/[0-9a-z-$%]+ |
       | d:getcontentlength | 34                        |
       | oc:remote-item-id  | %file_id_pattern%         |
+
     When user "Brian" searches for "testavatar.jpg" using the WebDAV API
     Then the HTTP status code should be "207"
     And the following headers should match these regular expressions

--- a/tests/acceptance/features/apiContract/spacesReport.feature
+++ b/tests/acceptance/features/apiContract/spacesReport.feature
@@ -15,6 +15,7 @@ Feature: REPORT request to project space
   @issue-10329
   Scenario: check the response of the searched file
     Given user "Alice" has uploaded a file inside space "findData" with content "some content" to "testFile.txt"
+    And user "Alice" has marked file "testFile.txt" as favorite from space "findData"
     When user "Alice" searches for "testFile.txt" using the WebDAV API
     Then the HTTP status code should be "207"
     And the search result of user "Alice" should contain only these entries:
@@ -30,6 +31,7 @@ Feature: REPORT request to project space
       | oc:permissions     | RDNVW                     |
       | oc:privatelink     | %base_url%/f/[0-9a-z-$%]+ |
       | d:getcontentlength | 12                        |
+      | oc:favorite        | 1                         |
 
   @issue-10329
   Scenario: check the response of the searched sub-file
@@ -54,6 +56,7 @@ Feature: REPORT request to project space
   @issue-10329
   Scenario: check the response of the searched folder
     Given user "Alice" has created a folder "folderMain" in space "findData"
+    And user "Alice" has marked folder "folderMain" as favorite from space "findData"
     When user "Alice" searches for "folderMain" using the WebDAV API
     Then the HTTP status code should be "207"
     And the search result of user "Alice" should contain only these entries:
@@ -69,6 +72,7 @@ Feature: REPORT request to project space
       | oc:permissions   | RDNVCK                    |
       | oc:privatelink   | %base_url%/f/[0-9a-z-$%]+ |
       | oc:size          | 0                         |
+      | oc:favorite      | 1                         |
 
   @issue-10329
   Scenario: check the response of the searched sub-folder


### PR DESCRIPTION
related https://github.com/opencloud-eu/opencloud/pull/2510

step: `And as user "Alice" folder/file "name" should be favorited` checks that Propfind has `<oc:favorite>1</oc:favorite>`

this PR adds checking that Report response contains`<oc:favorite>1</oc:favorite>` if file/folder marked as favorite or `<oc:favorite>0</oc:favorite>` if it's not favorite