### PR TITLE
chore: bump reva to 2.46.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/open-policy-agent/opa v1.15.2
 	github.com/opencloud-eu/icap-client v0.0.0-20250930132611-28a2afe62d89
 	github.com/opencloud-eu/libre-graph-api-go v1.0.8-0.20260310090739-853d972b282d
-	github.com/opencloud-eu/reva/v2 v2.46.1-0.20260522124452-c649de391cb1
+	github.com/opencloud-eu/reva/v2 v2.46.1
 	github.com/opensearch-project/opensearch-go/v4 v4.6.0
 	github.com/orcaman/concurrent-map v1.0.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -952,8 +952,8 @@ github.com/opencloud-eu/inotifywaitgo v0.0.0-20251111171128-a390bae3c5e9 h1:dIft
 github.com/opencloud-eu/inotifywaitgo v0.0.0-20251111171128-a390bae3c5e9/go.mod h1:JWyDC6H+5oZRdUJUgKuaye+8Ph5hEs6HVzVoPKzWSGI=
 github.com/opencloud-eu/libre-graph-api-go v1.0.8-0.20260310090739-853d972b282d h1:JcqGDiyrcaQwVyV861TUyQgO7uEmsjkhfm7aQd84dOw=
 github.com/opencloud-eu/libre-graph-api-go v1.0.8-0.20260310090739-853d972b282d/go.mod h1:pzatilMEHZFT3qV7C/X3MqOa3NlRQuYhlRhZTL+hN6Q=
-github.com/opencloud-eu/reva/v2 v2.46.1-0.20260522124452-c649de391cb1 h1:ABcjsejQbdD8exfmzjLJZQZfZBmPrnoi8aKh8bgHtDc=
-github.com/opencloud-eu/reva/v2 v2.46.1-0.20260522124452-c649de391cb1/go.mod h1:fWAzVpZlJQEY/qeIrd9d3U+LpqY9JGsjJ2dc0a1jCEs=
+github.com/opencloud-eu/reva/v2 v2.46.1 h1:V4bUOD2phDIc1NQO50RNI0hTtc2G/COf+0YZiGNR+tk=
+github.com/opencloud-eu/reva/v2 v2.46.1/go.mod h1:V1bwCQXM1pGmswtjdSJVIweA9Vv5EmtUZr/7Cm5086A=
 github.com/opencloud-eu/secure v0.0.0-20260312082735-b6f5cb2244e4 h1:l2oB/RctH+t8r7QBj5p8thfEHCM/jF35aAY3WQ3hADI=
 github.com/opencloud-eu/secure v0.0.0-20260312082735-b6f5cb2244e4/go.mod h1:BmF5hyM6tXczk3MpQkFf1hpKSRqCyhqcbiQtiAF7+40=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=

--- a/vendor/github.com/opencloud-eu/reva/v2/internal/grpc/services/storageprovider/storageprovider.go
+++ b/vendor/github.com/opencloud-eu/reva/v2/internal/grpc/services/storageprovider/storageprovider.go
@@ -1045,7 +1045,16 @@ func (s *Service) PurgeRecycle(ctx context.Context, req *provider.PurgeRecycleRe
 }
 
 func (s *Service) ListGrants(ctx context.Context, req *provider.ListGrantsRequest) (*provider.ListGrantsResponse, error) {
-	grants, err := s.Storage.ListGrants(ctx, req.Ref)
+	fs := s.Storage
+	if req.Opaque != nil && req.Opaque.Map != nil {
+		if _, ok := req.Opaque.Map["with_disabled_spaces"]; ok {
+			if dsfs, ok := fs.(storage.SpaceDisabledListableFS); ok {
+				fs = dsfs.WithDisabledSpaces()
+			}
+		}
+	}
+
+	grants, err := fs.ListGrants(ctx, req.Ref)
 	if err != nil {
 		var st *rpc.Status
 		switch err.(type) {

--- a/vendor/github.com/opencloud-eu/reva/v2/pkg/share/manager/jsoncs3/migrations/0002_import_spacemembers.go
+++ b/vendor/github.com/opencloud-eu/reva/v2/pkg/share/manager/jsoncs3/migrations/0002_import_spacemembers.go
@@ -79,7 +79,7 @@ func (m *ImportSpaceMembersMigration) Name() string {
 }
 
 func (m *ImportSpaceMembersMigration) Version() int {
-	return 1
+	return 2
 }
 
 func (m *ImportSpaceMembersMigration) Migrate() error {
@@ -162,7 +162,10 @@ func (m *ImportSpaceMembersMigration) migrateSpace(ctx context.Context, space *p
 	}
 
 	ref := &provider.Reference{ResourceId: space.GetRoot()}
-	grantsRes, err := spClient.ListGrants(ctx, &provider.ListGrantsRequest{Ref: ref})
+	grantsRes, err := spClient.ListGrants(ctx, &provider.ListGrantsRequest{
+		Ref:    ref,
+		Opaque: utils.AppendPlainToOpaque(nil, "with_disabled_spaces", "true"),
+	})
 	if err != nil {
 		return 0, err
 	}

--- a/vendor/github.com/opencloud-eu/reva/v2/pkg/storage/fs/posix/lookup/lookup.go
+++ b/vendor/github.com/opencloud-eu/reva/v2/pkg/storage/fs/posix/lookup/lookup.go
@@ -81,6 +81,8 @@ type Lookup struct {
 	userMapper      usermapper.Mapper
 	tm              node.TimeManager
 	log             *zerolog.Logger
+
+	listDisabledSpaces bool
 }
 
 // New returns a new Lookup instance
@@ -186,6 +188,13 @@ func (lu *Lookup) NodeFromResource(ctx context.Context, ref *provider.Reference)
 	return nil, fmt.Errorf("invalid reference %+v. resource_id must be set", ref)
 }
 
+// WithDisabledSpaces returns a lookup that can list disabled spaces
+func (lu *Lookup) WithDisabledSpaces() node.PathLookup {
+	l := *lu
+	l.listDisabledSpaces = true
+	return &l
+}
+
 // NodeFromID returns the internal path for the id
 func (lu *Lookup) NodeFromID(ctx context.Context, id *provider.ResourceId) (n *node.Node, err error) {
 	ctx, span := tracer.Start(ctx, "NodeFromID")
@@ -197,7 +206,7 @@ func (lu *Lookup) NodeFromID(ctx context.Context, id *provider.ResourceId) (n *n
 		// The Resource references the root of a space
 		return lu.NodeFromSpaceID(ctx, id.SpaceId)
 	}
-	return node.ReadNode(ctx, lu, id.SpaceId, id.OpaqueId, "", false, nil, false)
+	return node.ReadNode(ctx, lu, id.SpaceId, id.OpaqueId, "", lu.listDisabledSpaces, nil, false)
 }
 
 // Pathify segments the beginning of a string into depth segments of width length
@@ -218,7 +227,7 @@ func Pathify(id string, depth, width int) string {
 
 // NodeFromSpaceID converts a resource id into a Node
 func (lu *Lookup) NodeFromSpaceID(ctx context.Context, spaceID string) (n *node.Node, err error) {
-	node, err := node.ReadNode(ctx, lu, spaceID, spaceID, "", false, nil, false)
+	node, err := node.ReadNode(ctx, lu, spaceID, spaceID, "", lu.listDisabledSpaces, nil, false)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/opencloud-eu/reva/v2/pkg/storage/fs/posix/posix.go
+++ b/vendor/github.com/opencloud-eu/reva/v2/pkg/storage/fs/posix/posix.go
@@ -225,6 +225,12 @@ func New(o *options.Options, stream events.Stream, cache, historyCache *idcache.
 	return fs, nil
 }
 
+func (fs *posixFS) WithDisabledSpaces() storage.FS {
+	f := *fs
+	f.FS = fs.FS.(storage.SpaceDisabledListableFS).WithDisabledSpaces()
+	return &f
+}
+
 // WarmupIDCache allows triggering a posix fs scan and id cache warmup manually.
 func (fs *posixFS) WarmupIDCache(root string, assimilate, onlyDirty bool) error {
 	return fs.tree.WarmupIDCache(root, assimilate, onlyDirty)

--- a/vendor/github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/decomposedfs.go
+++ b/vendor/github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/decomposedfs.go
@@ -568,6 +568,13 @@ func (fs *Decomposedfs) Postprocessing(ch <-chan events.Event) {
 	}
 }
 
+// WithDisabledSpaces returns a filesystem that can list disabled spaces
+func (fs *Decomposedfs) WithDisabledSpaces() storage.FS {
+	f := *fs
+	f.lu = f.lu.WithDisabledSpaces()
+	return &f
+}
+
 // Shutdown shuts down the storage
 func (fs *Decomposedfs) Shutdown(ctx context.Context) error {
 	return nil

--- a/vendor/github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/lookup/lookup.go
+++ b/vendor/github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/lookup/lookup.go
@@ -57,6 +57,8 @@ type Lookup struct {
 
 	metadataBackend metadata.Backend
 	tm              node.TimeManager
+
+	listDisabledSpaces bool
 }
 
 // New returns a new Lookup instance
@@ -140,6 +142,13 @@ func (lu *Lookup) NodeFromResource(ctx context.Context, ref *provider.Reference)
 	return nil, fmt.Errorf("invalid reference %+v. resource_id must be set", ref)
 }
 
+// WithDisabledSpaces returns a lookup that can list disabled spaces
+func (lu *Lookup) WithDisabledSpaces() node.PathLookup {
+	l := *lu
+	l.listDisabledSpaces = true
+	return &l
+}
+
 // NodeFromID returns the internal path for the id
 func (lu *Lookup) NodeFromID(ctx context.Context, id *provider.ResourceId) (n *node.Node, err error) {
 	ctx, span := tracer.Start(ctx, "NodeFromID")
@@ -151,7 +160,7 @@ func (lu *Lookup) NodeFromID(ctx context.Context, id *provider.ResourceId) (n *n
 		// The Resource references the root of a space
 		return lu.NodeFromSpaceID(ctx, id.SpaceId)
 	}
-	return node.ReadNode(ctx, lu, id.SpaceId, id.OpaqueId, "", false, nil, false)
+	return node.ReadNode(ctx, lu, id.SpaceId, id.OpaqueId, "", lu.listDisabledSpaces, nil, false)
 }
 
 // Pathify segments the beginning of a string into depth segments of width length
@@ -172,7 +181,7 @@ func Pathify(id string, depth, width int) string {
 
 // NodeFromSpaceID converts a resource id into a Node
 func (lu *Lookup) NodeFromSpaceID(ctx context.Context, spaceID string) (n *node.Node, err error) {
-	node, err := node.ReadNode(ctx, lu, spaceID, spaceID, "", false, nil, false)
+	node, err := node.ReadNode(ctx, lu, spaceID, spaceID, "", lu.listDisabledSpaces, nil, false)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/node/node.go
+++ b/vendor/github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/node/node.go
@@ -148,6 +148,7 @@ type Tree interface {
 
 // PathLookup defines the interface for the lookup component
 type PathLookup interface {
+	WithDisabledSpaces() PathLookup
 	NodeFromSpaceID(ctx context.Context, spaceID string) (n *Node, err error)
 	NodeFromResource(ctx context.Context, ref *provider.Reference) (*Node, error)
 	NodeFromID(ctx context.Context, id *provider.ResourceId) (n *Node, err error)

--- a/vendor/github.com/opencloud-eu/reva/v2/pkg/storage/storage.go
+++ b/vendor/github.com/opencloud-eu/reva/v2/pkg/storage/storage.go
@@ -152,6 +152,12 @@ type FS interface {
 	GetHome(ctx context.Context) (string, error)
 }
 
+// SpaceDisabledListableFS is the interface to implement for storage drivers that
+// can list resources in disabled spaces.
+type SpaceDisabledListableFS interface {
+	WithDisabledSpaces() FS
+}
+
 // UnscopeFunc is a function that unscopes a user
 type UnscopeFunc func()
 

--- a/vendor/github.com/opencloud-eu/reva/v2/pkg/storage/utils/middleware/middleware.go
+++ b/vendor/github.com/opencloud-eu/reva/v2/pkg/storage/utils/middleware/middleware.go
@@ -51,6 +51,13 @@ func NewFS(next storage.FS, hooks ...Hook) *FS {
 	}
 }
 
+// WithDisabledSpaces returns a filesystem that can list disabled spaces
+func (fs *FS) WithDisabledSpaces() storage.FS {
+	f := *fs
+	f.next = fs.next.(storage.SpaceDisabledListableFS).WithDisabledSpaces()
+	return &f
+}
+
 // ListUploadSessions returns the upload sessions matching the given filter
 func (f *FS) ListUploadSessions(ctx context.Context, filter storage.UploadSessionFilter) ([]storage.UploadSession, error) {
 	return f.next.(storage.UploadSessionLister).ListUploadSessions(ctx, filter)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1363,7 +1363,7 @@ github.com/opencloud-eu/icap-client
 # github.com/opencloud-eu/libre-graph-api-go v1.0.8-0.20260310090739-853d972b282d
 ## explicit; go 1.18
 github.com/opencloud-eu/libre-graph-api-go
-# github.com/opencloud-eu/reva/v2 v2.46.1-0.20260522124452-c649de391cb1
+# github.com/opencloud-eu/reva/v2 v2.46.1
 ## explicit; go 1.25.0
 github.com/opencloud-eu/reva/v2/cmd/revad/internal/grace
 github.com/opencloud-eu/reva/v2/cmd/revad/runtime


### PR DESCRIPTION
# Description

## [2.46.1](https://github.com/opencloud-eu/reva/releases/tag/v2.46.1) - 2026-06-01

### 🐛 Bug Fixes

- Migrate disabled spaces [[#649](https://github.com/opencloud-eu/reva/pull/649)]
- fix: added /dav/public-files/ to Unprotected routes [[#648](https://github.com/opencloud-eu/reva/pull/648)]

### 📦️ Dependencies

- chore(deps): bump golang.org/x/text from 0.36.0 to 0.37.0 [[#643](https://github.com/opencloud-eu/reva/pull/643)]