### PR TITLE
ability to commit to release pr

### DIFF
--- a/.woodpecker.star
+++ b/.woodpecker.star
@@ -495,7 +495,7 @@ def main(ctx):
     if ctx.build.event == "cron" and ctx.build.sender == "translation-sync":
         return translation_sync(ctx)
 
-    is_release_pr = (ctx.build.event == "pull_request" and ctx.build.sender == "openclouders" and "🎉 release" in ctx.build.title.lower())
+    is_release_pr = (ctx.build.event == "pull_request" and "🎉 release" in ctx.build.title.lower())
     if is_release_pr:
         return checkVersionPlaceholder() + \
                licenseCheck(ctx) + \


### PR DESCRIPTION
after merging https://github.com/opencloud-eu/opencloud/pull/2547 - release PR was failed in CI
When I switched to `next-release/main` and rebased origin main this block didn't run
```
return checkVersionPlaceholder() + \
               licenseCheck(ctx) + \
               notifyMatrixCheckSteps(ctx, getPipelineNames(licenseCheck(ctx) + checkVersionPlaceholder()))
```
because `ctx.build.sender !== "openclouders"` and in the end `all-checks-finished` didn't start

I deleted  `ctx.build.sender == "openclouders"` to have more control