### PR TITLE
fix(thumbnails): use matched resolution for thumbnail cache keys

### DIFF
--- a/services/thumbnails/pkg/thumbnail/resolutions.go
+++ b/services/thumbnails/pkg/thumbnail/resolutions.go
@@ -34,6 +34,15 @@ func ParseResolution(s string) (image.Rectangle, error) {
 // Resolutions is a list of image.Rectangle representing resolutions.
 type Resolutions []image.Rectangle
 
+func (rs Resolutions) contains(resolution image.Rectangle) bool {
+	for _, current := range rs {
+		if current == resolution {
+			return true
+		}
+	}
+	return false
+}
+
 // ParseResolutions creates an instance of Resolutions from resolution strings.
 func ParseResolutions(strs []string) (Resolutions, error) {
 	rs := make(Resolutions, 0, len(strs))

--- a/services/thumbnails/pkg/thumbnail/thumbnail.go
+++ b/services/thumbnails/pkg/thumbnail/thumbnail.go
@@ -63,6 +63,11 @@ func (s SimpleManager) Generate(r Request, img any) (string, error) {
 		return "", errors.ErrImageTooLarge
 	}
 
+	r.Resolution = match
+	if key, exists := s.checkThumbnail(r); exists {
+		return key, nil
+	}
+
 	thumbnail, err := r.Generator.Generate(match, img)
 	if err != nil {
 		return "", err
@@ -83,6 +88,13 @@ func (s SimpleManager) Generate(r Request, img any) (string, error) {
 
 // CheckThumbnail checks if a thumbnail with the requested attributes exists.
 func (s SimpleManager) CheckThumbnail(r Request) (string, bool) {
+	if len(s.resolutions) > 0 && !s.resolutions.contains(r.Resolution) {
+		return "", false
+	}
+	return s.checkThumbnail(r)
+}
+
+func (s SimpleManager) checkThumbnail(r Request) (string, bool) {
 	k := s.storage.BuildKey(mapToStorageRequest(r))
 	return k, s.storage.Stat(k)
 }

--- a/services/thumbnails/pkg/thumbnail/thumbnail_test.go
+++ b/services/thumbnails/pkg/thumbnail/thumbnail_test.go
@@ -1,7 +1,9 @@
 package thumbnail
 
 import (
+	"fmt"
 	"image"
+	"io"
 	"os"
 	"path"
 	"path/filepath"
@@ -29,6 +31,94 @@ func (m NoOpManager) BuildKey(_ storage.Request) string {
 
 func (m NoOpManager) Set(_, _ string, _ []byte) error {
 	return nil
+}
+
+type memoryThumbnailStorage struct {
+	files map[string][]byte
+	puts  []string
+}
+
+func newMemoryThumbnailStorage() *memoryThumbnailStorage {
+	return &memoryThumbnailStorage{
+		files: map[string][]byte{},
+	}
+}
+
+func (s *memoryThumbnailStorage) Stat(key string) bool {
+	_, ok := s.files[key]
+	return ok
+}
+
+func (s *memoryThumbnailStorage) Get(key string) ([]byte, error) {
+	content, ok := s.files[key]
+	if !ok {
+		return nil, os.ErrNotExist
+	}
+	return content, nil
+}
+
+func (s *memoryThumbnailStorage) Put(key string, img []byte) error {
+	s.files[key] = img
+	s.puts = append(s.puts, key)
+	return nil
+}
+
+func (s *memoryThumbnailStorage) BuildKey(r storage.Request) string {
+	filetype := "unknown"
+	if len(r.Types) > 0 {
+		filetype = r.Types[0]
+	}
+
+	characteristic := ""
+	if r.Characteristic != "" {
+		characteristic = "-" + r.Characteristic
+	}
+
+	return fmt.Sprintf(
+		"%s/%dx%d%s.%s",
+		r.Checksum,
+		r.Resolution.Dx(),
+		r.Resolution.Dy(),
+		characteristic,
+		filetype,
+	)
+}
+
+type recordingGenerator struct {
+	dimensions image.Rectangle
+	generated  []image.Rectangle
+}
+
+func (g *recordingGenerator) Generate(size image.Rectangle, _ any) (any, error) {
+	g.generated = append(g.generated, size)
+	return size, nil
+}
+
+func (g *recordingGenerator) Dimensions(_ any) (image.Rectangle, error) {
+	return g.dimensions, nil
+}
+
+func (g *recordingGenerator) ProcessorID() string {
+	return "fit"
+}
+
+type recordingEncoder struct{}
+
+func (e recordingEncoder) Encode(w io.Writer, img any) error {
+	rect, ok := img.(image.Rectangle)
+	if !ok {
+		return fmt.Errorf("expected image.Rectangle")
+	}
+	_, err := fmt.Fprintf(w, "%dx%d", rect.Dx(), rect.Dy())
+	return err
+}
+
+func (e recordingEncoder) Types() []string {
+	return []string{typeJpeg}
+}
+
+func (e recordingEncoder) MimeType() string {
+	return "image/jpeg"
 }
 
 func BenchmarkGet(b *testing.B) {
@@ -142,6 +232,79 @@ func TestPrepareRequest(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSimpleManagerGenerateUsesClosestMatchForStorageKey(t *testing.T) {
+	resolutions, _ := ParseResolutions([]string{"64x64", "128x128", "256x256", "512x512"})
+	store := newMemoryThumbnailStorage()
+	generator := &recordingGenerator{
+		dimensions: image.Rect(0, 0, 2000, 1500),
+	}
+	sut := NewSimpleManager(resolutions, store, log.NewLogger(), 7680, 7680)
+	req := Request{
+		Resolution: image.Rect(0, 0, 1000, 1000),
+		Encoder:    recordingEncoder{},
+		Generator:  generator,
+		Checksum:   "1872ade88f3013edeb33decd74a4f947",
+	}
+
+	key, err := sut.Generate(req, image.Rect(0, 0, 2000, 1500))
+
+	assert.NoError(t, err)
+	assert.Equal(t, "1872ade88f3013edeb33decd74a4f947/512x512-fit.jpeg", key)
+	assert.Equal(t, []image.Rectangle{image.Rect(0, 0, 512, 512)}, generator.generated)
+	assert.Equal(t, []string{key}, store.puts)
+	assert.Equal(t, []byte("512x512"), store.files[key])
+	assert.NotContains(t, store.files, "1872ade88f3013edeb33decd74a4f947/1000x1000-fit.jpeg")
+}
+
+func TestSimpleManagerGenerateUsesClosestMatchForCacheHit(t *testing.T) {
+	resolutions, _ := ParseResolutions([]string{"64x64", "128x128", "256x256", "512x512"})
+	store := newMemoryThumbnailStorage()
+	cachedKey := "1872ade88f3013edeb33decd74a4f947/512x512-fit.jpeg"
+	store.files[cachedKey] = []byte("cached")
+	generator := &recordingGenerator{
+		dimensions: image.Rect(0, 0, 2000, 1500),
+	}
+	sut := NewSimpleManager(resolutions, store, log.NewLogger(), 7680, 7680)
+	req := Request{
+		Resolution: image.Rect(0, 0, 1000, 1000),
+		Encoder:    recordingEncoder{},
+		Generator:  generator,
+		Checksum:   "1872ade88f3013edeb33decd74a4f947",
+	}
+
+	key, err := sut.Generate(req, image.Rect(0, 0, 2000, 1500))
+
+	assert.NoError(t, err)
+	assert.Equal(t, cachedKey, key)
+	assert.Empty(t, generator.generated)
+	assert.Empty(t, store.puts)
+}
+
+func TestSimpleManagerCheckThumbnailIgnoresNonConfiguredRequestSize(t *testing.T) {
+	resolutions, _ := ParseResolutions([]string{"64x64", "128x128", "256x256", "512x512"})
+	store := newMemoryThumbnailStorage()
+	store.files["1872ade88f3013edeb33decd74a4f947/1000x1000-fit.jpeg"] = []byte("stale")
+	store.files["1872ade88f3013edeb33decd74a4f947/512x512-fit.jpeg"] = []byte("cached")
+	sut := NewSimpleManager(resolutions, store, log.NewLogger(), 7680, 7680)
+	req := Request{
+		Resolution: image.Rect(0, 0, 1000, 1000),
+		Encoder:    recordingEncoder{},
+		Generator:  &recordingGenerator{},
+		Checksum:   "1872ade88f3013edeb33decd74a4f947",
+	}
+
+	key, exists := sut.CheckThumbnail(req)
+
+	assert.Empty(t, key)
+	assert.False(t, exists)
+
+	req.Resolution = image.Rect(0, 0, 512, 512)
+	key, exists = sut.CheckThumbnail(req)
+
+	assert.Equal(t, "1872ade88f3013edeb33decd74a4f947/512x512-fit.jpeg", key)
+	assert.True(t, exists)
 }
 
 func TestPreviewGenerationTooBigImage(t *testing.T) {

--- a/services/thumbnails/pkg/thumbnail/thumbnail_test.go
+++ b/services/thumbnails/pkg/thumbnail/thumbnail_test.go
@@ -18,7 +18,14 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/opencloud-eu/opencloud/pkg/log"
+	thumbnailconfig "github.com/opencloud-eu/opencloud/services/thumbnails/pkg/config"
 	"github.com/opencloud-eu/opencloud/services/thumbnails/pkg/thumbnail/storage"
+)
+
+const (
+	testThumbnailChecksum = "1872ade88f3013edeb33decd74a4f947"
+	testMatchedKey        = "18/72/ade88f3013edeb33decd74a4f947/512x512-fit.jpeg"
+	testRequestedKey      = "18/72/ade88f3013edeb33decd74a4f947/1000x1000-fit.jpeg"
 )
 
 type NoOpManager struct {
@@ -31,57 +38,6 @@ func (m NoOpManager) BuildKey(_ storage.Request) string {
 
 func (m NoOpManager) Set(_, _ string, _ []byte) error {
 	return nil
-}
-
-type memoryThumbnailStorage struct {
-	files map[string][]byte
-	puts  []string
-}
-
-func newMemoryThumbnailStorage() *memoryThumbnailStorage {
-	return &memoryThumbnailStorage{
-		files: map[string][]byte{},
-	}
-}
-
-func (s *memoryThumbnailStorage) Stat(key string) bool {
-	_, ok := s.files[key]
-	return ok
-}
-
-func (s *memoryThumbnailStorage) Get(key string) ([]byte, error) {
-	content, ok := s.files[key]
-	if !ok {
-		return nil, os.ErrNotExist
-	}
-	return content, nil
-}
-
-func (s *memoryThumbnailStorage) Put(key string, img []byte) error {
-	s.files[key] = img
-	s.puts = append(s.puts, key)
-	return nil
-}
-
-func (s *memoryThumbnailStorage) BuildKey(r storage.Request) string {
-	filetype := "unknown"
-	if len(r.Types) > 0 {
-		filetype = r.Types[0]
-	}
-
-	characteristic := ""
-	if r.Characteristic != "" {
-		characteristic = "-" + r.Characteristic
-	}
-
-	return fmt.Sprintf(
-		"%s/%dx%d%s.%s",
-		r.Checksum,
-		r.Resolution.Dx(),
-		r.Resolution.Dy(),
-		characteristic,
-		filetype,
-	)
 }
 
 type recordingGenerator struct {
@@ -119,6 +75,31 @@ func (e recordingEncoder) Types() []string {
 
 func (e recordingEncoder) MimeType() string {
 	return "image/jpeg"
+}
+
+func newManagerFixture(t *testing.T) (SimpleManager, storage.FileSystem, *recordingGenerator) {
+	t.Helper()
+
+	resolutions, err := ParseResolutions([]string{"64x64", "128x128", "256x256", "512x512"})
+	assert.NoError(t, err)
+
+	store := storage.NewFileSystemStorage(
+		thumbnailconfig.FileSystemStorage{RootDirectory: t.TempDir()},
+		log.NewLogger(),
+	)
+	generator := &recordingGenerator{dimensions: image.Rect(0, 0, 2000, 1500)}
+	manager := NewSimpleManager(resolutions, store, log.NewLogger(), 7680, 7680)
+
+	return manager, store, generator
+}
+
+func newTestThumbnailRequest(generator Generator, resolution image.Rectangle) Request {
+	return Request{
+		Resolution: resolution,
+		Encoder:    recordingEncoder{},
+		Generator:  generator,
+		Checksum:   testThumbnailChecksum,
+	}
 }
 
 func BenchmarkGet(b *testing.B) {
@@ -235,65 +216,40 @@ func TestPrepareRequest(t *testing.T) {
 }
 
 func TestSimpleManagerGenerateUsesClosestMatchForStorageKey(t *testing.T) {
-	resolutions, _ := ParseResolutions([]string{"64x64", "128x128", "256x256", "512x512"})
-	store := newMemoryThumbnailStorage()
-	generator := &recordingGenerator{
-		dimensions: image.Rect(0, 0, 2000, 1500),
-	}
-	sut := NewSimpleManager(resolutions, store, log.NewLogger(), 7680, 7680)
-	req := Request{
-		Resolution: image.Rect(0, 0, 1000, 1000),
-		Encoder:    recordingEncoder{},
-		Generator:  generator,
-		Checksum:   "1872ade88f3013edeb33decd74a4f947",
-	}
+	sut, store, generator := newManagerFixture(t)
+	req := newTestThumbnailRequest(generator, image.Rect(0, 0, 1000, 1000))
 
 	key, err := sut.Generate(req, image.Rect(0, 0, 2000, 1500))
 
 	assert.NoError(t, err)
-	assert.Equal(t, "1872ade88f3013edeb33decd74a4f947/512x512-fit.jpeg", key)
+	assert.Equal(t, testMatchedKey, key)
 	assert.Equal(t, []image.Rectangle{image.Rect(0, 0, 512, 512)}, generator.generated)
-	assert.Equal(t, []string{key}, store.puts)
-	assert.Equal(t, []byte("512x512"), store.files[key])
-	assert.NotContains(t, store.files, "1872ade88f3013edeb33decd74a4f947/1000x1000-fit.jpeg")
+	assert.False(t, store.Stat(testRequestedKey))
+
+	content, err := store.Get(key)
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("512x512"), content)
 }
 
 func TestSimpleManagerGenerateUsesClosestMatchForCacheHit(t *testing.T) {
-	resolutions, _ := ParseResolutions([]string{"64x64", "128x128", "256x256", "512x512"})
-	store := newMemoryThumbnailStorage()
-	cachedKey := "1872ade88f3013edeb33decd74a4f947/512x512-fit.jpeg"
-	store.files[cachedKey] = []byte("cached")
-	generator := &recordingGenerator{
-		dimensions: image.Rect(0, 0, 2000, 1500),
-	}
-	sut := NewSimpleManager(resolutions, store, log.NewLogger(), 7680, 7680)
-	req := Request{
-		Resolution: image.Rect(0, 0, 1000, 1000),
-		Encoder:    recordingEncoder{},
-		Generator:  generator,
-		Checksum:   "1872ade88f3013edeb33decd74a4f947",
-	}
+	sut, store, generator := newManagerFixture(t)
+	req := newTestThumbnailRequest(generator, image.Rect(0, 0, 1000, 1000))
+
+	assert.NoError(t, store.Put(testMatchedKey, []byte("cached")))
 
 	key, err := sut.Generate(req, image.Rect(0, 0, 2000, 1500))
 
 	assert.NoError(t, err)
-	assert.Equal(t, cachedKey, key)
+	assert.Equal(t, testMatchedKey, key)
 	assert.Empty(t, generator.generated)
-	assert.Empty(t, store.puts)
 }
 
 func TestSimpleManagerCheckThumbnailIgnoresNonConfiguredRequestSize(t *testing.T) {
-	resolutions, _ := ParseResolutions([]string{"64x64", "128x128", "256x256", "512x512"})
-	store := newMemoryThumbnailStorage()
-	store.files["1872ade88f3013edeb33decd74a4f947/1000x1000-fit.jpeg"] = []byte("stale")
-	store.files["1872ade88f3013edeb33decd74a4f947/512x512-fit.jpeg"] = []byte("cached")
-	sut := NewSimpleManager(resolutions, store, log.NewLogger(), 7680, 7680)
-	req := Request{
-		Resolution: image.Rect(0, 0, 1000, 1000),
-		Encoder:    recordingEncoder{},
-		Generator:  &recordingGenerator{},
-		Checksum:   "1872ade88f3013edeb33decd74a4f947",
-	}
+	sut, store, generator := newManagerFixture(t)
+	req := newTestThumbnailRequest(generator, image.Rect(0, 0, 1000, 1000))
+
+	assert.NoError(t, store.Put(testRequestedKey, []byte("stale")))
+	assert.NoError(t, store.Put(testMatchedKey, []byte("cached")))
 
 	key, exists := sut.CheckThumbnail(req)
 
@@ -303,7 +259,7 @@ func TestSimpleManagerCheckThumbnailIgnoresNonConfiguredRequestSize(t *testing.T
 	req.Resolution = image.Rect(0, 0, 512, 512)
 	key, exists = sut.CheckThumbnail(req)
 
-	assert.Equal(t, "1872ade88f3013edeb33decd74a4f947/512x512-fit.jpeg", key)
+	assert.Equal(t, testMatchedKey, key)
 	assert.True(t, exists)
 }
 


### PR DESCRIPTION

  ## Summary

  I noticed that in folders with many large images the previews loaded quite slow compared to Nextcloud or Immich.
  Because of that i did some investigations and found that the images that the web interface loads are not actually the preview images. After some digging i found this bug and created a fix for it:

  Fix thumbnail cache key generation so configured thumbnail resolutions are honored consistently.

  When `THUMBNAILS_RESOLUTIONS` is configured, arbitrary client-requested preview sizes should be mapped to the closest
  configured resolution. The thumbnail manager already calculated that closest match, but the storage key was still
  built from the raw requested dimensions.

  This caused requests such as `1000x1000` and `1920x1920` to create separate cache files even when both resolved to the
  same configured thumbnail size.

  ## Root Cause

  `SimpleManager.Generate` calculated the closest configured resolution:

  ```go
  match = s.resolutions.ClosestMatch(r.Resolution, inputDimensions)

  But the request resolution was not updated before building the cache key:

  thumbnail, err := r.Generator.Generate(match, img)
  k := s.storage.BuildKey(mapToStorageRequest(r))

  As a result, mapToStorageRequest(r) still used the client-requested size.

  ## Fix

  Normalize the request resolution to the matched configured resolution before cache lookup, generation, and storage:

  r.Resolution = match
  if key, exists := s.checkThumbnail(r); exists {
      return key, nil
  }

  Also avoid serving stale arbitrary-size cache entries when configured resolutions are present.

  ## Verification

  Tested with:

  THUMBNAILS_RESOLUTIONS=16x16,32x32,64x64,128x128,256x256,384x384,512x512,768x768

  Manual before/after Docker verification:

  | Build | Request | Response image | Cache file |
  |---|---:|---:|---|
  | before fix | 1000x1000 | 768x576 | 1000x1000-fit.jpeg |
  | before fix | 1920x1920 | 768x576 | 1920x1920-fit.jpeg |
  | after fix | 1000x1000 | 768x576 | 768x768-fit.jpeg |
  | after fix | 1920x1920 | 768x576 | reused 768x768-fit.jpeg |

  ## Tests

  Added unit tests covering:

  - generation stores thumbnails under the matched configured resolution
  - repeated arbitrary-size requests reuse the matched configured cache key
  - stale non-configured cache keys are ignored when configured resolutions exist

  Verified with libvips enabled:

  go test -tags enable_vips ./services/thumbnails/pkg/...
