### PR TITLE
delete unused constants

### DIFF
--- a/services/graph/pkg/service/v0/users.go
+++ b/services/graph/pkg/service/v0/users.go
@@ -36,7 +36,6 @@ import (
 	"github.com/opencloud-eu/opencloud/services/graph/pkg/identity"
 	"github.com/opencloud-eu/opencloud/services/graph/pkg/odata"
 	"github.com/opencloud-eu/opencloud/services/graph/pkg/userstate"
-	ocsettingssvc "github.com/opencloud-eu/opencloud/services/settings/pkg/service/v0"
 	"github.com/opencloud-eu/opencloud/services/settings/pkg/store/defaults"
 )
 
@@ -421,10 +420,10 @@ func (g Graph) PostUser(w http.ResponseWriter, r *http.Request) {
 		// to all new users for now, as create Account request does not have any role field
 		if _, err = g.roleService.AssignRoleToUser(r.Context(), &settingssvc.AssignRoleToUserRequest{
 			AccountUuid: *u.Id,
-			RoleId:      ocsettingssvc.BundleUUIDRoleUser,
+			RoleId:      defaults.BundleUUIDRoleUser,
 		}); err != nil {
 			// log as error, admin eventually needs to do something
-			logger.Error().Err(err).Str("id", *u.Id).Str("role", ocsettingssvc.BundleUUIDRoleUser).Msg("could not create user: role assignment failed")
+			logger.Error().Err(err).Str("id", *u.Id).Str("role", defaults.BundleUUIDRoleUser).Msg("could not create user: role assignment failed")
 			errorcode.GeneralException.Render(w, r, http.StatusInternalServerError, "role assignment failed")
 			return
 		}

--- a/services/proxy/pkg/userroles/defaultrole.go
+++ b/services/proxy/pkg/userroles/defaultrole.go
@@ -6,7 +6,7 @@ import (
 	cs3 "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	"github.com/opencloud-eu/opencloud/pkg/middleware"
 	settingssvc "github.com/opencloud-eu/opencloud/protogen/gen/opencloud/services/settings/v0"
-	settingsService "github.com/opencloud-eu/opencloud/services/settings/pkg/service/v0"
+	"github.com/opencloud-eu/opencloud/services/settings/pkg/store/defaults"
 	"github.com/opencloud-eu/reva/v2/pkg/utils"
 	"go-micro.dev/v4/metadata"
 )
@@ -44,9 +44,9 @@ func (d defaultRoleAssigner) UpdateUserRoleAssignment(ctx context.Context, user 
 			// default user role. At least until proper roles are provided. See
 			// https://github.com/owncloud/ocis/issues/1825 for more context.
 			if user.Id.Type == cs3.UserType_USER_TYPE_PRIMARY || user.Id.Type == cs3.UserType_USER_TYPE_GUEST {
-				roleId := settingsService.BundleUUIDRoleUser
+				roleId := defaults.BundleUUIDRoleUser
 				if user.Id.Type == cs3.UserType_USER_TYPE_GUEST {
-					roleId = settingsService.BundleUUIDRoleGuest
+					roleId = defaults.BundleUUIDRoleGuest
 				}
 				d.logger.Info().Str("userid", user.Id.OpaqueId).Msg("user has no role assigned, assigning default user role")
 				ctx = metadata.Set(ctx, middleware.AccountID, user.Id.OpaqueId)

--- a/services/settings/pkg/service/v0/settings.go
+++ b/services/settings/pkg/service/v0/settings.go
@@ -1,61 +1,13 @@
 package svc
 
 const (
-	// BundleUUIDRoleAdmin represents the admin role
-	BundleUUIDRoleAdmin = "71881883-1768-46bd-a24d-a356a2afdf7f"
-
-	// BundleUUIDRoleSpaceAdmin represents the space admin role
-	BundleUUIDRoleSpaceAdmin = "2aadd357-682c-406b-8874-293091995fdd"
-
-	// BundleUUIDRoleUser represents the user role.
-	BundleUUIDRoleUser = "d7beeea8-8ff4-406b-8fb6-ab2dd81e6b11"
-
-	// BundleUUIDRoleGuest represents the guest role.
-	BundleUUIDRoleGuest = "38071a68-456a-4553-846a-fa67bf5596cc"
 
 	// RoleManagementPermissionID is the hardcoded setting UUID for the role management permission
 	RoleManagementPermissionID string = "a53e601e-571f-4f86-8fec-d4576ef49c62"
-	// RoleManagementPermissionName is the hardcoded setting name for the role management permission
-	RoleManagementPermissionName string = "role-management"
 
 	// SettingsManagementPermissionID is the hardcoded setting UUID for the settings management permission
 	SettingsManagementPermissionID string = "3d58f441-4a05-42f8-9411-ef5874528ae1"
-	// SettingsManagementPermissionName is the hardcoded setting name for the settings management permission
-	SettingsManagementPermissionName string = "settings-management"
-
-	// SetSpaceQuotaPermissionID is the hardcoded setting UUID for the set space quota permission
-	SetSpaceQuotaPermissionID string = "4e6f9709-f9e7-44f1-95d4-b762d27b7896"
-	// SetSpaceQuotaPermissionName is the hardcoded setting name for the set space quota permission
-	SetSpaceQuotaPermissionName string = "set-space-quota"
-
-	// ListAllSpacesPermissionID is the hardcoded setting UUID for the list all spaces permission
-	ListAllSpacesPermissionID string = "016f6ddd-9501-4a0a-8ebe-64a20ee8ec82"
-	// ListAllSpacesPermissionName is the hardcoded setting name for the list all spaces permission
-	ListAllSpacesPermissionName string = "list-all-spaces"
-
-	// CreateSpacePermissionID is the hardcoded setting UUID for the create space permission
-	CreateSpacePermissionID string = "79e13b30-3e22-11eb-bc51-0b9f0bad9a58"
-	// CreateSpacePermissionName is the hardcoded setting name for the create space permission
-	CreateSpacePermissionName string = "create-space"
-
-	// SettingUUIDProfileLanguage is the hardcoded setting UUID for the user profile language
-	SettingUUIDProfileLanguage = "aa8cfbe5-95d4-4f7e-a032-c3c01f5f062f"
 
 	// AccountManagementPermissionID is the hardcoded setting UUID for the account management permission
 	AccountManagementPermissionID string = "8e587774-d929-4215-910b-a317b1e80f73"
-	// AccountManagementPermissionName is the hardcoded setting name for the account management permission
-	AccountManagementPermissionName string = "account-management"
-	// GroupManagementPermissionID is the hardcoded setting UUID for the group management permission
-	GroupManagementPermissionID string = "522adfbe-5908-45b4-b135-41979de73245"
-	// GroupManagementPermissionName is the hardcoded setting name for the group management permission
-	GroupManagementPermissionName string = "group-management"
-	// SelfManagementPermissionID is the hardcoded setting UUID for the self management permission
-	SelfManagementPermissionID string = "e03070e9-4362-4cc6-a872-1c7cb2eb2b8e"
-	// SelfManagementPermissionName is the hardcoded setting name for the self management permission
-	SelfManagementPermissionName string = "self-management"
-
-	// ChangeLogoPermissionID is the hardcoded setting UUID for the change-logo permission
-	ChangeLogoPermissionID string = "ed83fc10-1f54-4a9e-b5a7-fb517f5f3e01"
-	// ChangeLogoPermissionName is the hardcoded setting name for the change-logo permission
-	ChangeLogoPermissionName string = "change-logo"
 )

--- a/services/settings/pkg/store/defaults/defaults.go
+++ b/services/settings/pkg/store/defaults/defaults.go
@@ -14,6 +14,8 @@ const (
 	BundleUUIDRoleUser = "d7beeea8-8ff4-406b-8fb6-ab2dd81e6b11"
 	// BundleUUIDRoleUserLight represents the user light role.
 	BundleUUIDRoleUserLight = "38071a68-456a-4553-846a-fa67bf5596cc"
+	// BundleUUIDRoleGuest represents the guest role.
+	BundleUUIDRoleGuest = "38071a68-456a-4553-846a-fa67bf5596cc"
 	// BundleUUIDProfile represents the user profile.
 	BundleUUIDProfile = "2a506de7-99bd-4f0d-994e-c38e72c28fd9"
 	// BundleUUIDServiceAccount represents the service account role.


### PR DESCRIPTION
The deleted constants are no longer used. Permissions are mostly referenced by name, sth like "Drives.ReadWritePersonalQuota".

I moved the Guest bundle id to the defaults package with all the other bundle ids. The other permissionids need further investigation as they read the role ids from context. And the contexxt contains ID. They are filled in the proxy in UpdateUserRoleAssignment.

We could use the role names instead of ids, I think. but out of scope for this PR.