### PR TITLE
fix(oidc): add override option for JWKS URI

### DIFF
--- a/pkg/oidc/client.go
+++ b/pkg/oidc/client.go
@@ -139,6 +139,11 @@ func (c *oidcClient) lookupWellKnownOpenidConfiguration(ctx context.Context) err
 				algs = append(algs, a)
 			}
 		}
+
+		if c.JWKSOptions.Uri != "" {
+			p.JwksURI = c.JWKSOptions.Uri
+		}
+
 		c.provider = &p
 		c.algorithms = algs
 		c.remoteKeySet = goidc.NewRemoteKeySet(goidc.ClientContext(ctx, c.httpClient), p.JwksURI)

--- a/services/proxy/pkg/config/config.go
+++ b/services/proxy/pkg/config/config.go
@@ -124,6 +124,7 @@ type OIDC struct {
 }
 
 type JWKS struct {
+	Uri               string `yaml:"uri" env:"PROXY_OIDC_JWKS_URI" desc:"An override for the JWKS URI endpoint of the IDP. This is used to fetch the public keys needed to verify JWT access tokens." introductionVersion:"6.2.0"`
 	RefreshInterval   uint64 `yaml:"refresh_interval" env:"PROXY_OIDC_JWKS_REFRESH_INTERVAL" desc:"The interval for refreshing the JWKS (JSON Web Key Set) in minutes in the background via a new HTTP request to the IDP." introductionVersion:"1.0.0"`
 	RefreshTimeout    uint64 `yaml:"refresh_timeout" env:"PROXY_OIDC_JWKS_REFRESH_TIMEOUT" desc:"The timeout in seconds for an outgoing JWKS request." introductionVersion:"1.0.0"`
 	RefreshRateLimit  uint64 `yaml:"refresh_limit" env:"PROXY_OIDC_JWKS_REFRESH_RATE_LIMIT" desc:"Limits the rate in seconds at which refresh requests are performed for unknown keys. This is used to prevent malicious clients from imposing high network load on the IDP via OpenCloud." introductionVersion:"1.0.0"`

--- a/services/proxy/pkg/config/defaults/defaultconfig.go
+++ b/services/proxy/pkg/config/defaults/defaultconfig.go
@@ -51,6 +51,7 @@ func DefaultConfig() *config.Config {
 				TTL:      time.Second * 10,
 			},
 			JWKS: config.JWKS{
+				Uri:               "",
 				RefreshInterval:   60, // minutes
 				RefreshRateLimit:  60, // seconds
 				RefreshTimeout:    10, // seconds


### PR DESCRIPTION
<!--
Thanks for submitting a change to OpenCloud!

For fixing potential security issues please see https://opencloud.eu/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the main branch which holds the next version of OpenCloud.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
This PR makes it so that admins can override the JWKS URI that is specified in the OIDC well-known configuration via an environment variable or config.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #2677

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Microsoft Entra ID is currently incompatible with OpenCloud, as their v2 issuer returns a v1 token for the MS Graph API that is signed by their v1 JWKS instead of their v2 JWKS that is referenced in their well-known configuration. See the linked issue above for more details. This fix will allow Microsoft Entra ID to be used with OpenCloud.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: Locally hosted and configured with Microsoft Entra ID for OIDC
- test case: Overrided JWKS URI to test successful access token verification

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added
