### PR TITLE
feat(kql): support dotted keys in property restrictions

### DIFF
--- a/pkg/kql/dictionary.peg
+++ b/pkg/kql/dictionary.peg
@@ -29,7 +29,7 @@ Node <-
 ////////////////////////////////////////////////////////
 
 GroupNode <-
-    k:(Char+)? (OperatorColonNode / OperatorEqualNode)? "(" v:Nodes ")" {
+    k:Key? (OperatorColonNode / OperatorEqualNode)? "(" v:Nodes ")" {
         return buildGroupNode(k, v, c.text, c.pos)
     }
 
@@ -43,12 +43,12 @@ PropertyRestrictionNodes <-
     TextPropertyRestrictionNode
 
 YesNoPropertyRestrictionNode <-
-    k:Char+ (OperatorColonNode / OperatorEqualNode) v:("true" / "false"){
+    k:Key (OperatorColonNode / OperatorEqualNode) v:("true" / "false"){
         return buildBooleanNode(k, v, c.text, c.pos)
     }
 
 DateTimeRestrictionNode <-
-    k:Char+ o:(
+    k:Key o:(
         OperatorGreaterOrEqualNode /
         OperatorLessOrEqualNode /
         OperatorGreaterNode /
@@ -62,7 +62,7 @@ DateTimeRestrictionNode <-
     ) '"'? {
         return buildDateTimeNode(k, o, v, c.text, c.pos)
     } /
-    k:Char+ (
+    k:Key (
         OperatorEqualNode /
         OperatorColonNode
     ) '"'? v:NaturalLanguageDateTime '"'? {
@@ -70,7 +70,7 @@ DateTimeRestrictionNode <-
     }
 
 TextPropertyRestrictionNode <-
-    k:Char+ (OperatorColonNode / OperatorEqualNode) v:(String / [^ ()]+){
+    k:Key (OperatorColonNode / OperatorEqualNode) v:(String / [^ ()]+){
         return buildStringNode(k, v, c.text, c.pos)
     }
 
@@ -216,6 +216,11 @@ NaturalLanguageDateTime  <-
 
 Char <-
     [A-Za-z] {
+        return c.text, nil
+    }
+
+Key <-
+    Char+ ("." Char+)* {
         return c.text, nil
     }
 

--- a/pkg/kql/dictionary_gen.go
+++ b/pkg/kql/dictionary_gen.go
@@ -43,12 +43,12 @@ var g = &grammar{
 					pos: position{line: 19, col: 6, offset: 351},
 					exprs: []any{
 						&actionExpr{
-							pos: position{line: 233, col: 5, offset: 4804},
+							pos: position{line: 238, col: 5, offset: 4858},
 							run: (*parser).callonNodes3,
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 233, col: 5, offset: 4804},
+								pos: position{line: 238, col: 5, offset: 4858},
 								expr: &charClassMatcher{
-									pos:        position{line: 233, col: 5, offset: 4804},
+									pos:        position{line: 238, col: 5, offset: 4858},
 									val:        "[ \\t]",
 									chars:      []rune{' ', '\t'},
 									ignoreCase: false,
@@ -75,47 +75,84 @@ var g = &grammar{
 						name: "GroupNode",
 					},
 					&actionExpr{
-						pos: position{line: 46, col: 5, offset: 1042},
+						pos: position{line: 46, col: 5, offset: 1038},
 						run: (*parser).callonNode3,
 						expr: &seqExpr{
-							pos: position{line: 46, col: 5, offset: 1042},
+							pos: position{line: 46, col: 5, offset: 1038},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 46, col: 5, offset: 1042},
+									pos:   position{line: 46, col: 5, offset: 1038},
 									label: "k",
-									expr: &oneOrMoreExpr{
-										pos: position{line: 46, col: 7, offset: 1044},
-										expr: &actionExpr{
-											pos: position{line: 218, col: 5, offset: 4634},
-											run: (*parser).callonNode7,
-											expr: &charClassMatcher{
-												pos:        position{line: 218, col: 5, offset: 4634},
-												val:        "[A-Za-z]",
-												ranges:     []rune{'A', 'Z', 'a', 'z'},
-												ignoreCase: false,
-												inverted:   false,
+									expr: &actionExpr{
+										pos: position{line: 223, col: 5, offset: 4678},
+										run: (*parser).callonNode6,
+										expr: &seqExpr{
+											pos: position{line: 223, col: 5, offset: 4678},
+											exprs: []any{
+												&oneOrMoreExpr{
+													pos: position{line: 223, col: 5, offset: 4678},
+													expr: &actionExpr{
+														pos: position{line: 218, col: 5, offset: 4622},
+														run: (*parser).callonNode9,
+														expr: &charClassMatcher{
+															pos:        position{line: 218, col: 5, offset: 4622},
+															val:        "[A-Za-z]",
+															ranges:     []rune{'A', 'Z', 'a', 'z'},
+															ignoreCase: false,
+															inverted:   false,
+														},
+													},
+												},
+												&zeroOrMoreExpr{
+													pos: position{line: 223, col: 11, offset: 4684},
+													expr: &seqExpr{
+														pos: position{line: 223, col: 12, offset: 4685},
+														exprs: []any{
+															&litMatcher{
+																pos:        position{line: 223, col: 12, offset: 4685},
+																val:        ".",
+																ignoreCase: false,
+																want:       "\".\"",
+															},
+															&oneOrMoreExpr{
+																pos: position{line: 223, col: 16, offset: 4689},
+																expr: &actionExpr{
+																	pos: position{line: 218, col: 5, offset: 4622},
+																	run: (*parser).callonNode15,
+																	expr: &charClassMatcher{
+																		pos:        position{line: 218, col: 5, offset: 4622},
+																		val:        "[A-Za-z]",
+																		ranges:     []rune{'A', 'Z', 'a', 'z'},
+																		ignoreCase: false,
+																		inverted:   false,
+																	},
+																},
+															},
+														},
+													},
+												},
 											},
 										},
 									},
 								},
 								&choiceExpr{
-									pos: position{line: 46, col: 14, offset: 1051},
+									pos: position{line: 46, col: 12, offset: 1045},
 									alternatives: []any{
 										&actionExpr{
-											pos: position{line: 120, col: 5, offset: 2911},
-											run: (*parser).callonNode10,
+											pos: position{line: 120, col: 5, offset: 2899},
+											run: (*parser).callonNode18,
 											expr: &litMatcher{
-												pos:        position{line: 120, col: 5, offset: 2911},
+												pos:        position{line: 120, col: 5, offset: 2899},
 												val:        ":",
 												ignoreCase: false,
 												want:       "\":\"",
 											},
 										},
 										&actionExpr{
-											pos: position{line: 125, col: 5, offset: 2997},
-											run: (*parser).callonNode12,
+											pos: position{line: 125, col: 5, offset: 2985},
+											run: (*parser).callonNode20,
 											expr: &litMatcher{
-												pos:        position{line: 125, col: 5, offset: 2997},
+												pos:        position{line: 125, col: 5, offset: 2985},
 												val:        "=",
 												ignoreCase: false,
 												want:       "\"=\"",
@@ -124,19 +161,19 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 46, col: 53, offset: 1090},
+									pos:   position{line: 46, col: 51, offset: 1084},
 									label: "v",
 									expr: &choiceExpr{
-										pos: position{line: 46, col: 56, offset: 1093},
+										pos: position{line: 46, col: 54, offset: 1087},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 46, col: 56, offset: 1093},
+												pos:        position{line: 46, col: 54, offset: 1087},
 												val:        "true",
 												ignoreCase: false,
 												want:       "\"true\"",
 											},
 											&litMatcher{
-												pos:        position{line: 46, col: 65, offset: 1102},
+												pos:        position{line: 46, col: 63, offset: 1096},
 												val:        "false",
 												ignoreCase: false,
 												want:       "\"false\"",
@@ -148,90 +185,127 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 51, col: 5, offset: 1203},
-						run: (*parser).callonNode18,
+						pos: position{line: 51, col: 5, offset: 1197},
+						run: (*parser).callonNode26,
 						expr: &seqExpr{
-							pos: position{line: 51, col: 5, offset: 1203},
+							pos: position{line: 51, col: 5, offset: 1197},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 51, col: 5, offset: 1203},
+									pos:   position{line: 51, col: 5, offset: 1197},
 									label: "k",
-									expr: &oneOrMoreExpr{
-										pos: position{line: 51, col: 7, offset: 1205},
-										expr: &actionExpr{
-											pos: position{line: 218, col: 5, offset: 4634},
-											run: (*parser).callonNode22,
-											expr: &charClassMatcher{
-												pos:        position{line: 218, col: 5, offset: 4634},
-												val:        "[A-Za-z]",
-												ranges:     []rune{'A', 'Z', 'a', 'z'},
-												ignoreCase: false,
-												inverted:   false,
+									expr: &actionExpr{
+										pos: position{line: 223, col: 5, offset: 4678},
+										run: (*parser).callonNode29,
+										expr: &seqExpr{
+											pos: position{line: 223, col: 5, offset: 4678},
+											exprs: []any{
+												&oneOrMoreExpr{
+													pos: position{line: 223, col: 5, offset: 4678},
+													expr: &actionExpr{
+														pos: position{line: 218, col: 5, offset: 4622},
+														run: (*parser).callonNode32,
+														expr: &charClassMatcher{
+															pos:        position{line: 218, col: 5, offset: 4622},
+															val:        "[A-Za-z]",
+															ranges:     []rune{'A', 'Z', 'a', 'z'},
+															ignoreCase: false,
+															inverted:   false,
+														},
+													},
+												},
+												&zeroOrMoreExpr{
+													pos: position{line: 223, col: 11, offset: 4684},
+													expr: &seqExpr{
+														pos: position{line: 223, col: 12, offset: 4685},
+														exprs: []any{
+															&litMatcher{
+																pos:        position{line: 223, col: 12, offset: 4685},
+																val:        ".",
+																ignoreCase: false,
+																want:       "\".\"",
+															},
+															&oneOrMoreExpr{
+																pos: position{line: 223, col: 16, offset: 4689},
+																expr: &actionExpr{
+																	pos: position{line: 218, col: 5, offset: 4622},
+																	run: (*parser).callonNode38,
+																	expr: &charClassMatcher{
+																		pos:        position{line: 218, col: 5, offset: 4622},
+																		val:        "[A-Za-z]",
+																		ranges:     []rune{'A', 'Z', 'a', 'z'},
+																		ignoreCase: false,
+																		inverted:   false,
+																	},
+																},
+															},
+														},
+													},
+												},
 											},
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 51, col: 13, offset: 1211},
+									pos:   position{line: 51, col: 11, offset: 1203},
 									label: "o",
 									expr: &choiceExpr{
-										pos: position{line: 52, col: 9, offset: 1223},
+										pos: position{line: 52, col: 9, offset: 1215},
 										alternatives: []any{
 											&actionExpr{
-												pos: position{line: 145, col: 5, offset: 3358},
-												run: (*parser).callonNode26,
+												pos: position{line: 145, col: 5, offset: 3346},
+												run: (*parser).callonNode42,
 												expr: &litMatcher{
-													pos:        position{line: 145, col: 5, offset: 3358},
+													pos:        position{line: 145, col: 5, offset: 3346},
 													val:        ">=",
 													ignoreCase: false,
 													want:       "\">=\"",
 												},
 											},
 											&actionExpr{
-												pos: position{line: 135, col: 5, offset: 3174},
-												run: (*parser).callonNode28,
+												pos: position{line: 135, col: 5, offset: 3162},
+												run: (*parser).callonNode44,
 												expr: &litMatcher{
-													pos:        position{line: 135, col: 5, offset: 3174},
+													pos:        position{line: 135, col: 5, offset: 3162},
 													val:        "<=",
 													ignoreCase: false,
 													want:       "\"<=\"",
 												},
 											},
 											&actionExpr{
-												pos: position{line: 140, col: 5, offset: 3263},
-												run: (*parser).callonNode30,
+												pos: position{line: 140, col: 5, offset: 3251},
+												run: (*parser).callonNode46,
 												expr: &litMatcher{
-													pos:        position{line: 140, col: 5, offset: 3263},
+													pos:        position{line: 140, col: 5, offset: 3251},
 													val:        ">",
 													ignoreCase: false,
 													want:       "\">\"",
 												},
 											},
 											&actionExpr{
-												pos: position{line: 130, col: 5, offset: 3082},
-												run: (*parser).callonNode32,
+												pos: position{line: 130, col: 5, offset: 3070},
+												run: (*parser).callonNode48,
 												expr: &litMatcher{
-													pos:        position{line: 130, col: 5, offset: 3082},
+													pos:        position{line: 130, col: 5, offset: 3070},
 													val:        "<",
 													ignoreCase: false,
 													want:       "\"<\"",
 												},
 											},
 											&actionExpr{
-												pos: position{line: 125, col: 5, offset: 2997},
-												run: (*parser).callonNode34,
+												pos: position{line: 125, col: 5, offset: 2985},
+												run: (*parser).callonNode50,
 												expr: &litMatcher{
-													pos:        position{line: 125, col: 5, offset: 2997},
+													pos:        position{line: 125, col: 5, offset: 2985},
 													val:        "=",
 													ignoreCase: false,
 													want:       "\"=\"",
 												},
 											},
 											&actionExpr{
-												pos: position{line: 120, col: 5, offset: 2911},
-												run: (*parser).callonNode36,
+												pos: position{line: 120, col: 5, offset: 2899},
+												run: (*parser).callonNode52,
 												expr: &litMatcher{
-													pos:        position{line: 120, col: 5, offset: 2911},
+													pos:        position{line: 120, col: 5, offset: 2899},
 													val:        ":",
 													ignoreCase: false,
 													want:       "\":\"",
@@ -241,43 +315,43 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 58, col: 7, offset: 1403},
+									pos: position{line: 58, col: 7, offset: 1395},
 									expr: &litMatcher{
-										pos:        position{line: 58, col: 7, offset: 1403},
+										pos:        position{line: 58, col: 7, offset: 1395},
 										val:        "\"",
 										ignoreCase: false,
 										want:       "\"\\\"\"",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 58, col: 12, offset: 1408},
+									pos:   position{line: 58, col: 12, offset: 1400},
 									label: "v",
 									expr: &choiceExpr{
-										pos: position{line: 59, col: 9, offset: 1420},
+										pos: position{line: 59, col: 9, offset: 1412},
 										alternatives: []any{
 											&actionExpr{
-												pos: position{line: 195, col: 5, offset: 4197},
-												run: (*parser).callonNode42,
+												pos: position{line: 195, col: 5, offset: 4185},
+												run: (*parser).callonNode58,
 												expr: &seqExpr{
-													pos: position{line: 195, col: 5, offset: 4197},
+													pos: position{line: 195, col: 5, offset: 4185},
 													exprs: []any{
 														&actionExpr{
-															pos: position{line: 185, col: 5, offset: 3960},
-															run: (*parser).callonNode44,
+															pos: position{line: 185, col: 5, offset: 3948},
+															run: (*parser).callonNode60,
 															expr: &seqExpr{
-																pos: position{line: 185, col: 5, offset: 3960},
+																pos: position{line: 185, col: 5, offset: 3948},
 																exprs: []any{
 																	&actionExpr{
-																		pos: position{line: 155, col: 5, offset: 3560},
-																		run: (*parser).callonNode46,
+																		pos: position{line: 155, col: 5, offset: 3548},
+																		run: (*parser).callonNode62,
 																		expr: &seqExpr{
-																			pos: position{line: 155, col: 5, offset: 3560},
+																			pos: position{line: 155, col: 5, offset: 3548},
 																			exprs: []any{
 																				&actionExpr{
-																					pos: position{line: 228, col: 5, offset: 4753},
-																					run: (*parser).callonNode48,
+																					pos: position{line: 233, col: 5, offset: 4807},
+																					run: (*parser).callonNode64,
 																					expr: &charClassMatcher{
-																						pos:        position{line: 228, col: 5, offset: 4753},
+																						pos:        position{line: 233, col: 5, offset: 4807},
 																						val:        "[0-9]",
 																						ranges:     []rune{'0', '9'},
 																						ignoreCase: false,
@@ -285,95 +359,10 @@ var g = &grammar{
 																					},
 																				},
 																				&actionExpr{
-																					pos: position{line: 228, col: 5, offset: 4753},
-																					run: (*parser).callonNode50,
-																					expr: &charClassMatcher{
-																						pos:        position{line: 228, col: 5, offset: 4753},
-																						val:        "[0-9]",
-																						ranges:     []rune{'0', '9'},
-																						ignoreCase: false,
-																						inverted:   false,
-																					},
-																				},
-																				&actionExpr{
-																					pos: position{line: 228, col: 5, offset: 4753},
-																					run: (*parser).callonNode52,
-																					expr: &charClassMatcher{
-																						pos:        position{line: 228, col: 5, offset: 4753},
-																						val:        "[0-9]",
-																						ranges:     []rune{'0', '9'},
-																						ignoreCase: false,
-																						inverted:   false,
-																					},
-																				},
-																				&actionExpr{
-																					pos: position{line: 228, col: 5, offset: 4753},
-																					run: (*parser).callonNode54,
-																					expr: &charClassMatcher{
-																						pos:        position{line: 228, col: 5, offset: 4753},
-																						val:        "[0-9]",
-																						ranges:     []rune{'0', '9'},
-																						ignoreCase: false,
-																						inverted:   false,
-																					},
-																				},
-																			},
-																		},
-																	},
-																	&litMatcher{
-																		pos:        position{line: 185, col: 14, offset: 3969},
-																		val:        "-",
-																		ignoreCase: false,
-																		want:       "\"-\"",
-																	},
-																	&actionExpr{
-																		pos: position{line: 160, col: 5, offset: 3637},
-																		run: (*parser).callonNode57,
-																		expr: &seqExpr{
-																			pos: position{line: 160, col: 5, offset: 3637},
-																			exprs: []any{
-																				&actionExpr{
-																					pos: position{line: 228, col: 5, offset: 4753},
-																					run: (*parser).callonNode59,
-																					expr: &charClassMatcher{
-																						pos:        position{line: 228, col: 5, offset: 4753},
-																						val:        "[0-9]",
-																						ranges:     []rune{'0', '9'},
-																						ignoreCase: false,
-																						inverted:   false,
-																					},
-																				},
-																				&actionExpr{
-																					pos: position{line: 228, col: 5, offset: 4753},
-																					run: (*parser).callonNode61,
-																					expr: &charClassMatcher{
-																						pos:        position{line: 228, col: 5, offset: 4753},
-																						val:        "[0-9]",
-																						ranges:     []rune{'0', '9'},
-																						ignoreCase: false,
-																						inverted:   false,
-																					},
-																				},
-																			},
-																		},
-																	},
-																	&litMatcher{
-																		pos:        position{line: 185, col: 28, offset: 3983},
-																		val:        "-",
-																		ignoreCase: false,
-																		want:       "\"-\"",
-																	},
-																	&actionExpr{
-																		pos: position{line: 165, col: 5, offset: 3700},
-																		run: (*parser).callonNode64,
-																		expr: &seqExpr{
-																			pos: position{line: 165, col: 5, offset: 3700},
-																			exprs: []any{
-																				&actionExpr{
-																					pos: position{line: 228, col: 5, offset: 4753},
+																					pos: position{line: 233, col: 5, offset: 4807},
 																					run: (*parser).callonNode66,
 																					expr: &charClassMatcher{
-																						pos:        position{line: 228, col: 5, offset: 4753},
+																						pos:        position{line: 233, col: 5, offset: 4807},
 																						val:        "[0-9]",
 																						ranges:     []rune{'0', '9'},
 																						ignoreCase: false,
@@ -381,10 +370,95 @@ var g = &grammar{
 																					},
 																				},
 																				&actionExpr{
-																					pos: position{line: 228, col: 5, offset: 4753},
+																					pos: position{line: 233, col: 5, offset: 4807},
 																					run: (*parser).callonNode68,
 																					expr: &charClassMatcher{
-																						pos:        position{line: 228, col: 5, offset: 4753},
+																						pos:        position{line: 233, col: 5, offset: 4807},
+																						val:        "[0-9]",
+																						ranges:     []rune{'0', '9'},
+																						ignoreCase: false,
+																						inverted:   false,
+																					},
+																				},
+																				&actionExpr{
+																					pos: position{line: 233, col: 5, offset: 4807},
+																					run: (*parser).callonNode70,
+																					expr: &charClassMatcher{
+																						pos:        position{line: 233, col: 5, offset: 4807},
+																						val:        "[0-9]",
+																						ranges:     []rune{'0', '9'},
+																						ignoreCase: false,
+																						inverted:   false,
+																					},
+																				},
+																			},
+																		},
+																	},
+																	&litMatcher{
+																		pos:        position{line: 185, col: 14, offset: 3957},
+																		val:        "-",
+																		ignoreCase: false,
+																		want:       "\"-\"",
+																	},
+																	&actionExpr{
+																		pos: position{line: 160, col: 5, offset: 3625},
+																		run: (*parser).callonNode73,
+																		expr: &seqExpr{
+																			pos: position{line: 160, col: 5, offset: 3625},
+																			exprs: []any{
+																				&actionExpr{
+																					pos: position{line: 233, col: 5, offset: 4807},
+																					run: (*parser).callonNode75,
+																					expr: &charClassMatcher{
+																						pos:        position{line: 233, col: 5, offset: 4807},
+																						val:        "[0-9]",
+																						ranges:     []rune{'0', '9'},
+																						ignoreCase: false,
+																						inverted:   false,
+																					},
+																				},
+																				&actionExpr{
+																					pos: position{line: 233, col: 5, offset: 4807},
+																					run: (*parser).callonNode77,
+																					expr: &charClassMatcher{
+																						pos:        position{line: 233, col: 5, offset: 4807},
+																						val:        "[0-9]",
+																						ranges:     []rune{'0', '9'},
+																						ignoreCase: false,
+																						inverted:   false,
+																					},
+																				},
+																			},
+																		},
+																	},
+																	&litMatcher{
+																		pos:        position{line: 185, col: 28, offset: 3971},
+																		val:        "-",
+																		ignoreCase: false,
+																		want:       "\"-\"",
+																	},
+																	&actionExpr{
+																		pos: position{line: 165, col: 5, offset: 3688},
+																		run: (*parser).callonNode80,
+																		expr: &seqExpr{
+																			pos: position{line: 165, col: 5, offset: 3688},
+																			exprs: []any{
+																				&actionExpr{
+																					pos: position{line: 233, col: 5, offset: 4807},
+																					run: (*parser).callonNode82,
+																					expr: &charClassMatcher{
+																						pos:        position{line: 233, col: 5, offset: 4807},
+																						val:        "[0-9]",
+																						ranges:     []rune{'0', '9'},
+																						ignoreCase: false,
+																						inverted:   false,
+																					},
+																				},
+																				&actionExpr{
+																					pos: position{line: 233, col: 5, offset: 4807},
+																					run: (*parser).callonNode84,
+																					expr: &charClassMatcher{
+																						pos:        position{line: 233, col: 5, offset: 4807},
 																						val:        "[0-9]",
 																						ranges:     []rune{'0', '9'},
 																						ignoreCase: false,
@@ -398,113 +472,113 @@ var g = &grammar{
 															},
 														},
 														&litMatcher{
-															pos:        position{line: 195, col: 14, offset: 4206},
+															pos:        position{line: 195, col: 14, offset: 4194},
 															val:        "T",
 															ignoreCase: false,
 															want:       "\"T\"",
 														},
 														&actionExpr{
-															pos: position{line: 190, col: 5, offset: 4047},
-															run: (*parser).callonNode71,
+															pos: position{line: 190, col: 5, offset: 4035},
+															run: (*parser).callonNode87,
 															expr: &seqExpr{
-																pos: position{line: 190, col: 5, offset: 4047},
+																pos: position{line: 190, col: 5, offset: 4035},
 																exprs: []any{
 																	&actionExpr{
-																		pos: position{line: 170, col: 5, offset: 3764},
-																		run: (*parser).callonNode73,
+																		pos: position{line: 170, col: 5, offset: 3752},
+																		run: (*parser).callonNode89,
 																		expr: &seqExpr{
-																			pos: position{line: 170, col: 5, offset: 3764},
+																			pos: position{line: 170, col: 5, offset: 3752},
 																			exprs: []any{
 																				&actionExpr{
-																					pos: position{line: 228, col: 5, offset: 4753},
-																					run: (*parser).callonNode75,
-																					expr: &charClassMatcher{
-																						pos:        position{line: 228, col: 5, offset: 4753},
-																						val:        "[0-9]",
-																						ranges:     []rune{'0', '9'},
-																						ignoreCase: false,
-																						inverted:   false,
-																					},
-																				},
-																				&actionExpr{
-																					pos: position{line: 228, col: 5, offset: 4753},
-																					run: (*parser).callonNode77,
-																					expr: &charClassMatcher{
-																						pos:        position{line: 228, col: 5, offset: 4753},
-																						val:        "[0-9]",
-																						ranges:     []rune{'0', '9'},
-																						ignoreCase: false,
-																						inverted:   false,
-																					},
-																				},
-																			},
-																		},
-																	},
-																	&litMatcher{
-																		pos:        position{line: 190, col: 14, offset: 4056},
-																		val:        ":",
-																		ignoreCase: false,
-																		want:       "\":\"",
-																	},
-																	&actionExpr{
-																		pos: position{line: 175, col: 5, offset: 3830},
-																		run: (*parser).callonNode80,
-																		expr: &seqExpr{
-																			pos: position{line: 175, col: 5, offset: 3830},
-																			exprs: []any{
-																				&actionExpr{
-																					pos: position{line: 228, col: 5, offset: 4753},
-																					run: (*parser).callonNode82,
-																					expr: &charClassMatcher{
-																						pos:        position{line: 228, col: 5, offset: 4753},
-																						val:        "[0-9]",
-																						ranges:     []rune{'0', '9'},
-																						ignoreCase: false,
-																						inverted:   false,
-																					},
-																				},
-																				&actionExpr{
-																					pos: position{line: 228, col: 5, offset: 4753},
-																					run: (*parser).callonNode84,
-																					expr: &charClassMatcher{
-																						pos:        position{line: 228, col: 5, offset: 4753},
-																						val:        "[0-9]",
-																						ranges:     []rune{'0', '9'},
-																						ignoreCase: false,
-																						inverted:   false,
-																					},
-																				},
-																			},
-																		},
-																	},
-																	&litMatcher{
-																		pos:        position{line: 190, col: 29, offset: 4071},
-																		val:        ":",
-																		ignoreCase: false,
-																		want:       "\":\"",
-																	},
-																	&actionExpr{
-																		pos: position{line: 180, col: 5, offset: 3896},
-																		run: (*parser).callonNode87,
-																		expr: &seqExpr{
-																			pos: position{line: 180, col: 5, offset: 3896},
-																			exprs: []any{
-																				&actionExpr{
-																					pos: position{line: 228, col: 5, offset: 4753},
-																					run: (*parser).callonNode89,
-																					expr: &charClassMatcher{
-																						pos:        position{line: 228, col: 5, offset: 4753},
-																						val:        "[0-9]",
-																						ranges:     []rune{'0', '9'},
-																						ignoreCase: false,
-																						inverted:   false,
-																					},
-																				},
-																				&actionExpr{
-																					pos: position{line: 228, col: 5, offset: 4753},
+																					pos: position{line: 233, col: 5, offset: 4807},
 																					run: (*parser).callonNode91,
 																					expr: &charClassMatcher{
-																						pos:        position{line: 228, col: 5, offset: 4753},
+																						pos:        position{line: 233, col: 5, offset: 4807},
+																						val:        "[0-9]",
+																						ranges:     []rune{'0', '9'},
+																						ignoreCase: false,
+																						inverted:   false,
+																					},
+																				},
+																				&actionExpr{
+																					pos: position{line: 233, col: 5, offset: 4807},
+																					run: (*parser).callonNode93,
+																					expr: &charClassMatcher{
+																						pos:        position{line: 233, col: 5, offset: 4807},
+																						val:        "[0-9]",
+																						ranges:     []rune{'0', '9'},
+																						ignoreCase: false,
+																						inverted:   false,
+																					},
+																				},
+																			},
+																		},
+																	},
+																	&litMatcher{
+																		pos:        position{line: 190, col: 14, offset: 4044},
+																		val:        ":",
+																		ignoreCase: false,
+																		want:       "\":\"",
+																	},
+																	&actionExpr{
+																		pos: position{line: 175, col: 5, offset: 3818},
+																		run: (*parser).callonNode96,
+																		expr: &seqExpr{
+																			pos: position{line: 175, col: 5, offset: 3818},
+																			exprs: []any{
+																				&actionExpr{
+																					pos: position{line: 233, col: 5, offset: 4807},
+																					run: (*parser).callonNode98,
+																					expr: &charClassMatcher{
+																						pos:        position{line: 233, col: 5, offset: 4807},
+																						val:        "[0-9]",
+																						ranges:     []rune{'0', '9'},
+																						ignoreCase: false,
+																						inverted:   false,
+																					},
+																				},
+																				&actionExpr{
+																					pos: position{line: 233, col: 5, offset: 4807},
+																					run: (*parser).callonNode100,
+																					expr: &charClassMatcher{
+																						pos:        position{line: 233, col: 5, offset: 4807},
+																						val:        "[0-9]",
+																						ranges:     []rune{'0', '9'},
+																						ignoreCase: false,
+																						inverted:   false,
+																					},
+																				},
+																			},
+																		},
+																	},
+																	&litMatcher{
+																		pos:        position{line: 190, col: 29, offset: 4059},
+																		val:        ":",
+																		ignoreCase: false,
+																		want:       "\":\"",
+																	},
+																	&actionExpr{
+																		pos: position{line: 180, col: 5, offset: 3884},
+																		run: (*parser).callonNode103,
+																		expr: &seqExpr{
+																			pos: position{line: 180, col: 5, offset: 3884},
+																			exprs: []any{
+																				&actionExpr{
+																					pos: position{line: 233, col: 5, offset: 4807},
+																					run: (*parser).callonNode105,
+																					expr: &charClassMatcher{
+																						pos:        position{line: 233, col: 5, offset: 4807},
+																						val:        "[0-9]",
+																						ranges:     []rune{'0', '9'},
+																						ignoreCase: false,
+																						inverted:   false,
+																					},
+																				},
+																				&actionExpr{
+																					pos: position{line: 233, col: 5, offset: 4807},
+																					run: (*parser).callonNode107,
+																					expr: &charClassMatcher{
+																						pos:        position{line: 233, col: 5, offset: 4807},
 																						val:        "[0-9]",
 																						ranges:     []rune{'0', '9'},
 																						ignoreCase: false,
@@ -515,23 +589,23 @@ var g = &grammar{
 																		},
 																	},
 																	&zeroOrOneExpr{
-																		pos: position{line: 190, col: 44, offset: 4086},
+																		pos: position{line: 190, col: 44, offset: 4074},
 																		expr: &seqExpr{
-																			pos: position{line: 190, col: 45, offset: 4087},
+																			pos: position{line: 190, col: 45, offset: 4075},
 																			exprs: []any{
 																				&litMatcher{
-																					pos:        position{line: 190, col: 45, offset: 4087},
+																					pos:        position{line: 190, col: 45, offset: 4075},
 																					val:        ".",
 																					ignoreCase: false,
 																					want:       "\".\"",
 																				},
 																				&oneOrMoreExpr{
-																					pos: position{line: 190, col: 49, offset: 4091},
+																					pos: position{line: 190, col: 49, offset: 4079},
 																					expr: &actionExpr{
-																						pos: position{line: 228, col: 5, offset: 4753},
-																						run: (*parser).callonNode97,
+																						pos: position{line: 233, col: 5, offset: 4807},
+																						run: (*parser).callonNode113,
 																						expr: &charClassMatcher{
-																							pos:        position{line: 228, col: 5, offset: 4753},
+																							pos:        position{line: 233, col: 5, offset: 4807},
 																							val:        "[0-9]",
 																							ranges:     []rune{'0', '9'},
 																							ignoreCase: false,
@@ -543,35 +617,35 @@ var g = &grammar{
 																		},
 																	},
 																	&choiceExpr{
-																		pos: position{line: 190, col: 59, offset: 4101},
+																		pos: position{line: 190, col: 59, offset: 4089},
 																		alternatives: []any{
 																			&litMatcher{
-																				pos:        position{line: 190, col: 59, offset: 4101},
+																				pos:        position{line: 190, col: 59, offset: 4089},
 																				val:        "Z",
 																				ignoreCase: false,
 																				want:       "\"Z\"",
 																			},
 																			&seqExpr{
-																				pos: position{line: 190, col: 65, offset: 4107},
+																				pos: position{line: 190, col: 65, offset: 4095},
 																				exprs: []any{
 																					&charClassMatcher{
-																						pos:        position{line: 190, col: 66, offset: 4108},
+																						pos:        position{line: 190, col: 66, offset: 4096},
 																						val:        "[+-]",
 																						chars:      []rune{'+', '-'},
 																						ignoreCase: false,
 																						inverted:   false,
 																					},
 																					&actionExpr{
-																						pos: position{line: 170, col: 5, offset: 3764},
-																						run: (*parser).callonNode103,
+																						pos: position{line: 170, col: 5, offset: 3752},
+																						run: (*parser).callonNode119,
 																						expr: &seqExpr{
-																							pos: position{line: 170, col: 5, offset: 3764},
+																							pos: position{line: 170, col: 5, offset: 3752},
 																							exprs: []any{
 																								&actionExpr{
-																									pos: position{line: 228, col: 5, offset: 4753},
-																									run: (*parser).callonNode105,
+																									pos: position{line: 233, col: 5, offset: 4807},
+																									run: (*parser).callonNode121,
 																									expr: &charClassMatcher{
-																										pos:        position{line: 228, col: 5, offset: 4753},
+																										pos:        position{line: 233, col: 5, offset: 4807},
 																										val:        "[0-9]",
 																										ranges:     []rune{'0', '9'},
 																										ignoreCase: false,
@@ -579,10 +653,10 @@ var g = &grammar{
 																									},
 																								},
 																								&actionExpr{
-																									pos: position{line: 228, col: 5, offset: 4753},
-																									run: (*parser).callonNode107,
+																									pos: position{line: 233, col: 5, offset: 4807},
+																									run: (*parser).callonNode123,
 																									expr: &charClassMatcher{
-																										pos:        position{line: 228, col: 5, offset: 4753},
+																										pos:        position{line: 233, col: 5, offset: 4807},
 																										val:        "[0-9]",
 																										ranges:     []rune{'0', '9'},
 																										ignoreCase: false,
@@ -593,22 +667,22 @@ var g = &grammar{
 																						},
 																					},
 																					&litMatcher{
-																						pos:        position{line: 190, col: 86, offset: 4128},
+																						pos:        position{line: 190, col: 86, offset: 4116},
 																						val:        ":",
 																						ignoreCase: false,
 																						want:       "\":\"",
 																					},
 																					&actionExpr{
-																						pos: position{line: 175, col: 5, offset: 3830},
-																						run: (*parser).callonNode110,
+																						pos: position{line: 175, col: 5, offset: 3818},
+																						run: (*parser).callonNode126,
 																						expr: &seqExpr{
-																							pos: position{line: 175, col: 5, offset: 3830},
+																							pos: position{line: 175, col: 5, offset: 3818},
 																							exprs: []any{
 																								&actionExpr{
-																									pos: position{line: 228, col: 5, offset: 4753},
-																									run: (*parser).callonNode112,
+																									pos: position{line: 233, col: 5, offset: 4807},
+																									run: (*parser).callonNode128,
 																									expr: &charClassMatcher{
-																										pos:        position{line: 228, col: 5, offset: 4753},
+																										pos:        position{line: 233, col: 5, offset: 4807},
 																										val:        "[0-9]",
 																										ranges:     []rune{'0', '9'},
 																										ignoreCase: false,
@@ -616,10 +690,10 @@ var g = &grammar{
 																									},
 																								},
 																								&actionExpr{
-																									pos: position{line: 228, col: 5, offset: 4753},
-																									run: (*parser).callonNode114,
+																									pos: position{line: 233, col: 5, offset: 4807},
+																									run: (*parser).callonNode130,
 																									expr: &charClassMatcher{
-																										pos:        position{line: 228, col: 5, offset: 4753},
+																										pos:        position{line: 233, col: 5, offset: 4807},
 																										val:        "[0-9]",
 																										ranges:     []rune{'0', '9'},
 																										ignoreCase: false,
@@ -640,22 +714,22 @@ var g = &grammar{
 												},
 											},
 											&actionExpr{
-												pos: position{line: 185, col: 5, offset: 3960},
-												run: (*parser).callonNode116,
+												pos: position{line: 185, col: 5, offset: 3948},
+												run: (*parser).callonNode132,
 												expr: &seqExpr{
-													pos: position{line: 185, col: 5, offset: 3960},
+													pos: position{line: 185, col: 5, offset: 3948},
 													exprs: []any{
 														&actionExpr{
-															pos: position{line: 155, col: 5, offset: 3560},
-															run: (*parser).callonNode118,
+															pos: position{line: 155, col: 5, offset: 3548},
+															run: (*parser).callonNode134,
 															expr: &seqExpr{
-																pos: position{line: 155, col: 5, offset: 3560},
+																pos: position{line: 155, col: 5, offset: 3548},
 																exprs: []any{
 																	&actionExpr{
-																		pos: position{line: 228, col: 5, offset: 4753},
-																		run: (*parser).callonNode120,
+																		pos: position{line: 233, col: 5, offset: 4807},
+																		run: (*parser).callonNode136,
 																		expr: &charClassMatcher{
-																			pos:        position{line: 228, col: 5, offset: 4753},
+																			pos:        position{line: 233, col: 5, offset: 4807},
 																			val:        "[0-9]",
 																			ranges:     []rune{'0', '9'},
 																			ignoreCase: false,
@@ -663,95 +737,10 @@ var g = &grammar{
 																		},
 																	},
 																	&actionExpr{
-																		pos: position{line: 228, col: 5, offset: 4753},
-																		run: (*parser).callonNode122,
-																		expr: &charClassMatcher{
-																			pos:        position{line: 228, col: 5, offset: 4753},
-																			val:        "[0-9]",
-																			ranges:     []rune{'0', '9'},
-																			ignoreCase: false,
-																			inverted:   false,
-																		},
-																	},
-																	&actionExpr{
-																		pos: position{line: 228, col: 5, offset: 4753},
-																		run: (*parser).callonNode124,
-																		expr: &charClassMatcher{
-																			pos:        position{line: 228, col: 5, offset: 4753},
-																			val:        "[0-9]",
-																			ranges:     []rune{'0', '9'},
-																			ignoreCase: false,
-																			inverted:   false,
-																		},
-																	},
-																	&actionExpr{
-																		pos: position{line: 228, col: 5, offset: 4753},
-																		run: (*parser).callonNode126,
-																		expr: &charClassMatcher{
-																			pos:        position{line: 228, col: 5, offset: 4753},
-																			val:        "[0-9]",
-																			ranges:     []rune{'0', '9'},
-																			ignoreCase: false,
-																			inverted:   false,
-																		},
-																	},
-																},
-															},
-														},
-														&litMatcher{
-															pos:        position{line: 185, col: 14, offset: 3969},
-															val:        "-",
-															ignoreCase: false,
-															want:       "\"-\"",
-														},
-														&actionExpr{
-															pos: position{line: 160, col: 5, offset: 3637},
-															run: (*parser).callonNode129,
-															expr: &seqExpr{
-																pos: position{line: 160, col: 5, offset: 3637},
-																exprs: []any{
-																	&actionExpr{
-																		pos: position{line: 228, col: 5, offset: 4753},
-																		run: (*parser).callonNode131,
-																		expr: &charClassMatcher{
-																			pos:        position{line: 228, col: 5, offset: 4753},
-																			val:        "[0-9]",
-																			ranges:     []rune{'0', '9'},
-																			ignoreCase: false,
-																			inverted:   false,
-																		},
-																	},
-																	&actionExpr{
-																		pos: position{line: 228, col: 5, offset: 4753},
-																		run: (*parser).callonNode133,
-																		expr: &charClassMatcher{
-																			pos:        position{line: 228, col: 5, offset: 4753},
-																			val:        "[0-9]",
-																			ranges:     []rune{'0', '9'},
-																			ignoreCase: false,
-																			inverted:   false,
-																		},
-																	},
-																},
-															},
-														},
-														&litMatcher{
-															pos:        position{line: 185, col: 28, offset: 3983},
-															val:        "-",
-															ignoreCase: false,
-															want:       "\"-\"",
-														},
-														&actionExpr{
-															pos: position{line: 165, col: 5, offset: 3700},
-															run: (*parser).callonNode136,
-															expr: &seqExpr{
-																pos: position{line: 165, col: 5, offset: 3700},
-																exprs: []any{
-																	&actionExpr{
-																		pos: position{line: 228, col: 5, offset: 4753},
+																		pos: position{line: 233, col: 5, offset: 4807},
 																		run: (*parser).callonNode138,
 																		expr: &charClassMatcher{
-																			pos:        position{line: 228, col: 5, offset: 4753},
+																			pos:        position{line: 233, col: 5, offset: 4807},
 																			val:        "[0-9]",
 																			ranges:     []rune{'0', '9'},
 																			ignoreCase: false,
@@ -759,10 +748,95 @@ var g = &grammar{
 																		},
 																	},
 																	&actionExpr{
-																		pos: position{line: 228, col: 5, offset: 4753},
+																		pos: position{line: 233, col: 5, offset: 4807},
 																		run: (*parser).callonNode140,
 																		expr: &charClassMatcher{
-																			pos:        position{line: 228, col: 5, offset: 4753},
+																			pos:        position{line: 233, col: 5, offset: 4807},
+																			val:        "[0-9]",
+																			ranges:     []rune{'0', '9'},
+																			ignoreCase: false,
+																			inverted:   false,
+																		},
+																	},
+																	&actionExpr{
+																		pos: position{line: 233, col: 5, offset: 4807},
+																		run: (*parser).callonNode142,
+																		expr: &charClassMatcher{
+																			pos:        position{line: 233, col: 5, offset: 4807},
+																			val:        "[0-9]",
+																			ranges:     []rune{'0', '9'},
+																			ignoreCase: false,
+																			inverted:   false,
+																		},
+																	},
+																},
+															},
+														},
+														&litMatcher{
+															pos:        position{line: 185, col: 14, offset: 3957},
+															val:        "-",
+															ignoreCase: false,
+															want:       "\"-\"",
+														},
+														&actionExpr{
+															pos: position{line: 160, col: 5, offset: 3625},
+															run: (*parser).callonNode145,
+															expr: &seqExpr{
+																pos: position{line: 160, col: 5, offset: 3625},
+																exprs: []any{
+																	&actionExpr{
+																		pos: position{line: 233, col: 5, offset: 4807},
+																		run: (*parser).callonNode147,
+																		expr: &charClassMatcher{
+																			pos:        position{line: 233, col: 5, offset: 4807},
+																			val:        "[0-9]",
+																			ranges:     []rune{'0', '9'},
+																			ignoreCase: false,
+																			inverted:   false,
+																		},
+																	},
+																	&actionExpr{
+																		pos: position{line: 233, col: 5, offset: 4807},
+																		run: (*parser).callonNode149,
+																		expr: &charClassMatcher{
+																			pos:        position{line: 233, col: 5, offset: 4807},
+																			val:        "[0-9]",
+																			ranges:     []rune{'0', '9'},
+																			ignoreCase: false,
+																			inverted:   false,
+																		},
+																	},
+																},
+															},
+														},
+														&litMatcher{
+															pos:        position{line: 185, col: 28, offset: 3971},
+															val:        "-",
+															ignoreCase: false,
+															want:       "\"-\"",
+														},
+														&actionExpr{
+															pos: position{line: 165, col: 5, offset: 3688},
+															run: (*parser).callonNode152,
+															expr: &seqExpr{
+																pos: position{line: 165, col: 5, offset: 3688},
+																exprs: []any{
+																	&actionExpr{
+																		pos: position{line: 233, col: 5, offset: 4807},
+																		run: (*parser).callonNode154,
+																		expr: &charClassMatcher{
+																			pos:        position{line: 233, col: 5, offset: 4807},
+																			val:        "[0-9]",
+																			ranges:     []rune{'0', '9'},
+																			ignoreCase: false,
+																			inverted:   false,
+																		},
+																	},
+																	&actionExpr{
+																		pos: position{line: 233, col: 5, offset: 4807},
+																		run: (*parser).callonNode156,
+																		expr: &charClassMatcher{
+																			pos:        position{line: 233, col: 5, offset: 4807},
 																			val:        "[0-9]",
 																			ranges:     []rune{'0', '9'},
 																			ignoreCase: false,
@@ -776,107 +850,107 @@ var g = &grammar{
 												},
 											},
 											&actionExpr{
-												pos: position{line: 190, col: 5, offset: 4047},
-												run: (*parser).callonNode142,
+												pos: position{line: 190, col: 5, offset: 4035},
+												run: (*parser).callonNode158,
 												expr: &seqExpr{
-													pos: position{line: 190, col: 5, offset: 4047},
+													pos: position{line: 190, col: 5, offset: 4035},
 													exprs: []any{
 														&actionExpr{
-															pos: position{line: 170, col: 5, offset: 3764},
-															run: (*parser).callonNode144,
+															pos: position{line: 170, col: 5, offset: 3752},
+															run: (*parser).callonNode160,
 															expr: &seqExpr{
-																pos: position{line: 170, col: 5, offset: 3764},
+																pos: position{line: 170, col: 5, offset: 3752},
 																exprs: []any{
 																	&actionExpr{
-																		pos: position{line: 228, col: 5, offset: 4753},
-																		run: (*parser).callonNode146,
-																		expr: &charClassMatcher{
-																			pos:        position{line: 228, col: 5, offset: 4753},
-																			val:        "[0-9]",
-																			ranges:     []rune{'0', '9'},
-																			ignoreCase: false,
-																			inverted:   false,
-																		},
-																	},
-																	&actionExpr{
-																		pos: position{line: 228, col: 5, offset: 4753},
-																		run: (*parser).callonNode148,
-																		expr: &charClassMatcher{
-																			pos:        position{line: 228, col: 5, offset: 4753},
-																			val:        "[0-9]",
-																			ranges:     []rune{'0', '9'},
-																			ignoreCase: false,
-																			inverted:   false,
-																		},
-																	},
-																},
-															},
-														},
-														&litMatcher{
-															pos:        position{line: 190, col: 14, offset: 4056},
-															val:        ":",
-															ignoreCase: false,
-															want:       "\":\"",
-														},
-														&actionExpr{
-															pos: position{line: 175, col: 5, offset: 3830},
-															run: (*parser).callonNode151,
-															expr: &seqExpr{
-																pos: position{line: 175, col: 5, offset: 3830},
-																exprs: []any{
-																	&actionExpr{
-																		pos: position{line: 228, col: 5, offset: 4753},
-																		run: (*parser).callonNode153,
-																		expr: &charClassMatcher{
-																			pos:        position{line: 228, col: 5, offset: 4753},
-																			val:        "[0-9]",
-																			ranges:     []rune{'0', '9'},
-																			ignoreCase: false,
-																			inverted:   false,
-																		},
-																	},
-																	&actionExpr{
-																		pos: position{line: 228, col: 5, offset: 4753},
-																		run: (*parser).callonNode155,
-																		expr: &charClassMatcher{
-																			pos:        position{line: 228, col: 5, offset: 4753},
-																			val:        "[0-9]",
-																			ranges:     []rune{'0', '9'},
-																			ignoreCase: false,
-																			inverted:   false,
-																		},
-																	},
-																},
-															},
-														},
-														&litMatcher{
-															pos:        position{line: 190, col: 29, offset: 4071},
-															val:        ":",
-															ignoreCase: false,
-															want:       "\":\"",
-														},
-														&actionExpr{
-															pos: position{line: 180, col: 5, offset: 3896},
-															run: (*parser).callonNode158,
-															expr: &seqExpr{
-																pos: position{line: 180, col: 5, offset: 3896},
-																exprs: []any{
-																	&actionExpr{
-																		pos: position{line: 228, col: 5, offset: 4753},
-																		run: (*parser).callonNode160,
-																		expr: &charClassMatcher{
-																			pos:        position{line: 228, col: 5, offset: 4753},
-																			val:        "[0-9]",
-																			ranges:     []rune{'0', '9'},
-																			ignoreCase: false,
-																			inverted:   false,
-																		},
-																	},
-																	&actionExpr{
-																		pos: position{line: 228, col: 5, offset: 4753},
+																		pos: position{line: 233, col: 5, offset: 4807},
 																		run: (*parser).callonNode162,
 																		expr: &charClassMatcher{
-																			pos:        position{line: 228, col: 5, offset: 4753},
+																			pos:        position{line: 233, col: 5, offset: 4807},
+																			val:        "[0-9]",
+																			ranges:     []rune{'0', '9'},
+																			ignoreCase: false,
+																			inverted:   false,
+																		},
+																	},
+																	&actionExpr{
+																		pos: position{line: 233, col: 5, offset: 4807},
+																		run: (*parser).callonNode164,
+																		expr: &charClassMatcher{
+																			pos:        position{line: 233, col: 5, offset: 4807},
+																			val:        "[0-9]",
+																			ranges:     []rune{'0', '9'},
+																			ignoreCase: false,
+																			inverted:   false,
+																		},
+																	},
+																},
+															},
+														},
+														&litMatcher{
+															pos:        position{line: 190, col: 14, offset: 4044},
+															val:        ":",
+															ignoreCase: false,
+															want:       "\":\"",
+														},
+														&actionExpr{
+															pos: position{line: 175, col: 5, offset: 3818},
+															run: (*parser).callonNode167,
+															expr: &seqExpr{
+																pos: position{line: 175, col: 5, offset: 3818},
+																exprs: []any{
+																	&actionExpr{
+																		pos: position{line: 233, col: 5, offset: 4807},
+																		run: (*parser).callonNode169,
+																		expr: &charClassMatcher{
+																			pos:        position{line: 233, col: 5, offset: 4807},
+																			val:        "[0-9]",
+																			ranges:     []rune{'0', '9'},
+																			ignoreCase: false,
+																			inverted:   false,
+																		},
+																	},
+																	&actionExpr{
+																		pos: position{line: 233, col: 5, offset: 4807},
+																		run: (*parser).callonNode171,
+																		expr: &charClassMatcher{
+																			pos:        position{line: 233, col: 5, offset: 4807},
+																			val:        "[0-9]",
+																			ranges:     []rune{'0', '9'},
+																			ignoreCase: false,
+																			inverted:   false,
+																		},
+																	},
+																},
+															},
+														},
+														&litMatcher{
+															pos:        position{line: 190, col: 29, offset: 4059},
+															val:        ":",
+															ignoreCase: false,
+															want:       "\":\"",
+														},
+														&actionExpr{
+															pos: position{line: 180, col: 5, offset: 3884},
+															run: (*parser).callonNode174,
+															expr: &seqExpr{
+																pos: position{line: 180, col: 5, offset: 3884},
+																exprs: []any{
+																	&actionExpr{
+																		pos: position{line: 233, col: 5, offset: 4807},
+																		run: (*parser).callonNode176,
+																		expr: &charClassMatcher{
+																			pos:        position{line: 233, col: 5, offset: 4807},
+																			val:        "[0-9]",
+																			ranges:     []rune{'0', '9'},
+																			ignoreCase: false,
+																			inverted:   false,
+																		},
+																	},
+																	&actionExpr{
+																		pos: position{line: 233, col: 5, offset: 4807},
+																		run: (*parser).callonNode178,
+																		expr: &charClassMatcher{
+																			pos:        position{line: 233, col: 5, offset: 4807},
 																			val:        "[0-9]",
 																			ranges:     []rune{'0', '9'},
 																			ignoreCase: false,
@@ -887,23 +961,23 @@ var g = &grammar{
 															},
 														},
 														&zeroOrOneExpr{
-															pos: position{line: 190, col: 44, offset: 4086},
+															pos: position{line: 190, col: 44, offset: 4074},
 															expr: &seqExpr{
-																pos: position{line: 190, col: 45, offset: 4087},
+																pos: position{line: 190, col: 45, offset: 4075},
 																exprs: []any{
 																	&litMatcher{
-																		pos:        position{line: 190, col: 45, offset: 4087},
+																		pos:        position{line: 190, col: 45, offset: 4075},
 																		val:        ".",
 																		ignoreCase: false,
 																		want:       "\".\"",
 																	},
 																	&oneOrMoreExpr{
-																		pos: position{line: 190, col: 49, offset: 4091},
+																		pos: position{line: 190, col: 49, offset: 4079},
 																		expr: &actionExpr{
-																			pos: position{line: 228, col: 5, offset: 4753},
-																			run: (*parser).callonNode168,
+																			pos: position{line: 233, col: 5, offset: 4807},
+																			run: (*parser).callonNode184,
 																			expr: &charClassMatcher{
-																				pos:        position{line: 228, col: 5, offset: 4753},
+																				pos:        position{line: 233, col: 5, offset: 4807},
 																				val:        "[0-9]",
 																				ranges:     []rune{'0', '9'},
 																				ignoreCase: false,
@@ -915,35 +989,35 @@ var g = &grammar{
 															},
 														},
 														&choiceExpr{
-															pos: position{line: 190, col: 59, offset: 4101},
+															pos: position{line: 190, col: 59, offset: 4089},
 															alternatives: []any{
 																&litMatcher{
-																	pos:        position{line: 190, col: 59, offset: 4101},
+																	pos:        position{line: 190, col: 59, offset: 4089},
 																	val:        "Z",
 																	ignoreCase: false,
 																	want:       "\"Z\"",
 																},
 																&seqExpr{
-																	pos: position{line: 190, col: 65, offset: 4107},
+																	pos: position{line: 190, col: 65, offset: 4095},
 																	exprs: []any{
 																		&charClassMatcher{
-																			pos:        position{line: 190, col: 66, offset: 4108},
+																			pos:        position{line: 190, col: 66, offset: 4096},
 																			val:        "[+-]",
 																			chars:      []rune{'+', '-'},
 																			ignoreCase: false,
 																			inverted:   false,
 																		},
 																		&actionExpr{
-																			pos: position{line: 170, col: 5, offset: 3764},
-																			run: (*parser).callonNode174,
+																			pos: position{line: 170, col: 5, offset: 3752},
+																			run: (*parser).callonNode190,
 																			expr: &seqExpr{
-																				pos: position{line: 170, col: 5, offset: 3764},
+																				pos: position{line: 170, col: 5, offset: 3752},
 																				exprs: []any{
 																					&actionExpr{
-																						pos: position{line: 228, col: 5, offset: 4753},
-																						run: (*parser).callonNode176,
+																						pos: position{line: 233, col: 5, offset: 4807},
+																						run: (*parser).callonNode192,
 																						expr: &charClassMatcher{
-																							pos:        position{line: 228, col: 5, offset: 4753},
+																							pos:        position{line: 233, col: 5, offset: 4807},
 																							val:        "[0-9]",
 																							ranges:     []rune{'0', '9'},
 																							ignoreCase: false,
@@ -951,10 +1025,10 @@ var g = &grammar{
 																						},
 																					},
 																					&actionExpr{
-																						pos: position{line: 228, col: 5, offset: 4753},
-																						run: (*parser).callonNode178,
+																						pos: position{line: 233, col: 5, offset: 4807},
+																						run: (*parser).callonNode194,
 																						expr: &charClassMatcher{
-																							pos:        position{line: 228, col: 5, offset: 4753},
+																							pos:        position{line: 233, col: 5, offset: 4807},
 																							val:        "[0-9]",
 																							ranges:     []rune{'0', '9'},
 																							ignoreCase: false,
@@ -965,22 +1039,22 @@ var g = &grammar{
 																			},
 																		},
 																		&litMatcher{
-																			pos:        position{line: 190, col: 86, offset: 4128},
+																			pos:        position{line: 190, col: 86, offset: 4116},
 																			val:        ":",
 																			ignoreCase: false,
 																			want:       "\":\"",
 																		},
 																		&actionExpr{
-																			pos: position{line: 175, col: 5, offset: 3830},
-																			run: (*parser).callonNode181,
+																			pos: position{line: 175, col: 5, offset: 3818},
+																			run: (*parser).callonNode197,
 																			expr: &seqExpr{
-																				pos: position{line: 175, col: 5, offset: 3830},
+																				pos: position{line: 175, col: 5, offset: 3818},
 																				exprs: []any{
 																					&actionExpr{
-																						pos: position{line: 228, col: 5, offset: 4753},
-																						run: (*parser).callonNode183,
+																						pos: position{line: 233, col: 5, offset: 4807},
+																						run: (*parser).callonNode199,
 																						expr: &charClassMatcher{
-																							pos:        position{line: 228, col: 5, offset: 4753},
+																							pos:        position{line: 233, col: 5, offset: 4807},
 																							val:        "[0-9]",
 																							ranges:     []rune{'0', '9'},
 																							ignoreCase: false,
@@ -988,10 +1062,10 @@ var g = &grammar{
 																						},
 																					},
 																					&actionExpr{
-																						pos: position{line: 228, col: 5, offset: 4753},
-																						run: (*parser).callonNode185,
+																						pos: position{line: 233, col: 5, offset: 4807},
+																						run: (*parser).callonNode201,
 																						expr: &charClassMatcher{
-																							pos:        position{line: 228, col: 5, offset: 4753},
+																							pos:        position{line: 233, col: 5, offset: 4807},
 																							val:        "[0-9]",
 																							ranges:     []rune{'0', '9'},
 																							ignoreCase: false,
@@ -1012,9 +1086,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 62, col: 7, offset: 1473},
+									pos: position{line: 62, col: 7, offset: 1465},
 									expr: &litMatcher{
-										pos:        position{line: 62, col: 7, offset: 1473},
+										pos:        position{line: 62, col: 7, offset: 1465},
 										val:        "\"",
 										ignoreCase: false,
 										want:       "\"\\\"\"",
@@ -1024,47 +1098,84 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 65, col: 5, offset: 1549},
-						run: (*parser).callonNode189,
+						pos: position{line: 65, col: 5, offset: 1541},
+						run: (*parser).callonNode205,
 						expr: &seqExpr{
-							pos: position{line: 65, col: 5, offset: 1549},
+							pos: position{line: 65, col: 5, offset: 1541},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 65, col: 5, offset: 1549},
+									pos:   position{line: 65, col: 5, offset: 1541},
 									label: "k",
-									expr: &oneOrMoreExpr{
-										pos: position{line: 65, col: 7, offset: 1551},
-										expr: &actionExpr{
-											pos: position{line: 218, col: 5, offset: 4634},
-											run: (*parser).callonNode193,
-											expr: &charClassMatcher{
-												pos:        position{line: 218, col: 5, offset: 4634},
-												val:        "[A-Za-z]",
-												ranges:     []rune{'A', 'Z', 'a', 'z'},
-												ignoreCase: false,
-												inverted:   false,
+									expr: &actionExpr{
+										pos: position{line: 223, col: 5, offset: 4678},
+										run: (*parser).callonNode208,
+										expr: &seqExpr{
+											pos: position{line: 223, col: 5, offset: 4678},
+											exprs: []any{
+												&oneOrMoreExpr{
+													pos: position{line: 223, col: 5, offset: 4678},
+													expr: &actionExpr{
+														pos: position{line: 218, col: 5, offset: 4622},
+														run: (*parser).callonNode211,
+														expr: &charClassMatcher{
+															pos:        position{line: 218, col: 5, offset: 4622},
+															val:        "[A-Za-z]",
+															ranges:     []rune{'A', 'Z', 'a', 'z'},
+															ignoreCase: false,
+															inverted:   false,
+														},
+													},
+												},
+												&zeroOrMoreExpr{
+													pos: position{line: 223, col: 11, offset: 4684},
+													expr: &seqExpr{
+														pos: position{line: 223, col: 12, offset: 4685},
+														exprs: []any{
+															&litMatcher{
+																pos:        position{line: 223, col: 12, offset: 4685},
+																val:        ".",
+																ignoreCase: false,
+																want:       "\".\"",
+															},
+															&oneOrMoreExpr{
+																pos: position{line: 223, col: 16, offset: 4689},
+																expr: &actionExpr{
+																	pos: position{line: 218, col: 5, offset: 4622},
+																	run: (*parser).callonNode217,
+																	expr: &charClassMatcher{
+																		pos:        position{line: 218, col: 5, offset: 4622},
+																		val:        "[A-Za-z]",
+																		ranges:     []rune{'A', 'Z', 'a', 'z'},
+																		ignoreCase: false,
+																		inverted:   false,
+																	},
+																},
+															},
+														},
+													},
+												},
 											},
 										},
 									},
 								},
 								&choiceExpr{
-									pos: position{line: 66, col: 9, offset: 1567},
+									pos: position{line: 66, col: 9, offset: 1557},
 									alternatives: []any{
 										&actionExpr{
-											pos: position{line: 125, col: 5, offset: 2997},
-											run: (*parser).callonNode196,
+											pos: position{line: 125, col: 5, offset: 2985},
+											run: (*parser).callonNode220,
 											expr: &litMatcher{
-												pos:        position{line: 125, col: 5, offset: 2997},
+												pos:        position{line: 125, col: 5, offset: 2985},
 												val:        "=",
 												ignoreCase: false,
 												want:       "\"=\"",
 											},
 										},
 										&actionExpr{
-											pos: position{line: 120, col: 5, offset: 2911},
-											run: (*parser).callonNode198,
+											pos: position{line: 120, col: 5, offset: 2899},
+											run: (*parser).callonNode222,
 											expr: &litMatcher{
-												pos:        position{line: 120, col: 5, offset: 2911},
+												pos:        position{line: 120, col: 5, offset: 2899},
 												val:        ":",
 												ignoreCase: false,
 												want:       "\":\"",
@@ -1073,79 +1184,79 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 68, col: 7, offset: 1619},
+									pos: position{line: 68, col: 7, offset: 1609},
 									expr: &litMatcher{
-										pos:        position{line: 68, col: 7, offset: 1619},
+										pos:        position{line: 68, col: 7, offset: 1609},
 										val:        "\"",
 										ignoreCase: false,
 										want:       "\"\\\"\"",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 68, col: 12, offset: 1624},
+									pos:   position{line: 68, col: 12, offset: 1614},
 									label: "v",
 									expr: &choiceExpr{
-										pos: position{line: 200, col: 5, offset: 4285},
+										pos: position{line: 200, col: 5, offset: 4273},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 200, col: 5, offset: 4285},
+												pos:        position{line: 200, col: 5, offset: 4273},
 												val:        "today",
 												ignoreCase: false,
 												want:       "\"today\"",
 											},
 											&litMatcher{
-												pos:        position{line: 201, col: 5, offset: 4299},
+												pos:        position{line: 201, col: 5, offset: 4287},
 												val:        "yesterday",
 												ignoreCase: false,
 												want:       "\"yesterday\"",
 											},
 											&litMatcher{
-												pos:        position{line: 202, col: 5, offset: 4317},
+												pos:        position{line: 202, col: 5, offset: 4305},
 												val:        "this week",
 												ignoreCase: false,
 												want:       "\"this week\"",
 											},
 											&litMatcher{
-												pos:        position{line: 203, col: 5, offset: 4335},
+												pos:        position{line: 203, col: 5, offset: 4323},
 												val:        "last week",
 												ignoreCase: false,
 												want:       "\"last week\"",
 											},
 											&litMatcher{
-												pos:        position{line: 204, col: 5, offset: 4353},
+												pos:        position{line: 204, col: 5, offset: 4341},
 												val:        "last 7 days",
 												ignoreCase: false,
 												want:       "\"last 7 days\"",
 											},
 											&litMatcher{
-												pos:        position{line: 205, col: 5, offset: 4373},
+												pos:        position{line: 205, col: 5, offset: 4361},
 												val:        "this month",
 												ignoreCase: false,
 												want:       "\"this month\"",
 											},
 											&litMatcher{
-												pos:        position{line: 206, col: 5, offset: 4392},
+												pos:        position{line: 206, col: 5, offset: 4380},
 												val:        "last month",
 												ignoreCase: false,
 												want:       "\"last month\"",
 											},
 											&litMatcher{
-												pos:        position{line: 207, col: 5, offset: 4411},
+												pos:        position{line: 207, col: 5, offset: 4399},
 												val:        "last 30 days",
 												ignoreCase: false,
 												want:       "\"last 30 days\"",
 											},
 											&litMatcher{
-												pos:        position{line: 208, col: 5, offset: 4432},
+												pos:        position{line: 208, col: 5, offset: 4420},
 												val:        "this year",
 												ignoreCase: false,
 												want:       "\"this year\"",
 											},
 											&actionExpr{
-												pos: position{line: 209, col: 5, offset: 4450},
-												run: (*parser).callonNode213,
+												pos: position{line: 209, col: 5, offset: 4438},
+												run: (*parser).callonNode237,
 												expr: &litMatcher{
-													pos:        position{line: 209, col: 5, offset: 4450},
+													pos:        position{line: 209, col: 5, offset: 4438},
 													val:        "last year",
 													ignoreCase: false,
 													want:       "\"last year\"",
@@ -1155,9 +1266,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 68, col: 38, offset: 1650},
+									pos: position{line: 68, col: 38, offset: 1640},
 									expr: &litMatcher{
-										pos:        position{line: 68, col: 38, offset: 1650},
+										pos:        position{line: 68, col: 38, offset: 1640},
 										val:        "\"",
 										ignoreCase: false,
 										want:       "\"\\\"\"",
@@ -1167,47 +1278,84 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 73, col: 5, offset: 1769},
-						run: (*parser).callonNode217,
+						pos: position{line: 73, col: 5, offset: 1759},
+						run: (*parser).callonNode241,
 						expr: &seqExpr{
-							pos: position{line: 73, col: 5, offset: 1769},
+							pos: position{line: 73, col: 5, offset: 1759},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 73, col: 5, offset: 1769},
+									pos:   position{line: 73, col: 5, offset: 1759},
 									label: "k",
-									expr: &oneOrMoreExpr{
-										pos: position{line: 73, col: 7, offset: 1771},
-										expr: &actionExpr{
-											pos: position{line: 218, col: 5, offset: 4634},
-											run: (*parser).callonNode221,
-											expr: &charClassMatcher{
-												pos:        position{line: 218, col: 5, offset: 4634},
-												val:        "[A-Za-z]",
-												ranges:     []rune{'A', 'Z', 'a', 'z'},
-												ignoreCase: false,
-												inverted:   false,
+									expr: &actionExpr{
+										pos: position{line: 223, col: 5, offset: 4678},
+										run: (*parser).callonNode244,
+										expr: &seqExpr{
+											pos: position{line: 223, col: 5, offset: 4678},
+											exprs: []any{
+												&oneOrMoreExpr{
+													pos: position{line: 223, col: 5, offset: 4678},
+													expr: &actionExpr{
+														pos: position{line: 218, col: 5, offset: 4622},
+														run: (*parser).callonNode247,
+														expr: &charClassMatcher{
+															pos:        position{line: 218, col: 5, offset: 4622},
+															val:        "[A-Za-z]",
+															ranges:     []rune{'A', 'Z', 'a', 'z'},
+															ignoreCase: false,
+															inverted:   false,
+														},
+													},
+												},
+												&zeroOrMoreExpr{
+													pos: position{line: 223, col: 11, offset: 4684},
+													expr: &seqExpr{
+														pos: position{line: 223, col: 12, offset: 4685},
+														exprs: []any{
+															&litMatcher{
+																pos:        position{line: 223, col: 12, offset: 4685},
+																val:        ".",
+																ignoreCase: false,
+																want:       "\".\"",
+															},
+															&oneOrMoreExpr{
+																pos: position{line: 223, col: 16, offset: 4689},
+																expr: &actionExpr{
+																	pos: position{line: 218, col: 5, offset: 4622},
+																	run: (*parser).callonNode253,
+																	expr: &charClassMatcher{
+																		pos:        position{line: 218, col: 5, offset: 4622},
+																		val:        "[A-Za-z]",
+																		ranges:     []rune{'A', 'Z', 'a', 'z'},
+																		ignoreCase: false,
+																		inverted:   false,
+																	},
+																},
+															},
+														},
+													},
+												},
 											},
 										},
 									},
 								},
 								&choiceExpr{
-									pos: position{line: 73, col: 14, offset: 1778},
+									pos: position{line: 73, col: 12, offset: 1766},
 									alternatives: []any{
 										&actionExpr{
-											pos: position{line: 120, col: 5, offset: 2911},
-											run: (*parser).callonNode224,
+											pos: position{line: 120, col: 5, offset: 2899},
+											run: (*parser).callonNode256,
 											expr: &litMatcher{
-												pos:        position{line: 120, col: 5, offset: 2911},
+												pos:        position{line: 120, col: 5, offset: 2899},
 												val:        ":",
 												ignoreCase: false,
 												want:       "\":\"",
 											},
 										},
 										&actionExpr{
-											pos: position{line: 125, col: 5, offset: 2997},
-											run: (*parser).callonNode226,
+											pos: position{line: 125, col: 5, offset: 2985},
+											run: (*parser).callonNode258,
 											expr: &litMatcher{
-												pos:        position{line: 125, col: 5, offset: 2997},
+												pos:        position{line: 125, col: 5, offset: 2985},
 												val:        "=",
 												ignoreCase: false,
 												want:       "\"=\"",
@@ -1216,30 +1364,30 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 73, col: 53, offset: 1817},
+									pos:   position{line: 73, col: 51, offset: 1805},
 									label: "v",
 									expr: &choiceExpr{
-										pos: position{line: 73, col: 56, offset: 1820},
+										pos: position{line: 73, col: 54, offset: 1808},
 										alternatives: []any{
 											&actionExpr{
-												pos: position{line: 223, col: 5, offset: 4693},
-												run: (*parser).callonNode230,
+												pos: position{line: 228, col: 5, offset: 4747},
+												run: (*parser).callonNode262,
 												expr: &seqExpr{
-													pos: position{line: 223, col: 5, offset: 4693},
+													pos: position{line: 228, col: 5, offset: 4747},
 													exprs: []any{
 														&litMatcher{
-															pos:        position{line: 223, col: 5, offset: 4693},
+															pos:        position{line: 228, col: 5, offset: 4747},
 															val:        "\"",
 															ignoreCase: false,
 															want:       "\"\\\"\"",
 														},
 														&labeledExpr{
-															pos:   position{line: 223, col: 9, offset: 4697},
+															pos:   position{line: 228, col: 9, offset: 4751},
 															label: "v",
 															expr: &zeroOrMoreExpr{
-																pos: position{line: 223, col: 11, offset: 4699},
+																pos: position{line: 228, col: 11, offset: 4753},
 																expr: &charClassMatcher{
-																	pos:        position{line: 223, col: 11, offset: 4699},
+																	pos:        position{line: 228, col: 11, offset: 4753},
 																	val:        "[^\"]",
 																	chars:      []rune{'"'},
 																	ignoreCase: false,
@@ -1248,7 +1396,7 @@ var g = &grammar{
 															},
 														},
 														&litMatcher{
-															pos:        position{line: 223, col: 17, offset: 4705},
+															pos:        position{line: 228, col: 17, offset: 4759},
 															val:        "\"",
 															ignoreCase: false,
 															want:       "\"\\\"\"",
@@ -1257,9 +1405,9 @@ var g = &grammar{
 												},
 											},
 											&oneOrMoreExpr{
-												pos: position{line: 73, col: 65, offset: 1829},
+												pos: position{line: 73, col: 63, offset: 1817},
 												expr: &charClassMatcher{
-													pos:        position{line: 73, col: 65, offset: 1829},
+													pos:        position{line: 73, col: 63, offset: 1817},
 													val:        "[^ ()]",
 													chars:      []rune{' ', '(', ')'},
 													ignoreCase: false,
@@ -1273,19 +1421,19 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 105, col: 5, offset: 2621},
-						run: (*parser).callonNode239,
+						pos: position{line: 105, col: 5, offset: 2609},
+						run: (*parser).callonNode271,
 						expr: &choiceExpr{
-							pos: position{line: 105, col: 6, offset: 2622},
+							pos: position{line: 105, col: 6, offset: 2610},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 105, col: 6, offset: 2622},
+									pos:        position{line: 105, col: 6, offset: 2610},
 									val:        "AND",
 									ignoreCase: false,
 									want:       "\"AND\"",
 								},
 								&litMatcher{
-									pos:        position{line: 105, col: 14, offset: 2630},
+									pos:        position{line: 105, col: 14, offset: 2618},
 									val:        "+",
 									ignoreCase: false,
 									want:       "\"+\"",
@@ -1294,19 +1442,19 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 110, col: 5, offset: 2722},
-						run: (*parser).callonNode243,
+						pos: position{line: 110, col: 5, offset: 2710},
+						run: (*parser).callonNode275,
 						expr: &choiceExpr{
-							pos: position{line: 110, col: 6, offset: 2723},
+							pos: position{line: 110, col: 6, offset: 2711},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 110, col: 6, offset: 2723},
+									pos:        position{line: 110, col: 6, offset: 2711},
 									val:        "NOT",
 									ignoreCase: false,
 									want:       "\"NOT\"",
 								},
 								&litMatcher{
-									pos:        position{line: 110, col: 14, offset: 2731},
+									pos:        position{line: 110, col: 14, offset: 2719},
 									val:        "-",
 									ignoreCase: false,
 									want:       "\"-\"",
@@ -1315,28 +1463,28 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 115, col: 5, offset: 2822},
-						run: (*parser).callonNode247,
+						pos: position{line: 115, col: 5, offset: 2810},
+						run: (*parser).callonNode279,
 						expr: &litMatcher{
-							pos:        position{line: 115, col: 6, offset: 2823},
+							pos:        position{line: 115, col: 6, offset: 2811},
 							val:        "OR",
 							ignoreCase: false,
 							want:       "\"OR\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 86, col: 6, offset: 2109},
-						run: (*parser).callonNode249,
+						pos: position{line: 86, col: 6, offset: 2097},
+						run: (*parser).callonNode281,
 						expr: &seqExpr{
-							pos: position{line: 86, col: 6, offset: 2109},
+							pos: position{line: 86, col: 6, offset: 2097},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 86, col: 6, offset: 2109},
+									pos: position{line: 86, col: 6, offset: 2097},
 									expr: &actionExpr{
-										pos: position{line: 120, col: 5, offset: 2911},
-										run: (*parser).callonNode252,
+										pos: position{line: 120, col: 5, offset: 2899},
+										run: (*parser).callonNode284,
 										expr: &litMatcher{
-											pos:        position{line: 120, col: 5, offset: 2911},
+											pos:        position{line: 120, col: 5, offset: 2899},
 											val:        ":",
 											ignoreCase: false,
 											want:       "\":\"",
@@ -1344,12 +1492,12 @@ var g = &grammar{
 									},
 								},
 								&actionExpr{
-									pos: position{line: 233, col: 5, offset: 4804},
-									run: (*parser).callonNode254,
+									pos: position{line: 238, col: 5, offset: 4858},
+									run: (*parser).callonNode286,
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 233, col: 5, offset: 4804},
+										pos: position{line: 238, col: 5, offset: 4858},
 										expr: &charClassMatcher{
-											pos:        position{line: 233, col: 5, offset: 4804},
+											pos:        position{line: 238, col: 5, offset: 4858},
 											val:        "[ \\t]",
 											chars:      []rune{' ', '\t'},
 											ignoreCase: false,
@@ -1358,27 +1506,27 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 86, col: 27, offset: 2130},
+									pos:   position{line: 86, col: 27, offset: 2118},
 									label: "v",
 									expr: &actionExpr{
-										pos: position{line: 223, col: 5, offset: 4693},
-										run: (*parser).callonNode258,
+										pos: position{line: 228, col: 5, offset: 4747},
+										run: (*parser).callonNode290,
 										expr: &seqExpr{
-											pos: position{line: 223, col: 5, offset: 4693},
+											pos: position{line: 228, col: 5, offset: 4747},
 											exprs: []any{
 												&litMatcher{
-													pos:        position{line: 223, col: 5, offset: 4693},
+													pos:        position{line: 228, col: 5, offset: 4747},
 													val:        "\"",
 													ignoreCase: false,
 													want:       "\"\\\"\"",
 												},
 												&labeledExpr{
-													pos:   position{line: 223, col: 9, offset: 4697},
+													pos:   position{line: 228, col: 9, offset: 4751},
 													label: "v",
 													expr: &zeroOrMoreExpr{
-														pos: position{line: 223, col: 11, offset: 4699},
+														pos: position{line: 228, col: 11, offset: 4753},
 														expr: &charClassMatcher{
-															pos:        position{line: 223, col: 11, offset: 4699},
+															pos:        position{line: 228, col: 11, offset: 4753},
 															val:        "[^\"]",
 															chars:      []rune{'"'},
 															ignoreCase: false,
@@ -1387,7 +1535,7 @@ var g = &grammar{
 													},
 												},
 												&litMatcher{
-													pos:        position{line: 223, col: 17, offset: 4705},
+													pos:        position{line: 228, col: 17, offset: 4759},
 													val:        "\"",
 													ignoreCase: false,
 													want:       "\"\\\"\"",
@@ -1397,12 +1545,12 @@ var g = &grammar{
 									},
 								},
 								&actionExpr{
-									pos: position{line: 233, col: 5, offset: 4804},
-									run: (*parser).callonNode265,
+									pos: position{line: 238, col: 5, offset: 4858},
+									run: (*parser).callonNode297,
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 233, col: 5, offset: 4804},
+										pos: position{line: 238, col: 5, offset: 4858},
 										expr: &charClassMatcher{
-											pos:        position{line: 233, col: 5, offset: 4804},
+											pos:        position{line: 238, col: 5, offset: 4858},
 											val:        "[ \\t]",
 											chars:      []rune{' ', '\t'},
 											ignoreCase: false,
@@ -1411,12 +1559,12 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 86, col: 38, offset: 2141},
+									pos: position{line: 86, col: 38, offset: 2129},
 									expr: &actionExpr{
-										pos: position{line: 120, col: 5, offset: 2911},
-										run: (*parser).callonNode269,
+										pos: position{line: 120, col: 5, offset: 2899},
+										run: (*parser).callonNode301,
 										expr: &litMatcher{
-											pos:        position{line: 120, col: 5, offset: 2911},
+											pos:        position{line: 120, col: 5, offset: 2899},
 											val:        ":",
 											ignoreCase: false,
 											want:       "\":\"",
@@ -1427,18 +1575,18 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 91, col: 6, offset: 2239},
-						run: (*parser).callonNode271,
+						pos: position{line: 91, col: 6, offset: 2227},
+						run: (*parser).callonNode303,
 						expr: &seqExpr{
-							pos: position{line: 91, col: 6, offset: 2239},
+							pos: position{line: 91, col: 6, offset: 2227},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 91, col: 6, offset: 2239},
+									pos: position{line: 91, col: 6, offset: 2227},
 									expr: &actionExpr{
-										pos: position{line: 120, col: 5, offset: 2911},
-										run: (*parser).callonNode274,
+										pos: position{line: 120, col: 5, offset: 2899},
+										run: (*parser).callonNode306,
 										expr: &litMatcher{
-											pos:        position{line: 120, col: 5, offset: 2911},
+											pos:        position{line: 120, col: 5, offset: 2899},
 											val:        ":",
 											ignoreCase: false,
 											want:       "\":\"",
@@ -1446,12 +1594,12 @@ var g = &grammar{
 									},
 								},
 								&actionExpr{
-									pos: position{line: 233, col: 5, offset: 4804},
-									run: (*parser).callonNode276,
+									pos: position{line: 238, col: 5, offset: 4858},
+									run: (*parser).callonNode308,
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 233, col: 5, offset: 4804},
+										pos: position{line: 238, col: 5, offset: 4858},
 										expr: &charClassMatcher{
-											pos:        position{line: 233, col: 5, offset: 4804},
+											pos:        position{line: 238, col: 5, offset: 4858},
 											val:        "[ \\t]",
 											chars:      []rune{' ', '\t'},
 											ignoreCase: false,
@@ -1460,12 +1608,12 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 91, col: 27, offset: 2260},
+									pos:   position{line: 91, col: 27, offset: 2248},
 									label: "v",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 91, col: 29, offset: 2262},
+										pos: position{line: 91, col: 29, offset: 2250},
 										expr: &charClassMatcher{
-											pos:        position{line: 91, col: 29, offset: 2262},
+											pos:        position{line: 91, col: 29, offset: 2250},
 											val:        "[^ :()]",
 											chars:      []rune{' ', ':', '(', ')'},
 											ignoreCase: false,
@@ -1474,12 +1622,12 @@ var g = &grammar{
 									},
 								},
 								&actionExpr{
-									pos: position{line: 233, col: 5, offset: 4804},
-									run: (*parser).callonNode282,
+									pos: position{line: 238, col: 5, offset: 4858},
+									run: (*parser).callonNode314,
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 233, col: 5, offset: 4804},
+										pos: position{line: 238, col: 5, offset: 4858},
 										expr: &charClassMatcher{
-											pos:        position{line: 233, col: 5, offset: 4804},
+											pos:        position{line: 238, col: 5, offset: 4858},
 											val:        "[ \\t]",
 											chars:      []rune{' ', '\t'},
 											ignoreCase: false,
@@ -1488,12 +1636,12 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 91, col: 40, offset: 2273},
+									pos: position{line: 91, col: 40, offset: 2261},
 									expr: &actionExpr{
-										pos: position{line: 120, col: 5, offset: 2911},
-										run: (*parser).callonNode286,
+										pos: position{line: 120, col: 5, offset: 2899},
+										run: (*parser).callonNode318,
 										expr: &litMatcher{
-											pos:        position{line: 120, col: 5, offset: 2911},
+											pos:        position{line: 120, col: 5, offset: 2899},
 											val:        ":",
 											ignoreCase: false,
 											want:       "\":\"",
@@ -1520,42 +1668,79 @@ var g = &grammar{
 							label: "k",
 							expr: &zeroOrOneExpr{
 								pos: position{line: 32, col: 7, offset: 614},
-								expr: &oneOrMoreExpr{
-									pos: position{line: 32, col: 8, offset: 615},
-									expr: &actionExpr{
-										pos: position{line: 218, col: 5, offset: 4634},
-										run: (*parser).callonGroupNode6,
-										expr: &charClassMatcher{
-											pos:        position{line: 218, col: 5, offset: 4634},
-											val:        "[A-Za-z]",
-											ranges:     []rune{'A', 'Z', 'a', 'z'},
-											ignoreCase: false,
-											inverted:   false,
+								expr: &actionExpr{
+									pos: position{line: 223, col: 5, offset: 4678},
+									run: (*parser).callonGroupNode5,
+									expr: &seqExpr{
+										pos: position{line: 223, col: 5, offset: 4678},
+										exprs: []any{
+											&oneOrMoreExpr{
+												pos: position{line: 223, col: 5, offset: 4678},
+												expr: &actionExpr{
+													pos: position{line: 218, col: 5, offset: 4622},
+													run: (*parser).callonGroupNode8,
+													expr: &charClassMatcher{
+														pos:        position{line: 218, col: 5, offset: 4622},
+														val:        "[A-Za-z]",
+														ranges:     []rune{'A', 'Z', 'a', 'z'},
+														ignoreCase: false,
+														inverted:   false,
+													},
+												},
+											},
+											&zeroOrMoreExpr{
+												pos: position{line: 223, col: 11, offset: 4684},
+												expr: &seqExpr{
+													pos: position{line: 223, col: 12, offset: 4685},
+													exprs: []any{
+														&litMatcher{
+															pos:        position{line: 223, col: 12, offset: 4685},
+															val:        ".",
+															ignoreCase: false,
+															want:       "\".\"",
+														},
+														&oneOrMoreExpr{
+															pos: position{line: 223, col: 16, offset: 4689},
+															expr: &actionExpr{
+																pos: position{line: 218, col: 5, offset: 4622},
+																run: (*parser).callonGroupNode14,
+																expr: &charClassMatcher{
+																	pos:        position{line: 218, col: 5, offset: 4622},
+																	val:        "[A-Za-z]",
+																	ranges:     []rune{'A', 'Z', 'a', 'z'},
+																	ignoreCase: false,
+																	inverted:   false,
+																},
+															},
+														},
+													},
+												},
+											},
 										},
 									},
 								},
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 32, col: 16, offset: 623},
+							pos: position{line: 32, col: 12, offset: 619},
 							expr: &choiceExpr{
-								pos: position{line: 32, col: 17, offset: 624},
+								pos: position{line: 32, col: 13, offset: 620},
 								alternatives: []any{
 									&actionExpr{
-										pos: position{line: 120, col: 5, offset: 2911},
-										run: (*parser).callonGroupNode10,
+										pos: position{line: 120, col: 5, offset: 2899},
+										run: (*parser).callonGroupNode18,
 										expr: &litMatcher{
-											pos:        position{line: 120, col: 5, offset: 2911},
+											pos:        position{line: 120, col: 5, offset: 2899},
 											val:        ":",
 											ignoreCase: false,
 											want:       "\":\"",
 										},
 									},
 									&actionExpr{
-										pos: position{line: 125, col: 5, offset: 2997},
-										run: (*parser).callonGroupNode12,
+										pos: position{line: 125, col: 5, offset: 2985},
+										run: (*parser).callonGroupNode20,
 										expr: &litMatcher{
-											pos:        position{line: 125, col: 5, offset: 2997},
+											pos:        position{line: 125, col: 5, offset: 2985},
 											val:        "=",
 											ignoreCase: false,
 											want:       "\"=\"",
@@ -1565,21 +1750,21 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 32, col: 57, offset: 664},
+							pos:        position{line: 32, col: 53, offset: 660},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 32, col: 61, offset: 668},
+							pos:   position{line: 32, col: 57, offset: 664},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 32, col: 63, offset: 670},
+								pos:  position{line: 32, col: 59, offset: 666},
 								name: "Nodes",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 32, col: 69, offset: 676},
+							pos:        position{line: 32, col: 65, offset: 672},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -1613,37 +1798,59 @@ func (p *parser) callonNodes3() (any, error) {
 	return p.cur.onNodes3()
 }
 
-func (c *current) onNode7() (any, error) {
+func (c *current) onNode9() (any, error) {
 	return c.text, nil
 
 }
 
-func (p *parser) callonNode7() (any, error) {
+func (p *parser) callonNode9() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onNode7()
+	return p.cur.onNode9()
 }
 
-func (c *current) onNode10() (any, error) {
+func (c *current) onNode15() (any, error) {
+	return c.text, nil
+
+}
+
+func (p *parser) callonNode15() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onNode15()
+}
+
+func (c *current) onNode6() (any, error) {
+	return c.text, nil
+
+}
+
+func (p *parser) callonNode6() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onNode6()
+}
+
+func (c *current) onNode18() (any, error) {
 	return buildOperatorNode(c.text, c.pos)
 
 }
 
-func (p *parser) callonNode10() (any, error) {
+func (p *parser) callonNode18() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onNode10()
+	return p.cur.onNode18()
 }
 
-func (c *current) onNode12() (any, error) {
+func (c *current) onNode20() (any, error) {
 	return buildOperatorNode(c.text, c.pos)
 
 }
 
-func (p *parser) callonNode12() (any, error) {
+func (p *parser) callonNode20() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onNode12()
+	return p.cur.onNode20()
 }
 
 func (c *current) onNode3(k, v any) (any, error) {
@@ -1657,52 +1864,8 @@ func (p *parser) callonNode3() (any, error) {
 	return p.cur.onNode3(stack["k"], stack["v"])
 }
 
-func (c *current) onNode22() (any, error) {
-	return c.text, nil
-
-}
-
-func (p *parser) callonNode22() (any, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onNode22()
-}
-
-func (c *current) onNode26() (any, error) {
-	return buildOperatorNode(c.text, c.pos)
-
-}
-
-func (p *parser) callonNode26() (any, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onNode26()
-}
-
-func (c *current) onNode28() (any, error) {
-	return buildOperatorNode(c.text, c.pos)
-
-}
-
-func (p *parser) callonNode28() (any, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onNode28()
-}
-
-func (c *current) onNode30() (any, error) {
-	return buildOperatorNode(c.text, c.pos)
-
-}
-
-func (p *parser) callonNode30() (any, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onNode30()
-}
-
 func (c *current) onNode32() (any, error) {
-	return buildOperatorNode(c.text, c.pos)
+	return c.text, nil
 
 }
 
@@ -1712,30 +1875,63 @@ func (p *parser) callonNode32() (any, error) {
 	return p.cur.onNode32()
 }
 
-func (c *current) onNode34() (any, error) {
+func (c *current) onNode38() (any, error) {
+	return c.text, nil
+
+}
+
+func (p *parser) callonNode38() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onNode38()
+}
+
+func (c *current) onNode29() (any, error) {
+	return c.text, nil
+
+}
+
+func (p *parser) callonNode29() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onNode29()
+}
+
+func (c *current) onNode42() (any, error) {
 	return buildOperatorNode(c.text, c.pos)
 
 }
 
-func (p *parser) callonNode34() (any, error) {
+func (p *parser) callonNode42() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onNode34()
+	return p.cur.onNode42()
 }
 
-func (c *current) onNode36() (any, error) {
+func (c *current) onNode44() (any, error) {
 	return buildOperatorNode(c.text, c.pos)
 
 }
 
-func (p *parser) callonNode36() (any, error) {
+func (p *parser) callonNode44() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onNode36()
+	return p.cur.onNode44()
+}
+
+func (c *current) onNode46() (any, error) {
+	return buildOperatorNode(c.text, c.pos)
+
+}
+
+func (p *parser) callonNode46() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onNode46()
 }
 
 func (c *current) onNode48() (any, error) {
-	return c.text, nil
+	return buildOperatorNode(c.text, c.pos)
 
 }
 
@@ -1746,7 +1942,7 @@ func (p *parser) callonNode48() (any, error) {
 }
 
 func (c *current) onNode50() (any, error) {
-	return c.text, nil
+	return buildOperatorNode(c.text, c.pos)
 
 }
 
@@ -1757,7 +1953,7 @@ func (p *parser) callonNode50() (any, error) {
 }
 
 func (c *current) onNode52() (any, error) {
-	return c.text, nil
+	return buildOperatorNode(c.text, c.pos)
 
 }
 
@@ -1767,59 +1963,15 @@ func (p *parser) callonNode52() (any, error) {
 	return p.cur.onNode52()
 }
 
-func (c *current) onNode54() (any, error) {
+func (c *current) onNode64() (any, error) {
 	return c.text, nil
 
 }
 
-func (p *parser) callonNode54() (any, error) {
+func (p *parser) callonNode64() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onNode54()
-}
-
-func (c *current) onNode46() (any, error) {
-	return c.text, nil
-
-}
-
-func (p *parser) callonNode46() (any, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onNode46()
-}
-
-func (c *current) onNode59() (any, error) {
-	return c.text, nil
-
-}
-
-func (p *parser) callonNode59() (any, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onNode59()
-}
-
-func (c *current) onNode61() (any, error) {
-	return c.text, nil
-
-}
-
-func (p *parser) callonNode61() (any, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onNode61()
-}
-
-func (c *current) onNode57() (any, error) {
-	return c.text, nil
-
-}
-
-func (p *parser) callonNode57() (any, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onNode57()
+	return p.cur.onNode64()
 }
 
 func (c *current) onNode66() (any, error) {
@@ -1844,26 +1996,26 @@ func (p *parser) callonNode68() (any, error) {
 	return p.cur.onNode68()
 }
 
-func (c *current) onNode64() (any, error) {
+func (c *current) onNode70() (any, error) {
 	return c.text, nil
 
 }
 
-func (p *parser) callonNode64() (any, error) {
+func (p *parser) callonNode70() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onNode64()
+	return p.cur.onNode70()
 }
 
-func (c *current) onNode44() (any, error) {
+func (c *current) onNode62() (any, error) {
 	return c.text, nil
 
 }
 
-func (p *parser) callonNode44() (any, error) {
+func (p *parser) callonNode62() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onNode44()
+	return p.cur.onNode62()
 }
 
 func (c *current) onNode75() (any, error) {
@@ -1932,15 +2084,15 @@ func (p *parser) callonNode80() (any, error) {
 	return p.cur.onNode80()
 }
 
-func (c *current) onNode89() (any, error) {
+func (c *current) onNode60() (any, error) {
 	return c.text, nil
 
 }
 
-func (p *parser) callonNode89() (any, error) {
+func (p *parser) callonNode60() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onNode89()
+	return p.cur.onNode60()
 }
 
 func (c *current) onNode91() (any, error) {
@@ -1954,26 +2106,59 @@ func (p *parser) callonNode91() (any, error) {
 	return p.cur.onNode91()
 }
 
-func (c *current) onNode87() (any, error) {
+func (c *current) onNode93() (any, error) {
 	return c.text, nil
 
 }
 
-func (p *parser) callonNode87() (any, error) {
+func (p *parser) callonNode93() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onNode87()
+	return p.cur.onNode93()
 }
 
-func (c *current) onNode97() (any, error) {
+func (c *current) onNode89() (any, error) {
 	return c.text, nil
 
 }
 
-func (p *parser) callonNode97() (any, error) {
+func (p *parser) callonNode89() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onNode97()
+	return p.cur.onNode89()
+}
+
+func (c *current) onNode98() (any, error) {
+	return c.text, nil
+
+}
+
+func (p *parser) callonNode98() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onNode98()
+}
+
+func (c *current) onNode100() (any, error) {
+	return c.text, nil
+
+}
+
+func (p *parser) callonNode100() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onNode100()
+}
+
+func (c *current) onNode96() (any, error) {
+	return c.text, nil
+
+}
+
+func (p *parser) callonNode96() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onNode96()
 }
 
 func (c *current) onNode105() (any, error) {
@@ -2009,92 +2194,70 @@ func (p *parser) callonNode103() (any, error) {
 	return p.cur.onNode103()
 }
 
-func (c *current) onNode112() (any, error) {
+func (c *current) onNode113() (any, error) {
 	return c.text, nil
 
 }
 
-func (p *parser) callonNode112() (any, error) {
+func (p *parser) callonNode113() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onNode112()
+	return p.cur.onNode113()
 }
 
-func (c *current) onNode114() (any, error) {
+func (c *current) onNode121() (any, error) {
 	return c.text, nil
 
 }
 
-func (p *parser) callonNode114() (any, error) {
+func (p *parser) callonNode121() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onNode114()
+	return p.cur.onNode121()
 }
 
-func (c *current) onNode110() (any, error) {
+func (c *current) onNode123() (any, error) {
 	return c.text, nil
 
 }
 
-func (p *parser) callonNode110() (any, error) {
+func (p *parser) callonNode123() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onNode110()
+	return p.cur.onNode123()
 }
 
-func (c *current) onNode71() (any, error) {
+func (c *current) onNode119() (any, error) {
 	return c.text, nil
 
 }
 
-func (p *parser) callonNode71() (any, error) {
+func (p *parser) callonNode119() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onNode71()
+	return p.cur.onNode119()
 }
 
-func (c *current) onNode42() (any, error) {
+func (c *current) onNode128() (any, error) {
 	return c.text, nil
 
 }
 
-func (p *parser) callonNode42() (any, error) {
+func (p *parser) callonNode128() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onNode42()
+	return p.cur.onNode128()
 }
 
-func (c *current) onNode120() (any, error) {
+func (c *current) onNode130() (any, error) {
 	return c.text, nil
 
 }
 
-func (p *parser) callonNode120() (any, error) {
+func (p *parser) callonNode130() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onNode120()
-}
-
-func (c *current) onNode122() (any, error) {
-	return c.text, nil
-
-}
-
-func (p *parser) callonNode122() (any, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onNode122()
-}
-
-func (c *current) onNode124() (any, error) {
-	return c.text, nil
-
-}
-
-func (p *parser) callonNode124() (any, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onNode124()
+	return p.cur.onNode130()
 }
 
 func (c *current) onNode126() (any, error) {
@@ -2108,48 +2271,37 @@ func (p *parser) callonNode126() (any, error) {
 	return p.cur.onNode126()
 }
 
-func (c *current) onNode118() (any, error) {
+func (c *current) onNode87() (any, error) {
 	return c.text, nil
 
 }
 
-func (p *parser) callonNode118() (any, error) {
+func (p *parser) callonNode87() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onNode118()
+	return p.cur.onNode87()
 }
 
-func (c *current) onNode131() (any, error) {
+func (c *current) onNode58() (any, error) {
 	return c.text, nil
 
 }
 
-func (p *parser) callonNode131() (any, error) {
+func (p *parser) callonNode58() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onNode131()
+	return p.cur.onNode58()
 }
 
-func (c *current) onNode133() (any, error) {
+func (c *current) onNode136() (any, error) {
 	return c.text, nil
 
 }
 
-func (p *parser) callonNode133() (any, error) {
+func (p *parser) callonNode136() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onNode133()
-}
-
-func (c *current) onNode129() (any, error) {
-	return c.text, nil
-
-}
-
-func (p *parser) callonNode129() (any, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onNode129()
+	return p.cur.onNode136()
 }
 
 func (c *current) onNode138() (any, error) {
@@ -2174,103 +2326,103 @@ func (p *parser) callonNode140() (any, error) {
 	return p.cur.onNode140()
 }
 
-func (c *current) onNode136() (any, error) {
+func (c *current) onNode142() (any, error) {
 	return c.text, nil
 
 }
 
-func (p *parser) callonNode136() (any, error) {
+func (p *parser) callonNode142() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onNode136()
+	return p.cur.onNode142()
 }
 
-func (c *current) onNode116() (any, error) {
+func (c *current) onNode134() (any, error) {
 	return c.text, nil
 
 }
 
-func (p *parser) callonNode116() (any, error) {
+func (p *parser) callonNode134() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onNode116()
+	return p.cur.onNode134()
 }
 
-func (c *current) onNode146() (any, error) {
+func (c *current) onNode147() (any, error) {
 	return c.text, nil
 
 }
 
-func (p *parser) callonNode146() (any, error) {
+func (p *parser) callonNode147() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onNode146()
+	return p.cur.onNode147()
 }
 
-func (c *current) onNode148() (any, error) {
+func (c *current) onNode149() (any, error) {
 	return c.text, nil
 
 }
 
-func (p *parser) callonNode148() (any, error) {
+func (p *parser) callonNode149() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onNode148()
+	return p.cur.onNode149()
 }
 
-func (c *current) onNode144() (any, error) {
+func (c *current) onNode145() (any, error) {
 	return c.text, nil
 
 }
 
-func (p *parser) callonNode144() (any, error) {
+func (p *parser) callonNode145() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onNode144()
+	return p.cur.onNode145()
 }
 
-func (c *current) onNode153() (any, error) {
+func (c *current) onNode154() (any, error) {
 	return c.text, nil
 
 }
 
-func (p *parser) callonNode153() (any, error) {
+func (p *parser) callonNode154() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onNode153()
+	return p.cur.onNode154()
 }
 
-func (c *current) onNode155() (any, error) {
+func (c *current) onNode156() (any, error) {
 	return c.text, nil
 
 }
 
-func (p *parser) callonNode155() (any, error) {
+func (p *parser) callonNode156() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onNode155()
+	return p.cur.onNode156()
 }
 
-func (c *current) onNode151() (any, error) {
+func (c *current) onNode152() (any, error) {
 	return c.text, nil
 
 }
 
-func (p *parser) callonNode151() (any, error) {
+func (p *parser) callonNode152() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onNode151()
+	return p.cur.onNode152()
 }
 
-func (c *current) onNode160() (any, error) {
+func (c *current) onNode132() (any, error) {
 	return c.text, nil
 
 }
 
-func (p *parser) callonNode160() (any, error) {
+func (p *parser) callonNode132() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onNode160()
+	return p.cur.onNode132()
 }
 
 func (c *current) onNode162() (any, error) {
@@ -2284,26 +2436,59 @@ func (p *parser) callonNode162() (any, error) {
 	return p.cur.onNode162()
 }
 
-func (c *current) onNode158() (any, error) {
+func (c *current) onNode164() (any, error) {
 	return c.text, nil
 
 }
 
-func (p *parser) callonNode158() (any, error) {
+func (p *parser) callonNode164() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onNode158()
+	return p.cur.onNode164()
 }
 
-func (c *current) onNode168() (any, error) {
+func (c *current) onNode160() (any, error) {
 	return c.text, nil
 
 }
 
-func (p *parser) callonNode168() (any, error) {
+func (p *parser) callonNode160() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onNode168()
+	return p.cur.onNode160()
+}
+
+func (c *current) onNode169() (any, error) {
+	return c.text, nil
+
+}
+
+func (p *parser) callonNode169() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onNode169()
+}
+
+func (c *current) onNode171() (any, error) {
+	return c.text, nil
+
+}
+
+func (p *parser) callonNode171() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onNode171()
+}
+
+func (c *current) onNode167() (any, error) {
+	return c.text, nil
+
+}
+
+func (p *parser) callonNode167() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onNode167()
 }
 
 func (c *current) onNode176() (any, error) {
@@ -2339,195 +2524,184 @@ func (p *parser) callonNode174() (any, error) {
 	return p.cur.onNode174()
 }
 
-func (c *current) onNode183() (any, error) {
+func (c *current) onNode184() (any, error) {
 	return c.text, nil
 
 }
 
-func (p *parser) callonNode183() (any, error) {
+func (p *parser) callonNode184() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onNode183()
+	return p.cur.onNode184()
 }
 
-func (c *current) onNode185() (any, error) {
+func (c *current) onNode192() (any, error) {
 	return c.text, nil
 
 }
 
-func (p *parser) callonNode185() (any, error) {
+func (p *parser) callonNode192() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onNode185()
+	return p.cur.onNode192()
 }
 
-func (c *current) onNode181() (any, error) {
+func (c *current) onNode194() (any, error) {
 	return c.text, nil
 
 }
 
-func (p *parser) callonNode181() (any, error) {
+func (p *parser) callonNode194() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onNode181()
+	return p.cur.onNode194()
 }
 
-func (c *current) onNode142() (any, error) {
+func (c *current) onNode190() (any, error) {
 	return c.text, nil
 
 }
 
-func (p *parser) callonNode142() (any, error) {
+func (p *parser) callonNode190() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onNode142()
+	return p.cur.onNode190()
 }
 
-func (c *current) onNode18(k, o, v any) (any, error) {
+func (c *current) onNode199() (any, error) {
+	return c.text, nil
+
+}
+
+func (p *parser) callonNode199() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onNode199()
+}
+
+func (c *current) onNode201() (any, error) {
+	return c.text, nil
+
+}
+
+func (p *parser) callonNode201() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onNode201()
+}
+
+func (c *current) onNode197() (any, error) {
+	return c.text, nil
+
+}
+
+func (p *parser) callonNode197() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onNode197()
+}
+
+func (c *current) onNode158() (any, error) {
+	return c.text, nil
+
+}
+
+func (p *parser) callonNode158() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onNode158()
+}
+
+func (c *current) onNode26(k, o, v any) (any, error) {
 	return buildDateTimeNode(k, o, v, c.text, c.pos)
 
 }
 
-func (p *parser) callonNode18() (any, error) {
+func (p *parser) callonNode26() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onNode18(stack["k"], stack["o"], stack["v"])
+	return p.cur.onNode26(stack["k"], stack["o"], stack["v"])
 }
 
-func (c *current) onNode193() (any, error) {
+func (c *current) onNode211() (any, error) {
 	return c.text, nil
 
 }
 
-func (p *parser) callonNode193() (any, error) {
+func (p *parser) callonNode211() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onNode193()
+	return p.cur.onNode211()
 }
 
-func (c *current) onNode196() (any, error) {
-	return buildOperatorNode(c.text, c.pos)
-
-}
-
-func (p *parser) callonNode196() (any, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onNode196()
-}
-
-func (c *current) onNode198() (any, error) {
-	return buildOperatorNode(c.text, c.pos)
-
-}
-
-func (p *parser) callonNode198() (any, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onNode198()
-}
-
-func (c *current) onNode213() (any, error) {
+func (c *current) onNode217() (any, error) {
 	return c.text, nil
-
-}
-
-func (p *parser) callonNode213() (any, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onNode213()
-}
-
-func (c *current) onNode189(k, v any) (any, error) {
-	return buildNaturalLanguageDateTimeNodes(k, v, c.text, c.pos)
-
-}
-
-func (p *parser) callonNode189() (any, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onNode189(stack["k"], stack["v"])
-}
-
-func (c *current) onNode221() (any, error) {
-	return c.text, nil
-
-}
-
-func (p *parser) callonNode221() (any, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onNode221()
-}
-
-func (c *current) onNode224() (any, error) {
-	return buildOperatorNode(c.text, c.pos)
-
-}
-
-func (p *parser) callonNode224() (any, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onNode224()
-}
-
-func (c *current) onNode226() (any, error) {
-	return buildOperatorNode(c.text, c.pos)
-
-}
-
-func (p *parser) callonNode226() (any, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onNode226()
-}
-
-func (c *current) onNode230(v any) (any, error) {
-	return v, nil
-
-}
-
-func (p *parser) callonNode230() (any, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onNode230(stack["v"])
-}
-
-func (c *current) onNode217(k, v any) (any, error) {
-	return buildStringNode(k, v, c.text, c.pos)
 
 }
 
 func (p *parser) callonNode217() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onNode217(stack["k"], stack["v"])
+	return p.cur.onNode217()
 }
 
-func (c *current) onNode239() (any, error) {
+func (c *current) onNode208() (any, error) {
+	return c.text, nil
+
+}
+
+func (p *parser) callonNode208() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onNode208()
+}
+
+func (c *current) onNode220() (any, error) {
 	return buildOperatorNode(c.text, c.pos)
 
 }
 
-func (p *parser) callonNode239() (any, error) {
+func (p *parser) callonNode220() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onNode239()
+	return p.cur.onNode220()
 }
 
-func (c *current) onNode243() (any, error) {
+func (c *current) onNode222() (any, error) {
 	return buildOperatorNode(c.text, c.pos)
 
 }
 
-func (p *parser) callonNode243() (any, error) {
+func (p *parser) callonNode222() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onNode243()
+	return p.cur.onNode222()
+}
+
+func (c *current) onNode237() (any, error) {
+	return c.text, nil
+
+}
+
+func (p *parser) callonNode237() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onNode237()
+}
+
+func (c *current) onNode205(k, v any) (any, error) {
+	return buildNaturalLanguageDateTimeNodes(k, v, c.text, c.pos)
+
+}
+
+func (p *parser) callonNode205() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onNode205(stack["k"], stack["v"])
 }
 
 func (c *current) onNode247() (any, error) {
-	return buildOperatorNode(c.text, c.pos)
+	return c.text, nil
 
 }
 
@@ -2537,107 +2711,118 @@ func (p *parser) callonNode247() (any, error) {
 	return p.cur.onNode247()
 }
 
-func (c *current) onNode252() (any, error) {
+func (c *current) onNode253() (any, error) {
+	return c.text, nil
+
+}
+
+func (p *parser) callonNode253() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onNode253()
+}
+
+func (c *current) onNode244() (any, error) {
+	return c.text, nil
+
+}
+
+func (p *parser) callonNode244() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onNode244()
+}
+
+func (c *current) onNode256() (any, error) {
 	return buildOperatorNode(c.text, c.pos)
 
 }
 
-func (p *parser) callonNode252() (any, error) {
+func (p *parser) callonNode256() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onNode252()
+	return p.cur.onNode256()
 }
 
-func (c *current) onNode254() (any, error) {
-	return nil, nil
-
-}
-
-func (p *parser) callonNode254() (any, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onNode254()
-}
-
-func (c *current) onNode258(v any) (any, error) {
-	return v, nil
+func (c *current) onNode258() (any, error) {
+	return buildOperatorNode(c.text, c.pos)
 
 }
 
 func (p *parser) callonNode258() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onNode258(stack["v"])
+	return p.cur.onNode258()
 }
 
-func (c *current) onNode265(v any) (any, error) {
-	return nil, nil
+func (c *current) onNode262(v any) (any, error) {
+	return v, nil
 
 }
 
-func (p *parser) callonNode265() (any, error) {
+func (p *parser) callonNode262() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onNode265(stack["v"])
+	return p.cur.onNode262(stack["v"])
 }
 
-func (c *current) onNode269() (any, error) {
+func (c *current) onNode241(k, v any) (any, error) {
+	return buildStringNode(k, v, c.text, c.pos)
+
+}
+
+func (p *parser) callonNode241() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onNode241(stack["k"], stack["v"])
+}
+
+func (c *current) onNode271() (any, error) {
 	return buildOperatorNode(c.text, c.pos)
 
 }
 
-func (p *parser) callonNode269() (any, error) {
+func (p *parser) callonNode271() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onNode269()
+	return p.cur.onNode271()
 }
 
-func (c *current) onNode249(v any) (any, error) {
-	return buildStringNode("", v, c.text, c.pos)
-
-}
-
-func (p *parser) callonNode249() (any, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onNode249(stack["v"])
-}
-
-func (c *current) onNode274() (any, error) {
+func (c *current) onNode275() (any, error) {
 	return buildOperatorNode(c.text, c.pos)
 
 }
 
-func (p *parser) callonNode274() (any, error) {
+func (p *parser) callonNode275() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onNode274()
+	return p.cur.onNode275()
 }
 
-func (c *current) onNode276() (any, error) {
-	return nil, nil
+func (c *current) onNode279() (any, error) {
+	return buildOperatorNode(c.text, c.pos)
 
 }
 
-func (p *parser) callonNode276() (any, error) {
+func (p *parser) callonNode279() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onNode276()
+	return p.cur.onNode279()
 }
 
-func (c *current) onNode282(v any) (any, error) {
-	return nil, nil
+func (c *current) onNode284() (any, error) {
+	return buildOperatorNode(c.text, c.pos)
 
 }
 
-func (p *parser) callonNode282() (any, error) {
+func (p *parser) callonNode284() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onNode282(stack["v"])
+	return p.cur.onNode284()
 }
 
 func (c *current) onNode286() (any, error) {
-	return buildOperatorNode(c.text, c.pos)
+	return nil, nil
 
 }
 
@@ -2647,48 +2832,158 @@ func (p *parser) callonNode286() (any, error) {
 	return p.cur.onNode286()
 }
 
-func (c *current) onNode271(v any) (any, error) {
+func (c *current) onNode290(v any) (any, error) {
+	return v, nil
+
+}
+
+func (p *parser) callonNode290() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onNode290(stack["v"])
+}
+
+func (c *current) onNode297(v any) (any, error) {
+	return nil, nil
+
+}
+
+func (p *parser) callonNode297() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onNode297(stack["v"])
+}
+
+func (c *current) onNode301() (any, error) {
+	return buildOperatorNode(c.text, c.pos)
+
+}
+
+func (p *parser) callonNode301() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onNode301()
+}
+
+func (c *current) onNode281(v any) (any, error) {
 	return buildStringNode("", v, c.text, c.pos)
 
 }
 
-func (p *parser) callonNode271() (any, error) {
+func (p *parser) callonNode281() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onNode271(stack["v"])
+	return p.cur.onNode281(stack["v"])
 }
 
-func (c *current) onGroupNode6() (any, error) {
+func (c *current) onNode306() (any, error) {
+	return buildOperatorNode(c.text, c.pos)
+
+}
+
+func (p *parser) callonNode306() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onNode306()
+}
+
+func (c *current) onNode308() (any, error) {
+	return nil, nil
+
+}
+
+func (p *parser) callonNode308() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onNode308()
+}
+
+func (c *current) onNode314(v any) (any, error) {
+	return nil, nil
+
+}
+
+func (p *parser) callonNode314() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onNode314(stack["v"])
+}
+
+func (c *current) onNode318() (any, error) {
+	return buildOperatorNode(c.text, c.pos)
+
+}
+
+func (p *parser) callonNode318() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onNode318()
+}
+
+func (c *current) onNode303(v any) (any, error) {
+	return buildStringNode("", v, c.text, c.pos)
+
+}
+
+func (p *parser) callonNode303() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onNode303(stack["v"])
+}
+
+func (c *current) onGroupNode8() (any, error) {
 	return c.text, nil
 
 }
 
-func (p *parser) callonGroupNode6() (any, error) {
+func (p *parser) callonGroupNode8() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onGroupNode6()
+	return p.cur.onGroupNode8()
 }
 
-func (c *current) onGroupNode10() (any, error) {
+func (c *current) onGroupNode14() (any, error) {
+	return c.text, nil
+
+}
+
+func (p *parser) callonGroupNode14() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onGroupNode14()
+}
+
+func (c *current) onGroupNode5() (any, error) {
+	return c.text, nil
+
+}
+
+func (p *parser) callonGroupNode5() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onGroupNode5()
+}
+
+func (c *current) onGroupNode18() (any, error) {
 	return buildOperatorNode(c.text, c.pos)
 
 }
 
-func (p *parser) callonGroupNode10() (any, error) {
+func (p *parser) callonGroupNode18() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onGroupNode10()
+	return p.cur.onGroupNode18()
 }
 
-func (c *current) onGroupNode12() (any, error) {
+func (c *current) onGroupNode20() (any, error) {
 	return buildOperatorNode(c.text, c.pos)
 
 }
 
-func (p *parser) callonGroupNode12() (any, error) {
+func (p *parser) callonGroupNode20() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onGroupNode12()
+	return p.cur.onGroupNode20()
 }
 
 func (c *current) onGroupNode1(k, v any) (any, error) {

--- a/pkg/kql/dictionary_test.go
+++ b/pkg/kql/dictionary_test.go
@@ -927,7 +927,7 @@ func TestParse_DottedKey(t *testing.T) {
 				},
 			},
 		},
-		// Multi-level key exercises the ("." Char+)* kleene in the Key rule.
+		// Multi-level key exercises the ("." Char+)* Kleene in the Key rule.
 		{
 			name: `foo.bar.baz:qux`,
 			ast: &ast.Ast{

--- a/pkg/kql/dictionary_test.go
+++ b/pkg/kql/dictionary_test.go
@@ -916,6 +916,61 @@ func TestParse_Errors(t *testing.T) {
 	}
 }
 
+func TestParse_DottedKey(t *testing.T) {
+	tests := []testCase{
+		// TextPropertyRestrictionNode with a dotted key.
+		{
+			name: `audio.artist:Motörhead`,
+			ast: &ast.Ast{
+				Nodes: []ast.Node{
+					&ast.StringNode{Key: "audio.artist", Value: "Motörhead"},
+				},
+			},
+		},
+		// Multi-level key exercises the ("." Char+)* kleene in the Key rule.
+		{
+			name: `foo.bar.baz:qux`,
+			ast: &ast.Ast{
+				Nodes: []ast.Node{
+					&ast.StringNode{Key: "foo.bar.baz", Value: "qux"},
+				},
+			},
+		},
+		// GroupNode also uses the Key rule via k:Key?.
+		{
+			name: `audio.artist:("Motörhead" OR Beatles)`,
+			ast: &ast.Ast{
+				Nodes: []ast.Node{
+					&ast.GroupNode{
+						Key: "audio.artist",
+						Nodes: []ast.Node{
+							&ast.StringNode{Value: "Motörhead"},
+							&ast.OperatorNode{Value: kql.BoolOR},
+							&ast.StringNode{Value: "Beatles"},
+						},
+					},
+				},
+			},
+		},
+		// A dot on the value side is still a literal character.
+		{
+			name: `name:foo.bar`,
+			ast: &ast.Ast{
+				Nodes: []ast.Node{
+					&ast.StringNode{Key: "name", Value: "foo.bar"},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			testKQL(t, tc)
+		})
+	}
+}
+
 func TestParse_Stress(t *testing.T) {
 	tests := []testCase{
 		{


### PR DESCRIPTION
## Summary
- Extend the KQL grammar with a dedicated `Key` rule (`Char+ ("." Char+)*`), used wherever property restrictions previously required `Char+`.
- Regenerate `pkg/kql/dictionary_gen.go` via pigeon.

This lets the KQL parser accept dotted keys that mirror the nested structure of a driveItem, such as `audio.artist`, `photo.cameraMake`, `image.width`, ... .

## Why this matters

Microsoft Graph's KQL implementation uses a flat property namespace: every searchable field is a "managed property" (`author`, `title`, `filetype`, …) that an admin configures. Nested data in driveItems - photo metadata, EXIF, location - is visible in API responses but not queryable, unless an admin manually maps each field to a refinable slot (`RefinableString07:Konzept`).

OpenCloud's approach: the data structure *is* the query namespace. If a response shows `photo.cameraMake: "Canon"`, the query `photo.cameraMake:Canon` should just work - no alias table, no admin mapping, no slot numbers. None of the bookkeeping Microsoft Graph requires.

Both bleve and OpenSearch already interpret dots as the nesting separator for field paths, and the existing compilers (`services/search/pkg/query/bleve/compiler.go`, `services/search/pkg/opensearch/internal/convert/kql_expand.go`) pass unknown keys through to the backend unchanged. The only artificial constraint was in the KQL grammar, where `Char <- [A-Za-z]` rejected any dot in a key before the backend ever saw the AST. Lifting that restriction is a single-rule change.

## Out of scope

- **Backslash-escaped literal dots in segment names** (e.g. `@libre\.graph\.motionPhoto`). Both backends treat dots strictly as nesting separators, so a literal dot inside a single segment would require sanitisation to underscores at the index boundary and a corresponding escape in the grammar. The grammar change to support this is straightforward, but not needed today -no indexed field currently has a literal dot in a segment name.
- **Case-sensitivity of query values.** Both backends currently lowercase every query value before handing it to the engine. With this PR alone, `audio.artist:Motörhead` parses, but the lowercased `motörhead` doesn't match the case-preserved tokens actually in the index, so the query returns zero hits. Independent change, follow-up PR.