### PR TITLE
feat: enable EnableInsertRemoteFile WOPI flag for Collabora

### DIFF
--- a/services/collaboration/pkg/connector/fileconnector.go
+++ b/services/collaboration/pkg/connector/fileconnector.go
@@ -1267,6 +1267,7 @@ func (f *FileConnector) CheckFileInfo(ctx context.Context) (*ConnectorResponse, 
 
 		fileinfo.KeyEnableOwnerTermination:     true, // only for collabora
 		fileinfo.KeyEnableInsertRemoteImage:    true,
+		fileinfo.KeyEnableInsertRemoteFile:     true,
 		fileinfo.KeySupportsExtendedLockLength: true,
 		fileinfo.KeySupportsGetLock:            true,
 		fileinfo.KeySupportsLocks:              true,

--- a/services/collaboration/pkg/connector/fileconnector_test.go
+++ b/services/collaboration/pkg/connector/fileconnector_test.go
@@ -1801,6 +1801,7 @@ var _ = Describe("FileConnector", func() {
 				BreadcrumbDocName:       "test.txt",
 				PostMessageOrigin:       "https://cloud.opencloud.test",
 				EnableInsertRemoteImage: true,
+				EnableInsertRemoteFile:  true,
 				IsAnonymousUser:         true,
 			}
 
@@ -1993,6 +1994,7 @@ var _ = Describe("FileConnector", func() {
 				BreadcrumbDocName:       "test.txt",
 				PostMessageOrigin:       "https://cloud.opencloud.test",
 				EnableInsertRemoteImage: true,
+				EnableInsertRemoteFile:  true,
 				IsAdminUser:             true,
 			}
 

--- a/services/collaboration/pkg/connector/fileinfo/collabora.go
+++ b/services/collaboration/pkg/connector/fileinfo/collabora.go
@@ -36,6 +36,8 @@ type Collabora struct {
 
 	// If set to true, this will enable the insertion of images chosen from the WOPI storage. A UI_InsertGraphic postMessage will be send to the WOPI host to request the UI to select the file.
 	EnableInsertRemoteImage bool `json:"EnableInsertRemoteImage,omitempty"`
+	// If set to true, this will enable the insertion of remote files chosen from the WOPI storage. A UI_InsertFile postMessage will be sent to the WOPI host to request the UI to select the file. This enables multimedia insertion and document comparison features.
+	EnableInsertRemoteFile bool `json:"EnableInsertRemoteFile,omitempty"`
 	// If set to true, this will disable the insertion of image chosen from the local device. If EnableInsertRemoteImage is not set to true, then inserting images files is not possible.
 	DisableInsertLocalImage bool `json:"DisableInsertLocalImage,omitempty"`
 	// If set to true, hides the print option from the file menu bar in the UI.
@@ -111,6 +113,8 @@ func (cinfo *Collabora) SetProperties(props map[string]interface{}) {
 
 		case KeyEnableInsertRemoteImage:
 			cinfo.EnableInsertRemoteImage = value.(bool)
+		case KeyEnableInsertRemoteFile:
+			cinfo.EnableInsertRemoteFile = value.(bool)
 		case KeyDisableInsertLocalImage:
 			cinfo.DisableInsertLocalImage = value.(bool)
 		case KeyHidePrintOption:

--- a/services/collaboration/pkg/connector/fileinfo/fileinfo.go
+++ b/services/collaboration/pkg/connector/fileinfo/fileinfo.go
@@ -103,6 +103,7 @@ const (
 	KeyTemplateSource    = "TemplateSource"
 
 	KeyEnableInsertRemoteImage = "EnableInsertRemoteImage"
+	KeyEnableInsertRemoteFile  = "EnableInsertRemoteFile"
 	KeyDisableInsertLocalImage = "DisableInsertLocalImage"
 	KeyHidePrintOption         = "HidePrintOption"
 	KeyHideSaveOption          = "HideSaveOption"


### PR DESCRIPTION
Set EnableInsertRemoteFile: true in CheckFileInfo response so Collabora
shows "Insert Multimedia" and "Compare Document" menu entries. This
triggers UI_InsertFile postMessages to the WOPI host, following the same
pattern as the existing EnableInsertRemoteImage flag.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>


## Screenshots (if appropriate):

<img width="1820" height="756" alt="opencloud-compare-documents" src="https://github.com/user-attachments/assets/c0b466ad-609c-4fc4-bcc7-ef99238d96b0" />
