### PR TITLE
docs(adr): Remove erroneous mention of kanidm

### DIFF
--- a/docs/adr/0003-oidc-client-config-discovery.md
+++ b/docs/adr/0003-oidc-client-config-discovery.md
@@ -18,7 +18,7 @@ OpenCloud with various existing identity providers. For example:
 - Authentik basically creates a different issuer URL for each client. As OpenCloud
   can only work with a single issuer URL, all OpenCloud clients need to use the
   same client id to work with Authentik.
-- Some IDPs (kanidm) are not able to work with user-supplied client ids. They generate
+- Some IDPs are not able to work with user-supplied client ids. They generate
   client ids automatically and do not allow to specify them manually.
 - To make features like automatic role assignment work, clients need to request
   specific scopes, depending on which exact IDP is used.


### PR DESCRIPTION
As pointed out in: https://github.com/opencloud-eu/opencloud/commit/2bf4f2e12ebf42718ebbaff1b006b8d29d47a483#r177716492

Apparently kanidm does allow to set the client-id.

