### PR TITLE
feat: enable EnableRemoteLinkPicker WOPI flag for Collabora Online

### DIFF
--- a/services/collaboration/pkg/connector/fileconnector.go
+++ b/services/collaboration/pkg/connector/fileconnector.go
@@ -1278,6 +1278,7 @@ func (f *FileConnector) CheckFileInfo(ctx context.Context) (*ConnectorResponse, 
 		fileinfo.KeyEnableOwnerTermination:     true, // only for collabora
 		fileinfo.KeyEnableInsertRemoteImage:    true,
 		fileinfo.KeyEnableInsertRemoteFile:     true,
+		fileinfo.KeyEnableRemoteLinkPicker:     true,
 		fileinfo.KeySupportsExtendedLockLength: true,
 		fileinfo.KeySupportsGetLock:            true,
 		fileinfo.KeySupportsLocks:              true,

--- a/services/collaboration/pkg/connector/fileconnector_test.go
+++ b/services/collaboration/pkg/connector/fileconnector_test.go
@@ -1802,6 +1802,7 @@ var _ = Describe("FileConnector", func() {
 				PostMessageOrigin:       "https://cloud.opencloud.test",
 				EnableInsertRemoteImage: true,
 				EnableInsertRemoteFile:  true,
+				EnableRemoteLinkPicker:  true,
 				IsAnonymousUser:         true,
 			}
 
@@ -1995,6 +1996,7 @@ var _ = Describe("FileConnector", func() {
 				PostMessageOrigin:       "https://cloud.opencloud.test",
 				EnableInsertRemoteImage: true,
 				EnableInsertRemoteFile:  true,
+				EnableRemoteLinkPicker:  true,
 				IsAdminUser:             true,
 				UserExtraInfo: &fileinfo.UserExtraInfo{
 					Mail: "shaft@example.com",

--- a/services/collaboration/pkg/connector/fileinfo/collabora.go
+++ b/services/collaboration/pkg/connector/fileinfo/collabora.go
@@ -46,6 +46,8 @@ type Collabora struct {
 	EnableInsertRemoteImage bool `json:"EnableInsertRemoteImage,omitempty"`
 	// If set to true, this will enable the insertion of remote files chosen from the WOPI storage. A UI_InsertFile postMessage will be sent to the WOPI host to request the UI to select the file. This enables multimedia insertion and document comparison features.
 	EnableInsertRemoteFile bool `json:"EnableInsertRemoteFile,omitempty"`
+	// If set to true, this will enable picking a link to a remote file from the WOPI storage. A UI_PickLink postMessage will be sent to the WOPI host to request the UI to select the file. The host is expected to reply with an Action_InsertLink message carrying the file URL.
+	EnableRemoteLinkPicker bool `json:"EnableRemoteLinkPicker,omitempty"`
 	// If set to true, this will disable the insertion of image chosen from the local device. If EnableInsertRemoteImage is not set to true, then inserting images files is not possible.
 	DisableInsertLocalImage bool `json:"DisableInsertLocalImage,omitempty"`
 	// If set to true, hides the print option from the file menu bar in the UI.
@@ -124,6 +126,8 @@ func (cinfo *Collabora) SetProperties(props map[string]any) {
 			cinfo.EnableInsertRemoteImage = value.(bool)
 		case KeyEnableInsertRemoteFile:
 			cinfo.EnableInsertRemoteFile = value.(bool)
+		case KeyEnableRemoteLinkPicker:
+			cinfo.EnableRemoteLinkPicker = value.(bool)
 		case KeyDisableInsertLocalImage:
 			cinfo.DisableInsertLocalImage = value.(bool)
 		case KeyHidePrintOption:

--- a/services/collaboration/pkg/connector/fileinfo/fileinfo.go
+++ b/services/collaboration/pkg/connector/fileinfo/fileinfo.go
@@ -104,6 +104,7 @@ const (
 
 	KeyEnableInsertRemoteImage = "EnableInsertRemoteImage"
 	KeyEnableInsertRemoteFile  = "EnableInsertRemoteFile"
+	KeyEnableRemoteLinkPicker  = "EnableRemoteLinkPicker"
 	KeyDisableInsertLocalImage = "DisableInsertLocalImage"
 	KeyHidePrintOption         = "HidePrintOption"
 	KeyHideSaveOption          = "HideSaveOption"


### PR DESCRIPTION
Set EnableRemoteLinkPicker: true in CheckFileInfo response so
Collabora Online exposes its "Smart Picker" UI for link
insertion. Clicking it sends a UI_PickLink postMessage to the WOPI
host, which is expected to reply with Action_InsertLink carrying the
URL of the selected file. Follows the same pattern as the existing
EnableInsertRemoteImage / EnableInsertRemoteFile flags.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>

---

`go test ./services/collaboration/pkg/connector/...` passes

---

                                                                                                                                         
When the flag is enabled, clicking the Smart Picker button in Collabora fires a `UI_PickLink` postMessage to the WOPI host. The host opens its file picker and replies with `Action_InsertLink` carrying the selected document's URL (and an optional `text` label). 

The `text` label is honored upstream since CollaboraOnline/online#15561 (MERGED) — older coolwsd simply falls back to the URL. SDK reference: https://sdk.collaboraonline.com/docs/advanced_integration.html#enableremotelinkpicker
