### PR TITLE
adapt pipeline for prod releases

### DIFF
--- a/.woodpecker.star
+++ b/.woodpecker.star
@@ -1838,7 +1838,7 @@ def checkVersionPlaceholder():
         "when": [
             event["pull_request"],
         ],
-    },{
+    }, {
         "name": "check-version-placeholder-next-production-release",
         "steps": [
             {
@@ -1850,14 +1850,14 @@ def checkVersionPlaceholder():
                         dirs["base"],
                     ),
                     'if [ -s next_production_version.txt ]; then echo "replace version placeholders"; cat next_production_version.txt; exit 1; fi',
-                    ],
+                ],
             },
         ],
         "when": [
             {
-               "event": "pull_request",
-               "evaluate": 'CI_COMMIT_PULL_REQUEST_LABELS contains "production_release"',
-            }
+                "event": "pull_request",
+                "evaluate": 'CI_COMMIT_PULL_REQUEST_LABELS contains "production_release"',
+            },
         ],
     }]
 


### PR DESCRIPTION
This PR splits the check_version pipeline into two steps, the step for detecting leftover `%%NEXT_PRODUCTION_VERSION%%`  placeholders only is run when the label `production_release` is set for the PR.

/cc @ScharfViktor && @individual-it 