### PR TITLE
fix(search): preserve value case for non-lowercased bleve fields

### DIFF
--- a/services/search/pkg/bleve/backend_test.go
+++ b/services/search/pkg/bleve/backend_test.go
@@ -138,16 +138,15 @@ var _ = Describe("Bleve", func() {
 				assertDocCount(rootResource.ID, "Size:>100000", 0)
 			})
 
-			// FIXME: switch Title to audio.artist once
-			// https://github.com/opencloud-eu/opencloud/pull/2632 lands
-			// (KQL grammar then accepts dotted keys).
 			It("preserves value case for fields not explicitly marked lowercase", func() {
-				parentResource.Document.Title = "Some Title"
+				parentResource.Document.Audio = &libregraph.Audio{
+					Artist: libregraph.PtrString("Some Artist"),
+				}
 				err := eng.Upsert(parentResource.ID, parentResource)
 				Expect(err).ToNot(HaveOccurred())
 
-				assertDocCount(rootResource.ID, `Title:"Some Title"`, 1)
-				assertDocCount(rootResource.ID, `Title:"some title"`, 0)
+				assertDocCount(rootResource.ID, `audio.artist:"Some Artist"`, 1)
+				assertDocCount(rootResource.ID, `audio.artist:"some artist"`, 0)
 			})
 		})
 

--- a/services/search/pkg/bleve/backend_test.go
+++ b/services/search/pkg/bleve/backend_test.go
@@ -137,6 +137,18 @@ var _ = Describe("Bleve", func() {
 				assertDocCount(rootResource.ID, "Size:<1000", 0)
 				assertDocCount(rootResource.ID, "Size:>100000", 0)
 			})
+
+			// FIXME: switch Title to audio.artist once
+			// https://github.com/opencloud-eu/opencloud/pull/2632 lands
+			// (KQL grammar then accepts dotted keys).
+			It("preserves value case for fields not explicitly marked lowercase", func() {
+				parentResource.Document.Title = "Some Title"
+				err := eng.Upsert(parentResource.ID, parentResource)
+				Expect(err).ToNot(HaveOccurred())
+
+				assertDocCount(rootResource.ID, `Title:"Some Title"`, 1)
+				assertDocCount(rootResource.ID, `Title:"some title"`, 0)
+			})
 		})
 
 		Context("by filename", func() {

--- a/services/search/pkg/query/bleve/compiler.go
+++ b/services/search/pkg/query/bleve/compiler.go
@@ -10,6 +10,17 @@ import (
 	"github.com/opencloud-eu/opencloud/pkg/kql"
 )
 
+// lowercaseFields lists the bleve fields whose index mapping uses a lowercasing analyzer.
+// Values bound to these fields are pre-lowercased so that non-analyzed query types
+// (e.g. wildcard, fuzzy) still match the lowercased terms in the index.
+// Keep in sync with services/search/pkg/bleve/index.go NewMapping.
+var lowercaseFields = map[string]bool{
+	"Name":      true,
+	"Tags":      true,
+	"Favorites": true,
+	"Content":   true,
+}
+
 var _fields = map[string]string{
 	"rootid":    "RootID",
 	"path":      "Path",
@@ -91,7 +102,7 @@ func walk(offset int, nodes []ast.Node) (bleveQuery.Query, int, error) {
 				v = bleveEscaper.Replace(n.Value)
 			}
 
-			if k != "Hidden" {
+			if lowercaseFields[k] {
 				v = strings.ToLower(v)
 			}
 

--- a/services/search/pkg/query/bleve/compiler.go
+++ b/services/search/pkg/query/bleve/compiler.go
@@ -14,11 +14,11 @@ import (
 // lowercasing analyzer. Values bound to these fields are pre-lowercased
 // so query-side matching stays consistent with the index.
 // Keep in sync with services/search/pkg/bleve/index.go NewMapping.
-var lowercaseFields = map[string]bool{
-	"Name":      true,
-	"Tags":      true,
-	"Favorites": true,
-	"Content":   true,
+var lowercaseFields = map[string]struct{}{
+	"Name":      {},
+	"Tags":      {},
+	"Favorites": {},
+	"Content":   {},
 }
 
 var _fields = map[string]string{
@@ -102,7 +102,7 @@ func walk(offset int, nodes []ast.Node) (bleveQuery.Query, int, error) {
 				v = bleveEscaper.Replace(n.Value)
 			}
 
-			if lowercaseFields[k] {
+			if _, ok := lowercaseFields[k]; ok {
 				v = strings.ToLower(v)
 			}
 

--- a/services/search/pkg/query/bleve/compiler.go
+++ b/services/search/pkg/query/bleve/compiler.go
@@ -10,9 +10,9 @@ import (
 	"github.com/opencloud-eu/opencloud/pkg/kql"
 )
 
-// lowercaseFields lists the bleve fields whose index mapping uses a lowercasing analyzer.
-// Values bound to these fields are pre-lowercased so that non-analyzed query types
-// (e.g. wildcard, fuzzy) still match the lowercased terms in the index.
+// lowercaseFields lists the bleve fields whose index mapping uses a
+// lowercasing analyzer. Values bound to these fields are pre-lowercased
+// so query-side matching stays consistent with the index.
 // Keep in sync with services/search/pkg/bleve/index.go NewMapping.
 var lowercaseFields = map[string]bool{
 	"Name":      true,

--- a/services/search/pkg/query/bleve/compiler_test.go
+++ b/services/search/pkg/query/bleve/compiler_test.go
@@ -227,8 +227,8 @@ func Test_compile(t *testing.T) {
 				},
 			},
 			want: query.NewConjunctionQuery([]query.Query{
-				query.NewQueryStringQuery(`author:john\ smith`),
-				query.NewQueryStringQuery(`author:jane`),
+				query.NewQueryStringQuery(`author:John\ Smith`),
+				query.NewQueryStringQuery(`author:Jane`),
 			}),
 			wantErr: false,
 		},
@@ -249,8 +249,8 @@ func Test_compile(t *testing.T) {
 				},
 			},
 			want: query.NewConjunctionQuery([]query.Query{
-				query.NewQueryStringQuery(`author:john\ smith`),
-				query.NewQueryStringQuery(`author:jane`),
+				query.NewQueryStringQuery(`author:John\ Smith`),
+				query.NewQueryStringQuery(`author:Jane`),
 				query.NewQueryStringQuery(`Tags:bestseller`),
 			}),
 			wantErr: false,


### PR DESCRIPTION
## Summary
- Replace the unconditional `strings.ToLower(v)` in the bleve compiler with a small allowlist (`Name`, `Tags`, `Favorites`, `Content`) that matches the fields whose index mapping uses a lowercasing analyzer.
- Update the existing `author:("John Smith" Jane)` compiler tests; those names are not in the allowlist, so the compiler now preserves case.
- Add an end-to-end regression in `bleve/backend_test.go`: `Title:"Some Title"` returns 1 hit, `Title:"some title"` returns 0 hits.

## Why

The previous compiler lowercased every query value before emitting a bleve `QueryStringQuery`. That was a workaround for the four fields whose analyzer lowercases at index time — without the compiler-side fold, a query like `Name:Report.pdf` wouldn't match the indexed `report.pdf`. But every other field uses the default `keyword` analyzer, which preserves case. For those, the unconditional lowercasing silently turned `audio.artist:Motörhead`, `Title:"Some Title"`, `Path:"./Some Dir"`, etc. into lookups against tokens that didn't exist in the index.

The allowlist approach puts the case-folding decision next to the field mapping it mirrors. If a future field opts into a lowercasing analyzer, it gets added to the allowlist; otherwise it preserves case — which is also what value identity and aggregation display need. Names like `deadmau5` or `Motörhead` stay the way the tag writer wrote them.

## Out of scope

- OpenSearch backend. Its default dynamic mapping uses `text` (standard analyzer, tokenised + lowercased) with a `.keyword` multi-field. The equivalent change there requires switching the `TermQuery` emission to `MatchQuery` for text fields (analyser applies) and using `.keyword` for aggregations. Separate PR, once aggregations are actually implemented.
- The dotted-key KQL grammar (`audio.artist:…`) lives in #2632. The regression test in this PR uses `Title` as a stand-in and has a FIXME pointing at that PR — once it lands, `Title` can be swapped for `audio.artist`.