### PR TITLE
fix(init): Only log admin password if it was generated

### DIFF
--- a/opencloud/pkg/command/init.go
+++ b/opencloud/pkg/command/init.go
@@ -35,9 +35,10 @@ func InitCommand(_ *config.Config) *cobra.Command {
 			}
 			forceOverwriteFlag := viper.GetBool("force-overwrite")
 			diffFlag, _ := cmd.Flags().GetBool("diff")
+			quietFlag, _ := cmd.Flags().GetBool("quiet")
 			configPathFlag := viper.GetString("config-path")
 			adminPasswordFlag := viper.GetString("admin-password")
-			err := ocinit.CreateConfig(insecure, forceOverwriteFlag, diffFlag, configPathFlag, adminPasswordFlag)
+			err := ocinit.CreateConfig(insecure, forceOverwriteFlag, diffFlag, configPathFlag, adminPasswordFlag, quietFlag)
 			if err != nil {
 				log.Fatalf("Could not create config: %s", err)
 			}
@@ -49,6 +50,7 @@ func InitCommand(_ *config.Config) *cobra.Command {
 	_ = viper.BindPFlag("insecure", initCmd.Flags().Lookup("insecure"))
 
 	initCmd.Flags().BoolP("diff", "d", false, "Show the difference between the current config and the new one")
+	initCmd.Flags().BoolP("quiet", "q", false, "Work quietly. Surpresses and non-error message")
 
 	initCmd.Flags().BoolP("force-overwrite", "f", false, "Force overwrite existing config file")
 	_ = viper.BindEnv("force-overwrite", "OC_FORCE_CONFIG_OVERWRITE")

--- a/opencloud/pkg/init/functions.go
+++ b/opencloud/pkg/init/functions.go
@@ -47,15 +47,22 @@ func backupOpenCloudConfigFile(configPath string) (string, error) {
 }
 
 // printBanner prints the generated opencloud config banner.
-func printBanner(targetPath, ocAdminServicePassword, targetBackupConfig string) {
+func printBanner(targetPath, ocAdminServicePassword string, adminPWgenerated bool, targetBackupConfig string) {
 	fmt.Printf(
 		"\n=========================================\n"+
 			" generated OpenCloud Config\n"+
 			"=========================================\n"+
-			" configpath : %s\n"+
-			" user       : admin\n"+
-			" password   : %s\n\n",
-		targetPath, ocAdminServicePassword)
+			" configpath : %s\n",
+		targetPath,
+	)
+	if adminPWgenerated {
+		fmt.Printf(" user       : admin\n"+
+			" password   : %s\n",
+			ocAdminServicePassword,
+		)
+	}
+	fmt.Println()
+
 	if targetBackupConfig != "" {
 		fmt.Printf("\n=========================================\n"+
 			"An older config file has been backed up to\n %s\n\n",
@@ -64,13 +71,15 @@ func printBanner(targetPath, ocAdminServicePassword, targetBackupConfig string) 
 }
 
 // writeConfig writes the config to the target path and prints a banner
-func writeConfig(configPath, ocAdminServicePassword, targetBackupConfig string, yamlOutput []byte) error {
+func writeConfig(configPath, ocAdminServicePassword, targetBackupConfig string, yamlOutput []byte, adminPWgenerated, quiet bool) error {
 	targetPath := path.Join(configPath, configFilename)
 	err := os.WriteFile(targetPath, yamlOutput, 0600)
 	if err != nil {
 		return err
 	}
-	printBanner(targetPath, ocAdminServicePassword, targetBackupConfig)
+	if !quiet {
+		printBanner(targetPath, ocAdminServicePassword, adminPWgenerated, targetBackupConfig)
+	}
 	return nil
 }
 

--- a/opencloud/pkg/init/init.go
+++ b/opencloud/pkg/init/init.go
@@ -22,7 +22,7 @@ var (
 )
 
 // CreateConfig creates a config file with random passwords at configPath
-func CreateConfig(insecure, forceOverwrite, diff bool, configPath, adminPassword string) error {
+func CreateConfig(insecure, forceOverwrite, diff bool, configPath, adminPassword string, quiet bool) error {
 	if diff && forceOverwrite {
 		return fmt.Errorf("diff and force-overwrite flags are mutually exclusive")
 	}
@@ -69,6 +69,7 @@ func CreateConfig(insecure, forceOverwrite, diff bool, configPath, adminPassword
 		idmServicePassword, idpServicePassword, ocAdminServicePassword, revaServicePassword  string
 		tokenManagerJwtSecret, collaborationWOPISecret, machineAuthAPIKey, systemUserAPIKey  string
 		revaTransferSecret, thumbnailsTransferSecret, serviceAccountSecret, urlSigningSecret string
+		adminPasswdwordGenerated                                                             bool
 	)
 
 	if diff {
@@ -123,6 +124,7 @@ func CreateConfig(insecure, forceOverwrite, diff bool, configPath, adminPassword
 			if err != nil {
 				return fmt.Errorf("could not generate random password for opencloud admin: %s", err)
 			}
+			adminPasswdwordGenerated = true
 		}
 
 		revaServicePassword, err = generators.GenerateRandomPassword(passwordLength)
@@ -311,5 +313,5 @@ func CreateConfig(insecure, forceOverwrite, diff bool, configPath, adminPassword
 	if diff {
 		return writePatch(configPath, yamlOutput)
 	}
-	return writeConfig(configPath, ocAdminServicePassword, targetBackupConfig, yamlOutput)
+	return writeConfig(configPath, ocAdminServicePassword, targetBackupConfig, yamlOutput, adminPasswdwordGenerated, quiet)
 }


### PR DESCRIPTION
This fixes `opencloud init` to only print the admin password if it was generated by `init`. No longer log is when is was set via env var or command line arguments.

Additionally add a `--quiet` command line flag to disable all non error output.

Fixes: #1022
