### PR TITLE
fix(debug): drop duplicate service field from probe fallback log

### DIFF
--- a/pkg/service/debug/service.go
+++ b/pkg/service/debug/service.go
@@ -29,8 +29,6 @@ var handleProbe = func(mux *http.ServeMux, pattern string, h http.Handler, logge
 	mux.Handle(pattern, h)
 }
 
-//var probeHandler = func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) }
-
 // NewService initializes a new debug service.
 func NewService(opts ...Option) *http.Server {
 	dopts := newOptions(opts...)

--- a/pkg/service/debug/service.go
+++ b/pkg/service/debug/service.go
@@ -18,11 +18,10 @@ import (
 	graphMiddleware "github.com/opencloud-eu/opencloud/services/graph/pkg/middleware"
 )
 
-var handleProbe = func(mux *http.ServeMux, pattern string, h http.Handler, name string, logger log.Logger) {
+var handleProbe = func(mux *http.ServeMux, pattern string, h http.Handler, logger log.Logger) {
 	if h == nil {
 		h = handlers.NewCheckHandler(handlers.NewCheckHandlerConfiguration())
 		logger.Info().
-			Str("service", name).
 			Str("endpoint", pattern).
 			Msg("no probe provided, reverting to default (OK)")
 	}
@@ -45,8 +44,8 @@ func NewService(opts ...Option) *http.Server {
 		promhttp.Handler(),
 	))
 
-	handleProbe(mux, "/healthz", dopts.Health, dopts.Name, dopts.Logger) // healthiness check
-	handleProbe(mux, "/readyz", dopts.Ready, dopts.Name, dopts.Logger)   // readiness check
+	handleProbe(mux, "/healthz", dopts.Health, dopts.Logger) // healthiness check
+	handleProbe(mux, "/readyz", dopts.Ready, dopts.Logger)   // readiness check
 
 	if dopts.ConfigDump != nil {
 		mux.Handle("/config", dopts.ConfigDump)


### PR DESCRIPTION
## Summary

The debug service's `handleProbe` helper emitted the `service` field twice in its JSON log line when no probe handler was supplied:

```
"message": [
  "{\"level\":\"info\",
    \"service\":\"clientlog\",
    \"service\":\"clientlog\",
    \"endpoint\":\"/healthz\",
    \"time\":\"...\",
    \"line\":\"...service.go:27\",
    \"message\":\"no probe provided, reverting to default (OK)\"}"
]
```

The base logger built by `log.Configure` (`pkg/log/log.go:119`) already attaches `service` to every log event via its context. `handleProbe` added it again with `Str("service", name)`, producing the duplicate key.

This was introduced in commit `043772235` ("Bugfix: Fix health and ready endpoint checker configurations") together with the default probe handler, so it has been present since that fallback log was added.

## Changes

- Remove the redundant `Str("service", name)` in `handleProbe`.
- Drop the now-unused `name` parameter and update both call sites.