### PR TITLE
allow configuring initial scan of the posix fs

### DIFF
--- a/services/storage-users/pkg/config/config.go
+++ b/services/storage-users/pkg/config/config.go
@@ -204,6 +204,7 @@ type PosixDriver struct {
 
 	EnableFSRevisions bool `yaml:"enable_fs_revisions" env:"STORAGE_USERS_POSIX_ENABLE_FS_REVISIONS" desc:"Allow for generating revisions from changes done to the local storage. Note: This doubles the number of bytes stored on disk because a copy of the current revision is stored to be turned into a revision later." introductionVersion:"1.0.0"`
 
+	ScanFS                   bool          `yaml:"scan_fs" env:"STORAGE_USERS_POSIX_SCAN_FS" desc:"Scan the filesystem on startup to update the metadata." introductionVersion:"%%NEXT%%"`
 	WatchFS                  bool          `yaml:"watch_fs" env:"STORAGE_USERS_POSIX_WATCH_FS" desc:"Enable the filesystem watcher to detect changes to the filesystem. This is used to detect changes to the filesystem and update the metadata accordingly." introductionVersion:"2.0.0"`
 	WatchType                string        `yaml:"watch_type" env:"STORAGE_USERS_POSIX_WATCH_TYPE" desc:"Type of the watcher to use for getting notified about changes to the filesystem. Currently available options are 'inotifywait' (default), 'cephfs', 'gpfswatchfolder' and 'gpfsfileauditlogging'." introductionVersion:"1.0.0"`
 	WatchPath                string        `yaml:"watch_path" env:"STORAGE_USERS_POSIX_WATCH_PATH" desc:"Path to the watch directory/file. Only applies to the 'gpfsfileauditlogging' and 'inotifywait' watcher, in which case it is the path of the file audit log file/base directory to watch." introductionVersion:"1.0.0"`

--- a/services/storage-users/pkg/config/defaults/defaultconfig.go
+++ b/services/storage-users/pkg/config/defaults/defaultconfig.go
@@ -151,6 +151,7 @@ func DefaultConfig() *config.Config {
 				PermissionsEndpoint:        "eu.opencloud.api.settings",
 				AsyncUploads:               true,
 				ScanDebounceDelay:          1 * time.Second,
+				ScanFS:                     true,
 				WatchFS:                    false,
 				EnableFSRevisions:          false,
 				InotifyStatsFrequency:      5 * time.Minute,

--- a/services/storage-users/pkg/revaconfig/user.go
+++ b/services/storage-users/pkg/revaconfig/user.go
@@ -15,7 +15,7 @@ func StorageProviderDrivers(cfg *config.Config) map[string]any {
 		"owncloudsql":  OwnCloudSQL(cfg),
 		"decomposed":   DecomposedNoEvents(cfg),
 		"decomposeds3": DecomposedS3NoEvents(cfg),
-		"posix":        Posix(cfg, true, cfg.Drivers.Posix.WatchFS),
+		"posix":        Posix(cfg, cfg.Drivers.Posix.ScanFS, cfg.Drivers.Posix.WatchFS),
 
 		"ocis": Decomposed(cfg),           // deprecated: use decomposed
 		"s3ng": DecomposedS3NoEvents(cfg), // deprecated: use decomposeds3


### PR DESCRIPTION
In kubernetes deployments additional pods may be started under load. We do not want to scan the fs at that time. We added a new `STORAGE_USERS_POSIX_SCAN_FS="true"` env var to toggle that. The default remains enabled.