### PR TITLE
do not build daily on stable branch

### DIFF
--- a/.woodpecker.star
+++ b/.woodpecker.star
@@ -1920,7 +1920,6 @@ def dockerRelease(ctx, repo, build_type):
                 },
                 "when": [
                     event["cron"],
-                    event["base"],
                     event["tag"],
                 ],
             },


### PR DESCRIPTION
after merge https://github.com/opencloud-eu/opencloud/pull/2338 I got: 
- https://ci.opencloud.rocks/repos/3/pipeline/2515/120 ❌️ `opencloudeu/opencloud-rolling:daily` - we try to build production to `opencloud-rolling:daily`
- https://ci.opencloud.rocks/repos/3/pipeline/2516/33 - ✅️ correct build and push `opencloudeu/opencloud:4.0.4`

I removed `event["base"]` from `build-and-push`. `event["tag"]` should still work 

```
event = {
    "base": {
        "event": ["push", "manual"],
        "branch": "stable-*",
    },
```