### PR TITLE
chore: fix dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,4 +12,4 @@ updates:
       interval: "daily"
     open-pull-requests-limit: 4
     cooldown:
-      default: 1
+      default-days: 1


### PR DESCRIPTION
It's `cooldown.default-days` not `cooldown.default`.
