### PR TITLE
fix(webdav): register chi REPORT method in init to avoid race with settings

### DIFF
--- a/services/webdav/pkg/service/v0/service.go
+++ b/services/webdav/pkg/service/v0/service.go
@@ -45,6 +45,11 @@ var (
 	}
 )
 
+// register the REPORT method at init so it cannot race with concurrent route setup in other services.
+func init() {
+	chi.RegisterMethod("REPORT")
+}
+
 // Service defines the extension handlers.
 type Service interface {
 	ServeHTTP(w http.ResponseWriter, r *http.Request)
@@ -92,9 +97,6 @@ func NewService(opts ...Option) (Service, error) {
 	if svc.config.DisablePreviews {
 		svc.thumbnailsClient = nil
 	}
-
-	// register method with chi before any routing is set up
-	chi.RegisterMethod("REPORT")
 
 	m.Route(options.Config.HTTP.Root, func(r chi.Router) {
 


### PR DESCRIPTION
<!--
Status:Needs-Review
-->

## Description

Move `chi.RegisterMethod("REPORT")` from `webdav.NewService` into a package `init()` so it runs before any service goroutine is started by the suture supervisor.

## Related Issue

- Fixes #2686

## Motivation and Context

`chi.RegisterMethod` mutates the package-global `methodMap` in `github.com/go-chi/chi/v5`, which `(*node).setEndpoint` iterates during route insertion. opencloud starts many services concurrently under suture, so calling `RegisterMethod` inside `NewService` could race with another service's `mux.Route(...)` and trigger a "concurrent map iteration and map write" fatal (the stack in #2686). Doing it in `init()` happens during package import, before any supervised goroutine starts. `chi.RegisterMethod` is idempotent so it stays safe.

## How Has This Been Tested?

- `go build ./...` and `gofmt` on the affected package pass.
- `go test -race ./services/webdav/pkg/service/v0/...` builds cleanly under the race detector.

I do not have a deterministic local reproducer for the intermittent panic, but the race is visible in the chi source (a package-global map written by `RegisterMethod` and iterated by `setEndpoint`).

## Screenshots (if appropriate):

n/a

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added (changelog entry)
