### PR TITLE
fix: allow buildOpencloudBinaryForTesting if SKIP_WORKFLOW is true

### DIFF
--- a/.woodpecker.star
+++ b/.woodpecker.star
@@ -893,8 +893,7 @@ def scanOpencloud(ctx):
 def buildOpencloudBinaryForTesting(ctx):
     pipeline = {
         "name": "build-opencloud-for-testing",
-        "steps": skipCheckStep(ctx, "base") +
-                 makeNodeGenerate("") +
+        "steps": makeNodeGenerate("") +
                  makeGoGenerate("") +
                  build() +
                  rebuildBuildArtifactCache(ctx, dirs["opencloudBinArtifact"], dirs["opencloudBinPath"]),
@@ -905,10 +904,6 @@ def buildOpencloudBinaryForTesting(ctx):
         ],
         "workspace": workspace,
     }
-    prefixStepCommands(pipeline, [
-        ". ./.woodpecker.env",
-        '[ "$SKIP_WORKFLOW" = "true" ] && exit 0',
-    ])
     return [pipeline]
 
 def vendorbinCodestyle(phpVersion):


### PR DESCRIPTION
related https://github.com/opencloud-eu/opencloud/pull/2616

### Issue: 

If `skipCheckStep`(ctx, "base") returned true,
`buildOpencloudBinaryForTesting` failed because it could not skip `genericCache`, which depends on the plugin artifact produced by this step.

As a result, the pipeline failed when only base files were changed.
```
base = [
        ".github/**",
        ".vscode/**",
        "docs/**",
        "deployments/**",
        "CHANGELOG.md",
        "CONTRIBUTING.md",
        "LICENSE",
        "README.md",
    ]
    unit = [
        "**/*_test.go",
    ]
    acceptance = [
        "tests/acceptance/**",
    ]
```

<img width="1485" height="608" alt="image" src="https://github.com/user-attachments/assets/2b4c84d0-a091-4058-91d0-3a28333617e3" />

### Solution:

Removed `skipCheckStep(ctx, "base")` from `buildOpencloudBinaryForTesting`.

Now:

- buildOpencloudBinaryForTesting always runs
- Tests are still skipped when only base files are changed
- Pipeline works correctly in all cases


