### PR TITLE
chore(web): bump web to v4.2.2

### DIFF
--- a/.woodpecker.env
+++ b/.woodpecker.env
@@ -1,4 +1,4 @@
 # The test runner source for UI tests
-WEB_COMMITID=50e3fff6a518361d59cba864a927470f313b6f91
+WEB_COMMITID=c247f854a95b7bcaf10f27577458d2f566b2f939
 WEB_BRANCH=stable-4.2
 

--- a/services/web/Makefile
+++ b/services/web/Makefile
@@ -1,6 +1,6 @@
 SHELL := bash
 NAME := web
-WEB_ASSETS_VERSION = v4.2.1
+WEB_ASSETS_VERSION = v4.2.2
 WEB_ASSETS_BRANCH = main
 
 ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI


### PR DESCRIPTION
## [4.2.2](https://github.com/opencloud-eu/web/releases/tag/v4.2.2) - 2026-04-07

### ❤️ Thanks to all contributors! ❤️

@AlexAndBear, @JammingBen, @ScharfViktor, @kulmann, @prashant-gurung899

### 🔒 Security

- chore: bump lodash-es to v4.18.1 [[#2292](https://github.com/opencloud-eu/web/pull/2292)]
- chore(deps): bump markdown-it to v4.1.1 [security] [[#1985](https://github.com/opencloud-eu/web/pull/1985)]
- chore(deps): bump qs to v6.14.2 [security] [[#1986](https://github.com/opencloud-eu/web/pull/1986)]
- chore(deps): update dependency fast-xml-parser to v5 [security] [[#1918](https://github.com/opencloud-eu/web/pull/1918)]
- chore(deps): bump @isaacs/brace-expansion to v5.0.1 [security] [[#1930](https://github.com/opencloud-eu/web/pull/1930)]
- fix(deps): update dependency lodash-es to v4.17.23 [security] [[#1858](https://github.com/opencloud-eu/web/pull/1858)]
- chore(deps): bump preact to v10.28.2 [security] [[#1824](https://github.com/opencloud-eu/web/pull/1824)]
- chore(deps): bump qs to v6.14.1 [security] [[#1813](https://github.com/opencloud-eu/web/pull/1813)]

### 🐛 Bug Fixes

- fix: faulty french translation for 'copy link and password' results i… [[#2061](https://github.com/opencloud-eu/web/pull/2061)]
- [stable-4.2] fix: backchannel logout react to sid (#1969) [[#2060](https://github.com/opencloud-eu/web/pull/2060)]

### ✅ Tests

- port https://github.com/opencloud-eu/web/pull/2051 [[#2056](https://github.com/opencloud-eu/web/pull/2056)]
- [stable-4.2] Port https://github.com/opencloud-eu/web/pull/1714, https://github.com/opencloud-eu/web/pull/1736 and https://github.com/opencloud-eu/web/pull/1700 [[#1738](https://github.com/opencloud-eu/web/pull/1738)]
- [stable-4.2] e2e-tests. undo deleted resources (https://github.com/opencloud-eu/web/pull/1580) [[#1704](https://github.com/opencloud-eu/web/pull/1704)]

### 📦️ Dependencies

- [stable-4.2] update-playwright-1.57 (#1709) [[#1710](https://github.com/opencloud-eu/web/pull/1710)]