### PR TITLE
fix(search): read --force-rescan flag with its registered name

### DIFF
--- a/services/search/pkg/command/index.go
+++ b/services/search/pkg/command/index.go
@@ -29,7 +29,7 @@ func Index(cfg *config.Config) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			allSpacesFlag, _ := cmd.Flags().GetBool("all-spaces")
 			spaceFlag, _ := cmd.Flags().GetString("space")
-			forceReindexFlag, _ := cmd.Flags().GetBool("force-reindex")
+			forceReindexFlag, _ := cmd.Flags().GetBool("force-rescan")
 			if spaceFlag == "" && !allSpacesFlag {
 				return errors.New("either --space or --all-spaces is required")
 			}

--- a/services/search/pkg/command/index.go
+++ b/services/search/pkg/command/index.go
@@ -29,7 +29,7 @@ func Index(cfg *config.Config) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			allSpacesFlag, _ := cmd.Flags().GetBool("all-spaces")
 			spaceFlag, _ := cmd.Flags().GetString("space")
-			forceReindexFlag, _ := cmd.Flags().GetBool("force-rescan")
+			forceRescanFlag, _ := cmd.Flags().GetBool("force-rescan")
 			if spaceFlag == "" && !allSpacesFlag {
 				return errors.New("either --space or --all-spaces is required")
 			}
@@ -50,7 +50,7 @@ func Index(cfg *config.Config) *cobra.Command {
 			c := searchsvc.NewSearchProviderService("eu.opencloud.api.search", grpcClient)
 			_, err = c.IndexSpace(context.Background(), &searchsvc.IndexSpaceRequest{
 				SpaceId:      spaceFlag,
-				ForceReindex: forceReindexFlag,
+				ForceReindex: forceRescanFlag,
 			}, func(opts *client.CallOptions) { opts.RequestTimeout = 10 * time.Minute })
 			if err != nil {
 				fmt.Println("failed to index space: " + err.Error())


### PR DESCRIPTION
## Description

Read the `--force-rescan` flag on `opencloud search index` under the name it is actually registered with.

## Related Issue

No tracking issue — happy to open one if preferred.

## Motivation and Context

`services/search/pkg/command/index.go` registers the flag as `--force-rescan` (help text uses "rescan" too) but reads its value via `cmd.Flags().GetBool("force-reindex")`. No flag by that name exists, so `GetBool` silently returns `false` and every invocation of `opencloud search index --force-rescan` ends up with a false flag value on the wire — the gRPC `IndexSpaceRequest.ForceReindex` field is always false, the searcher's `forceRescan` parameter is always false, and no rescan ever happens regardless of what the operator typed.

The one-line fix aligns the reader with the registered name. Everything else in this feature already speaks "rescan" (flag name, help text, internal variable inside the searcher); the only remaining occurrence of "reindex" is the proto field `ForceReindex`, which is left untouched so the wire format stays the same.

## How Has This Been Tested?

- test environment: local dev stack (OpenCloud + bleve search engine)
- test case 1: before the fix, `opencloud search index --all-spaces --force-rescan` did not rewrite bleve segments (existing indexed documents kept their old field values); after the fix, new `.zap` segments appear immediately and re-extracted metadata (e.g. `audio.duration`) shows up on search hits
- test case 2: `--force-rescan=false` (default) still skips up-to-date items, as expected

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:

- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added