### PR TITLE
[stable/4.0] Backports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ COPY --from=generate /opencloud /opencloud
 WORKDIR /opencloud/opencloud
 RUN make go-generate build ENABLE_VIPS=true
 
-FROM alpine:3.20
+FROM alpine:3.23
 
 RUN apk add --no-cache attr ca-certificates curl mailcap tree vips && \
 	echo 'hosts: files dns' >| /etc/nsswitch.conf

--- a/opencloud/docker/Dockerfile.multiarch
+++ b/opencloud/docker/Dockerfile.multiarch
@@ -1,4 +1,4 @@
-FROM golang:alpine3.22 AS build
+FROM golang:alpine3.23 AS build
 ARG TARGETOS
 ARG TARGETARCH
 ARG VERSION
@@ -14,7 +14,7 @@ RUN --mount=type=bind,target=/build,rw \
     GOOS="${TARGETOS:-linux}" GOARCH="${TARGETARCH:-amd64}" ; \
     make -C opencloud/opencloud release-linux-docker-${TARGETARCH} ENABLE_VIPS=true DIST=/dist
 
-FROM alpine:3.22
+FROM alpine:3.23
 ARG VERSION
 ARG REVISION
 ARG TARGETOS

--- a/services/thumbnails/pkg/thumbnail/mimetypes_vips.go
+++ b/services/thumbnails/pkg/thumbnail/mimetypes_vips.go
@@ -2,6 +2,15 @@
 
 package thumbnail
 
+import "github.com/davidbyttow/govips/v2/vips"
+
+func init() {
+	// temporary remove TIFF and JP2K from go-vips' list of supported
+	// imagetypes
+	delete(vips.ImageTypes, vips.ImageTypeTIFF)
+	delete(vips.ImageTypes, vips.ImageTypeJP2K)
+}
+
 var (
 	// SupportedMimeTypes contains an all mimetypes which are supported by the thumbnailer.
 	SupportedMimeTypes = map[string]struct{}{
@@ -11,7 +20,6 @@ var (
 		"image/gif":                         {},
 		"image/bmp":                         {},
 		"image/x-ms-bmp":                    {},
-		"image/tiff":                        {},
 		"text/plain":                        {},
 		"audio/flac":                        {},
 		"audio/mpeg":                        {},


### PR DESCRIPTION
This cherry-picks the base image bump and tiff-disablement to the stable-4.0 branch.