### PR TITLE
More graceful shutdown fixes

### DIFF
--- a/.woodpecker.star
+++ b/.woodpecker.star
@@ -2316,7 +2316,6 @@ def opencloudServer(storage = "decomposed", depends_on = [], deploy_type = "", e
     user = "0:0"
     container_name = OC_SERVER_NAME
     environment = {
-        "OC_CI_ENVIRONMENT": "true",
         "OC_URL": OC_URL,
         "OC_CONFIG_DIR": "/root/.opencloud/config",  # needed for checking config later
         "STORAGE_USERS_DRIVER": "%s" % storage,

--- a/opencloud/cmd/opencloud/main.go
+++ b/opencloud/cmd/opencloud/main.go
@@ -16,7 +16,7 @@ func main() {
 	// INFO: this is a hotfix, we need to replace suture and wait for nats to
 	//       gracefully shutdown using rungroups
 	// 		 see https://github.com/opencloud-eu/opencloud/issues/2282
-	if os.Getenv("OC_CI_ENVIRONMENT") == "true" {
+	if os.Getenv("TEST_SERVER_URL") == "" {
 		fmt.Println("Waiting for 30 seconds before exiting...")
 		time.Sleep(30 * time.Second)
 		fmt.Println("Exiting...")

--- a/opencloud/cmd/opencloud/main.go
+++ b/opencloud/cmd/opencloud/main.go
@@ -16,9 +16,7 @@ func main() {
 	// INFO: this is a hotfix, we need to replace suture and wait for nats to
 	//       gracefully shutdown using rungroups
 	// 		 see https://github.com/opencloud-eu/opencloud/issues/2282
-	if os.Getenv("TEST_SERVER_URL") == "" {
-		fmt.Println("Waiting for 30 seconds before exiting...")
-		time.Sleep(30 * time.Second)
-		fmt.Println("Exiting...")
-	}
+	fmt.Println("Waiting for 30 seconds before exiting...")
+	time.Sleep(30 * time.Second)
+	fmt.Println("Exiting...")
 }

--- a/opencloud/cmd/opencloud/main.go
+++ b/opencloud/cmd/opencloud/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"time"
 
 	"github.com/opencloud-eu/opencloud/opencloud/pkg/command"
 )
@@ -13,10 +12,4 @@ func main() {
 		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(1)
 	}
-	// INFO: this is a hotfix, we need to replace suture and wait for nats to
-	//       gracefully shutdown using rungroups
-	// 		 see https://github.com/opencloud-eu/opencloud/issues/2282
-	fmt.Println("Waiting for 30 seconds before exiting...")
-	time.Sleep(30 * time.Second)
-	fmt.Println("Exiting...")
 }

--- a/opencloud/cmd/opencloud/main.go
+++ b/opencloud/cmd/opencloud/main.go
@@ -16,7 +16,7 @@ func main() {
 	// INFO: this is a hotfix, we need to replace suture and wait for nats to
 	//       gracefully shutdown using rungroups
 	// 		 see https://github.com/opencloud-eu/opencloud/issues/2282
-	if os.Getenv("OC_CI_ENVIRONMENT") != "true" {
+	if os.Getenv("OC_CI_ENVIRONMENT") == "true" {
 		fmt.Println("Waiting for 30 seconds before exiting...")
 		time.Sleep(30 * time.Second)
 		fmt.Println("Exiting...")

--- a/opencloud/pkg/runtime/service/service.go
+++ b/opencloud/pkg/runtime/service/service.go
@@ -428,11 +428,8 @@ func Start(ctx context.Context, o ...Option) error {
 	// prepare the set of services to run
 	s.generateRunSet(s.cfg)
 
-	// There are reasons not to do this, but we have race conditions ourselves. Until we resolve them, mind the following disclaimer:
-	// Calling ServeBackground will CORRECTLY start the supervisor running in a new goroutine. It is risky to directly run
-	// go supervisor.Serve()
-	// because that will briefly create a race condition as it starts up, if you try to .Add() services immediately afterward.
-	// https://pkg.go.dev/github.com/thejerf/suture/v4@v4.0.0#Supervisor
+	// We need to control the order in which services are started and shut down,
+	// so we need a backgroud context that will outlive the service execution.
 	go s.Supervisor.ServeBackground(context.Background())
 
 	for i, service := range s.Services {

--- a/opencloud/pkg/runtime/service/service.go
+++ b/opencloud/pkg/runtime/service/service.go
@@ -433,7 +433,7 @@ func Start(ctx context.Context, o ...Option) error {
 	// go supervisor.Serve()
 	// because that will briefly create a race condition as it starts up, if you try to .Add() services immediately afterward.
 	// https://pkg.go.dev/github.com/thejerf/suture/v4@v4.0.0#Supervisor
-	go s.Supervisor.ServeBackground(ctx)
+	go s.Supervisor.ServeBackground(context.Background())
 
 	for i, service := range s.Services {
 		scheduleServiceTokens(s, service)

--- a/services/nats/pkg/command/server.go
+++ b/services/nats/pkg/command/server.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"os/signal"
-	"time"
 
 	"github.com/opencloud-eu/opencloud/pkg/config/configlog"
 	pkgcrypto "github.com/opencloud-eu/opencloud/pkg/crypto"
@@ -92,13 +91,7 @@ func Server(cfg *config.Config) *cobra.Command {
 			gr.Add(runner.New(cfg.Service.Name+".svc", func() error {
 				return natsServer.ListenAndServe()
 			}, func() {
-				// INFO: this is a hotfix, we need to replace suture and wait for nats to
-				//       gracefully shutdown using rungroups
-				// 		 see https://github.com/opencloud-eu/opencloud/issues/2282
-				logger.Info().Msg("Gracefully shutting down the NATS server...")
 				natsServer.Shutdown()
-				time.Sleep(5 * time.Second) // wait for the server to shutdown gracefully
-				logger.Info().Msg("NATS server shutdown")
 			}))
 
 			grResults := gr.Run(ctx)

--- a/services/nats/pkg/command/server.go
+++ b/services/nats/pkg/command/server.go
@@ -91,7 +91,9 @@ func Server(cfg *config.Config) *cobra.Command {
 			gr.Add(runner.New(cfg.Service.Name+".svc", func() error {
 				return natsServer.ListenAndServe()
 			}, func() {
+				logger.Info().Msg("Gracefully shutting down the NATS server...")
 				natsServer.Shutdown()
+				logger.Info().Msg("NATS server shutdown")
 			}))
 
 			grResults := gr.Run(ctx)

--- a/services/postprocessing/pkg/service/service.go
+++ b/services/postprocessing/pkg/service/service.go
@@ -88,7 +88,7 @@ func NewPostprocessingService(ctx context.Context, logger log.Logger, sto store.
 
 	m := metrics.New()
 	m.BuildInfo.WithLabelValues(version.GetString()).Set(1)
-	monitorMetrics(raw, "postprocessing-pull", m, logger)
+	monitorMetrics(ctx, raw, "postprocessing-pull", m, logger)
 
 	return &PostprocessingService{
 		ctx:     ctx,
@@ -423,25 +423,30 @@ func (pps *PostprocessingService) findUploadsByStep(step events.Postprocessingst
 	return ids
 }
 
-func monitorMetrics(stream raw.Stream, name string, m *metrics.Metrics, logger log.Logger) {
-	ctx := context.Background()
+func monitorMetrics(ctx context.Context, stream raw.Stream, name string, m *metrics.Metrics, logger log.Logger) {
 	consumer, err := stream.JetStream().Consumer(ctx, name)
 	if err != nil {
 		logger.Error().Err(err).Msg("failed to get consumer")
 	}
 	ticker := time.NewTicker(5 * time.Second)
 	go func() {
-		for range ticker.C {
-			info, err := consumer.Info(ctx)
-			if err != nil {
-				logger.Error().Err(err).Msg("failed to get consumer")
-				continue
-			}
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				info, err := consumer.Info(ctx)
+				if err != nil {
+					logger.Error().Err(err).Msg("failed to get consumer")
+					continue
+				}
 
-			m.EventsOutstandingAcks.Set(float64(info.NumAckPending))
-			m.EventsUnprocessed.Set(float64(info.NumPending))
-			m.EventsRedelivered.Set(float64(info.NumRedelivered))
-			logger.Trace().Msg("updated postprocessing event metrics")
+				m.EventsOutstandingAcks.Set(float64(info.NumAckPending))
+				m.EventsUnprocessed.Set(float64(info.NumPending))
+				m.EventsRedelivered.Set(float64(info.NumRedelivered))
+				logger.Trace().Msg("updated postprocessing event metrics")
+			}
 		}
 	}()
 }

--- a/services/search/pkg/service/event/service.go
+++ b/services/search/pkg/service/event/service.go
@@ -90,7 +90,7 @@ func (s Service) Run() error {
 	}
 
 	if s.m != nil {
-		monitorMetrics(s.stream, "search-pull", s.m, s.log)
+		monitorMetrics(s.ctx, s.stream, "search-pull", s.m, s.log)
 	}
 
 	var wg sync.WaitGroup
@@ -208,25 +208,30 @@ func (s Service) processEvent(e raw.Event) error {
 	return nil
 }
 
-func monitorMetrics(stream raw.Stream, name string, m *metrics.Metrics, logger log.Logger) {
-	ctx := context.Background()
+func monitorMetrics(ctx context.Context, stream raw.Stream, name string, m *metrics.Metrics, logger log.Logger) {
 	consumer, err := stream.JetStream().Consumer(ctx, name)
 	if err != nil {
 		logger.Error().Err(err).Msg("failed to get consumer")
 	}
 	ticker := time.NewTicker(5 * time.Second)
 	go func() {
-		for range ticker.C {
-			info, err := consumer.Info(ctx)
-			if err != nil {
-				logger.Error().Err(err).Msg("failed to get consumer")
-				continue
-			}
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				info, err := consumer.Info(ctx)
+				if err != nil {
+					logger.Error().Err(err).Msg("failed to get consumer")
+					continue
+				}
 
-			m.EventsOutstandingAcks.Set(float64(info.NumAckPending))
-			m.EventsUnprocessed.Set(float64(info.NumPending))
-			m.EventsRedelivered.Set(float64(info.NumRedelivered))
-			logger.Trace().Msg("updated search event metrics")
+				m.EventsOutstandingAcks.Set(float64(info.NumAckPending))
+				m.EventsUnprocessed.Set(float64(info.NumPending))
+				m.EventsRedelivered.Set(float64(info.NumRedelivered))
+				logger.Trace().Msg("updated search event metrics")
+			}
 		}
 	}()
 }

--- a/tests/ocwrapper/opencloud/opencloud.go
+++ b/tests/ocwrapper/opencloud/opencloud.go
@@ -153,24 +153,7 @@ func IsOpencloudRunning() bool {
 	return false
 }
 
-func waitAllServices(startTime time.Time, timeout time.Duration) {
-	timeoutS := timeout * time.Second
-
-	c := exec.Command(config.Get("bin"), "list")
-	_, err := c.CombinedOutput()
-	if err != nil {
-		if time.Since(startTime) <= timeoutS {
-			time.Sleep(500 * time.Millisecond)
-			waitAllServices(startTime, timeout)
-		}
-		return
-	}
-	log.Println("All services are up")
-}
-
 func WaitForConnection() (bool, string) {
-	waitAllServices(time.Now(), 30)
-	
 	transport := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}

--- a/tests/ocwrapper/opencloud/opencloud.go
+++ b/tests/ocwrapper/opencloud/opencloud.go
@@ -121,10 +121,19 @@ func Stop() (bool, string) {
 		return true, "OpenCloud server is not running"
 	}
 
-	exec.Command("sh", "-c", "pkill -9 -f 'opencloud|nats-server' 2>/dev/null || true").Run()
-	
+	err := cmd.Process.Signal(syscall.SIGINT)
+	if err != nil {
+		if !strings.HasSuffix(err.Error(), "process already finished") {
+			log.Fatalln(err)
+		} else {
+			return true, "OpenCloud server is already stopped"
+		}
+	}
+	cmd.Process.Wait()
+	success, message := waitUntilCompleteShutdown()
+
 	cmd = nil
-	return true, "OpenCloud server stopped successfully"
+	return success, message
 }
 
 func Restart(envMap []string) (bool, string) {
@@ -144,7 +153,24 @@ func IsOpencloudRunning() bool {
 	return false
 }
 
+func waitAllServices(startTime time.Time, timeout time.Duration) {
+	timeoutS := timeout * time.Second
+
+	c := exec.Command(config.Get("bin"), "list")
+	_, err := c.CombinedOutput()
+	if err != nil {
+		if time.Since(startTime) <= timeoutS {
+			time.Sleep(500 * time.Millisecond)
+			waitAllServices(startTime, timeout)
+		}
+		return
+	}
+	log.Println("All services are up")
+}
+
 func WaitForConnection() (bool, string) {
+	waitAllServices(time.Now(), 30)
+
 	transport := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}
@@ -188,7 +214,7 @@ func WaitForConnection() (bool, string) {
 }
 
 func waitUntilCompleteShutdown() (bool, string) {
-	timeout := 45 * time.Second
+	timeout := 30 * time.Second
 	startTime := time.Now()
 
 	c := exec.Command("sh", "-c", "ps ax | grep 'opencloud server' | grep -v grep | awk '{print $1}'")

--- a/tests/ocwrapper/opencloud/opencloud.go
+++ b/tests/ocwrapper/opencloud/opencloud.go
@@ -43,10 +43,6 @@ func Start(envMap []string) {
 	} else {
 		cmd.Env = append(os.Environ(), envMap...)
 	}
-	// Start the command in a new process group to be able to kill it and all its children
-	cmd.SysProcAttr = &syscall.SysProcAttr{
-		Setpgid: true,
-	}
 
 	logs, err := cmd.StderrPipe()
 	if err != nil {
@@ -125,12 +121,7 @@ func Stop() (bool, string) {
 		return true, "OpenCloud server is not running"
 	}
 
-	// kill the process group to stop the server and all its children
-	if cmd.Process != nil {
-		syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM)
-		time.Sleep(10 * time.Second)
-		syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
-	}
+	exec.Command("sh", "-c", "pkill -9 -f 'opencloud|nats-server' 2>/dev/null || true").Run()
 	
 	cmd = nil
 	return true, "OpenCloud server stopped successfully"


### PR DESCRIPTION
This reverts #2631 and contains an alternative fix for graceful shutdown via Suture by avoiding the Supervisor to be stopped early.