### PR TITLE
feat: add EditorLitePlus sharing role (edit without delete)

### DIFF
--- a/services/graph/pkg/unifiedrole/conversion.go
+++ b/services/graph/pkg/unifiedrole/conversion.go
@@ -220,6 +220,8 @@ func cs3RoleToDisplayName(role *conversions.Role) string {
 		return _fileEditorUnifiedRoleDisplayName
 	case conversions.RoleFileEditorListGrants:
 		return _fileEditorListGrantsUnifiedRoleDisplayName
+	case conversions.RoleEditorLitePlus:
+		return _editorLitePlusUnifiedRoleDisplayName
 	case conversions.RoleEditorLite:
 		return _editorLiteUnifiedRoleDisplayName
 	case conversions.RoleManager:

--- a/services/graph/pkg/unifiedrole/roles.go
+++ b/services/graph/pkg/unifiedrole/roles.go
@@ -32,6 +32,8 @@ const (
 	UnifiedRoleFileEditorID = "2d00ce52-1fc2-4dbc-8b95-a73b73395f5a"
 	// UnifiedRoleFileEditorListGrantsID Unified role file editor id.
 	UnifiedRoleFileEditorListGrantsID = "c1235aea-d106-42db-8458-7d5610fb0a67"
+	// UnifiedRoleEditorLitePlusID Unified role editor-lite-plus id.
+	UnifiedRoleEditorLitePlusID = "48d8a2b0-d7c2-4b63-a0b5-2e3f5c9e8d1a"
 	// UnifiedRoleEditorLiteID Unified role editor-lite id.
 	UnifiedRoleEditorLiteID = "1c996275-f1c9-4e71-abdf-a42f6495e960"
 	// UnifiedRoleManagerID Unified role manager id.
@@ -145,6 +147,12 @@ var (
 	// UnifiedRole FileEditorListGrants, Role DisplayName (resolves directly)
 	_fileEditorListGrantsUnifiedRoleDisplayName = l10n.Template("Can edit")
 
+	// UnifiedRole EditorLitePlus, Role Description (resolves directly)
+	_editorLightUnifiedRoleDescription = l10n.Template("View, download, upload, edit and add. No delete.")
+
+	// UnifiedRole EditorLitePlus, Role DisplayName (resolves directly)
+	_editorLightUnifiedRoleDisplayName = l10n.Template("Can edit (no delete)")
+
 	// UnifiedRole EditorLite, Role Description (resolves directly)
 	_editorLiteUnifiedRoleDescription = l10n.Template("View, download and upload.")
 
@@ -179,6 +187,7 @@ var (
 		UnifiedRoleSpaceEditorWithoutVersionsID: conversions.RoleSpaceEditorWithoutVersions,
 		UnifiedRoleEditorID:                     conversions.RoleEditor,
 		UnifiedRoleFileEditorID:                 conversions.RoleFileEditor,
+		UnifiedRoleEditorLitePlusID:                conversions.RoleEditorLitePlus,
 		UnifiedRoleEditorLiteID:                 conversions.RoleEditorLite,
 		UnifiedRoleManagerID:                    conversions.RoleManager,
 		UnifiedRoleSecureViewerID:               conversions.RoleSecureViewer,
@@ -195,6 +204,7 @@ var (
 		roleSpaceEditorWithoutVersions,
 		roleFileEditor,
 		roleFileEditorListGrants,
+		roleEditorLitePlus,
 		roleEditorLite,
 		roleManager,
 		roleSecureViewer,
@@ -311,6 +321,23 @@ var (
 				},
 			},
 			LibreGraphWeight: proto.Int32(50),
+		}
+	}()
+
+	// roleEditorLitePlus creates an editor role without delete permission.
+	roleEditorLitePlus = func() *libregraph.UnifiedRoleDefinition {
+		r := conversions.NewEditorLitePlusRole()
+		return &libregraph.UnifiedRoleDefinition{
+			Id:          proto.String(UnifiedRoleEditorLitePlusID),
+			Description: proto.String(_editorLitePlusUnifiedRoleDescription),
+			DisplayName: proto.String(cs3RoleToDisplayName(r)),
+			RolePermissions: []libregraph.UnifiedRolePermission{
+				{
+					AllowedResourceActions: CS3ResourcePermissionsToLibregraphActions(r.CS3ResourcePermissions()),
+					Condition:              proto.String(UnifiedRoleConditionFolder),
+				},
+			},
+			LibreGraphWeight: proto.Int32(55),
 		}
 	}()
 

--- a/vendor/github.com/opencloud-eu/reva/v2/pkg/conversions/role.go
+++ b/vendor/github.com/opencloud-eu/reva/v2/pkg/conversions/role.go
@@ -55,6 +55,8 @@ const (
 	RoleFileEditorListGrants = "file-editor-list-grants"
 	// RoleCoowner grants co-owner permissions on a resource.
 	RoleCoowner = "coowner"
+	// RoleEditorLitePlus grants editor permission without delete on a resource.
+	RoleEditorLitePlus = "editor-lite-plus"
 	// RoleEditorLite grants permission to upload and download to a resource.
 	RoleEditorLite = "editor-lite"
 	// RoleUploader grants uploader permission to upload onto a resource (no download).
@@ -268,6 +270,25 @@ func NewEditorRole() *Role {
 			Stat:                 true,
 		},
 		ocsPermissions: p,
+	}
+}
+
+// NewEditorLitePlusRole creates an editor role without delete permission.
+// Users can view, download, upload, edit, add and move but not delete.
+func NewEditorLitePlusRole() *Role {
+	return &Role{
+		Name: RoleEditorLitePlus,
+		cS3ResourcePermissions: &provider.ResourcePermissions{
+			CreateContainer:      true,
+			GetPath:              true,
+			GetQuota:             true,
+			InitiateFileDownload: true,
+			InitiateFileUpload:   true,
+			ListContainer:        true,
+			Move:                 true,
+			Stat:                 true,
+		},
+		ocsPermissions: PermissionRead | PermissionCreate | PermissionWrite,
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds a new sharing role **EditorLitePlus** that grants all editor permissions except delete.

## Motivation

There is currently a gap between the existing sharing roles:

| Role | Download | Upload | Edit | Create | Delete | Move |
|------|----------|--------|------|--------|--------|------|
| Viewer | x | - | - | - | - | - |
| EditorLite | x | x | - | x | - | x |
| **EditorLitePlus (new)** | **x** | **x** | **x** | **x** | **-** | **x** |
| Editor | x | x | x | x | x | x |

EditorLite allows uploading but not editing existing files. Editor allows everything including deletion. There is no role that lets users fully edit and create content while preventing deletion.

This is needed for shared project folders, document management scenarios and compliance use cases where accidental or unauthorized deletion must be prevented.

## Changes

- `vendor/.../reva/v2/pkg/conversions/role.go`: Add `RoleEditorLitePlus` constant and `NewEditorLitePlusRole()`
- `services/graph/pkg/unifiedrole/roles.go`: Add role definition (weight 55, between EditorLite and Editor)
- `services/graph/pkg/unifiedrole/conversion.go`: Add display name mapping

## Details

Uses only existing CS3 ResourcePermissions — no proto changes needed.

Explicitly excluded: `Delete`, `PurgeRecycle`, `ListRecycle`, `RestoreRecycleItem`.

Overwriting existing files is allowed (uses `InitiateFileUpload`, not `Delete`). Old versions are preserved as revisions.

Enabled by default.

## Test plan

- [ ] Role appears in sharing dialog for folders
- [ ] User with EditorLitePlus can upload, edit, create folders, move files
- [ ] User with EditorLitePlus cannot delete files or folders
- [ ] User with EditorLitePlus can overwrite existing files (old version becomes revision)
- [ ] Existing roles are unaffected