### PR TITLE
fix(search): parse tika xmpDM:duration as a float

### DIFF
--- a/services/search/pkg/content/tika.go
+++ b/services/search/pkg/content/tika.go
@@ -264,9 +264,10 @@ func (t Tika) getAudio(meta map[string][]string) *libregraph.Audio {
 	//  TODO: audio.DiscCount: not provided by tika
 
 	if v, err := getFirstValue(meta, "xmpDM:duration"); err == nil {
-		if i, err := strconv.ParseInt(v, 10, 64); err == nil {
+		// Tika emits fractional seconds.
+		if f, err := strconv.ParseFloat(v, 64); err == nil {
 			initAudio()
-			audio.SetDuration(i * 1000)
+			audio.SetDuration(int64(f * 1000))
 		}
 	}
 

--- a/services/search/pkg/content/tika.go
+++ b/services/search/pkg/content/tika.go
@@ -267,7 +267,7 @@ func (t Tika) getAudio(meta map[string][]string) *libregraph.Audio {
 		// Tika emits fractional seconds.
 		if f, err := strconv.ParseFloat(v, 64); err == nil {
 			initAudio()
-			audio.SetDuration(int64(f * 1000))
+			audio.SetDuration(int64(math.Round(f * 1000)))
 		}
 	}
 

--- a/services/search/pkg/content/tika_test.go
+++ b/services/search/pkg/content/tika_test.go
@@ -108,7 +108,7 @@ var _ = Describe("Tika", func() {
 					"xmpDM:audioSampleRate": "44100",
 					"channels": "2",
 					"dc:title": "Some Title",
-					"xmpDM:duration": "225",
+					"xmpDM:duration": "225.5",
 					"Content-Type": "audio/mpeg",
 					"samplerate": "44100"
 				}
@@ -130,7 +130,7 @@ var _ = Describe("Tika", func() {
 			// Expect(audio.Copyright).To(Equal(libregraph.PtrString("Some Copyright")))
 			Expect(audio.Disc).To(Equal(libregraph.PtrInt32(4)))
 			// Expect(audio.DiscCount).To(Equal(libregraph.PtrInt32(5)))
-			Expect(audio.Duration).To(Equal(libregraph.PtrInt64(225000)))
+			Expect(audio.Duration).To(Equal(libregraph.PtrInt64(225500)))
 			Expect(audio.Genre).To(Equal(libregraph.PtrString("Some Genre")))
 			// Expect(audio.HasDrm).To(Equal(libregraph.PtrBool(false)))
 			// Expect(audio.IsVariableBitrate).To(Equal(libregraph.PtrBool(true)))


### PR DESCRIPTION
## Description

Parse the `xmpDM:duration` metadata value Tika returns with `strconv.ParseFloat` instead of `strconv.ParseInt`, and convert the result to milliseconds when calling `audio.SetDuration`.

## Related Issue

No tracking issue yet — happy to open one if preferred.

## Motivation and Context

Tika emits `xmpDM:duration` as seconds in floating-point form (e.g. `"154.57379150390625"`). `strconv.ParseInt` rejects the decimal separator, returns an error, and the whole block is skipped — so every audio item indexed through the Tika extractor ended up without a duration, silently.

Symptom in the Graph API: `audio` facets on driveItem search hits never included `duration`, even for MP3 files Tika parses happily.

## How Has This Been Tested?

- test environment: local dev stack (OpenCloud + Tika 3.3.0 on `localhost:9998`, bleve search engine), `opencloud search index --all-spaces --force-rescan` after the patch (separate fix PR upcoming)
- `go test ./services/search/pkg/content/...` — the existing extractor spec now exercises the fractional case (`"225.5"` → `225500` ms); all 12 specs pass
- OGG/FLAC files remain without duration (Tika doesn't emit `xmpDM:duration` for them — that's a separate upstream limitation, not this PR's concern)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:

- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added