### PR TITLE
enhancement: increase display size of graph flow diagram

### DIFF
--- a/services/graph/README.md
+++ b/services/graph/README.md
@@ -9,7 +9,7 @@ for a detailed specification of the API implemented by the graph service.
 
 The following image gives an overview of the scenario when a client requests to list available spaces the user has access to. To do so, the client is directed with his request automatically via the proxy service to the graph service.
 
-<img src="https://raw.githubusercontent.com/opencloud-eu/opencloud/main/services/graph/images/mermaid-graph.svg" width="500" />
+<img src="https://raw.githubusercontent.com/opencloud-eu/opencloud/main/services/graph/images/mermaid-graph.svg" width="900" />
 
 ## Users and Groups API
 


### PR DESCRIPTION
## Description
The current size of the graph service' flow diagram is quite small and requires resizing the whole browser page being able to see details.

## Related Issue
I have not created a dedicated bug.

## Motivation and Context
More convenience while reading the documentation.

## How Has This Been Tested?
- checked in .md file preview
- also checked in rendered and built documentation on docs repo (via _static files)
 
## Screenshots (if appropriate):

Before:

<img width="1229" height="803" alt="before" src="https://github.com/user-attachments/assets/21ec6bf2-fa3e-4b09-808f-d386582c4986" />

After:

<img width="1270" height="1015" alt="after" src="https://github.com/user-attachments/assets/72853545-7c7e-48f1-a471-27e168657552" />

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)
