### PR TITLE
fix version placeholder

### DIFF
--- a/.woodpecker.star
+++ b/.woodpecker.star
@@ -1827,7 +1827,7 @@ def checkVersionPlaceholder():
                 "name": "check-version-placeholder",
                 "image": OC_CI_ALPINE,
                 "commands": [
-                    "grep -r -e '%%NEXT%%' %s/services %s/pkg > next_version.txt" % (
+                    "grep -r -e '%%NEXT%%' %s/services %s/pkg > next_version.txt || true" % (
                         dirs["base"],
                         dirs["base"],
                     ),


### PR DESCRIPTION
see https://ci.opencloud.rocks/repos/3/pipeline/2537/14 
when we don't grep `'%NEXT%'` -> we get exit 1

correct logic: 
- grep always return true
- if file `next_version.txt` is not empty(we found '%NEXT%) -> then exit 1 (fail)