### PR TITLE
use ldap instead of ldaps internally

### DIFF
--- a/services/auth-basic/pkg/config/defaults/defaultconfig.go
+++ b/services/auth-basic/pkg/config/defaults/defaultconfig.go
@@ -1,9 +1,6 @@
 package defaults
 
 import (
-	"path/filepath"
-
-	"github.com/opencloud-eu/opencloud/pkg/config/defaults"
 	"github.com/opencloud-eu/opencloud/pkg/shared"
 	"github.com/opencloud-eu/opencloud/pkg/structs"
 	"github.com/opencloud-eu/opencloud/services/auth-basic/pkg/config"
@@ -38,8 +35,7 @@ func DefaultConfig() *config.Config {
 		AuthProvider: "ldap",
 		AuthProviders: config.AuthProviders{
 			LDAP: config.LDAPProvider{
-				URI:                      "ldaps://localhost:9235",
-				CACert:                   filepath.Join(defaults.BaseDataPath(), "idm", "ldap.crt"),
+				URI:                      "ldap://localhost:9235",
 				Insecure:                 false,
 				UserBaseDN:               "ou=users,o=libregraph-idm",
 				GroupBaseDN:              "ou=groups,o=libregraph-idm",

--- a/services/auth-basic/pkg/config/defaults/defaultconfig.go
+++ b/services/auth-basic/pkg/config/defaults/defaultconfig.go
@@ -35,7 +35,7 @@ func DefaultConfig() *config.Config {
 		AuthProvider: "ldap",
 		AuthProviders: config.AuthProviders{
 			LDAP: config.LDAPProvider{
-				URI:                      "ldap://localhost:9235",
+				URI:                      "ldap://localhost:9236",
 				Insecure:                 false,
 				UserBaseDN:               "ou=users,o=libregraph-idm",
 				GroupBaseDN:              "ou=groups,o=libregraph-idm",

--- a/services/graph/pkg/config/defaults/defaultconfig.go
+++ b/services/graph/pkg/config/defaults/defaultconfig.go
@@ -1,11 +1,9 @@
 package defaults
 
 import (
-	"path"
 	"strings"
 	"time"
 
-	"github.com/opencloud-eu/opencloud/pkg/config/defaults"
 	"github.com/opencloud-eu/opencloud/pkg/shared"
 	"github.com/opencloud-eu/opencloud/pkg/structs"
 	"github.com/opencloud-eu/opencloud/services/graph/pkg/config"
@@ -79,9 +77,8 @@ func DefaultConfig() *config.Config {
 		Identity: config.Identity{
 			Backend: "ldap",
 			LDAP: config.LDAP{
-				URI:                      "ldaps://localhost:9235",
+				URI:                      "ldap://localhost:9235",
 				Insecure:                 false,
-				CACert:                   path.Join(defaults.BaseDataPath(), "idm", "ldap.crt"),
 				BindDN:                   "uid=libregraph,ou=sysusers,o=libregraph-idm",
 				UseServerUUID:            false,
 				UsePasswordModExOp:       true,

--- a/services/graph/pkg/config/defaults/defaultconfig.go
+++ b/services/graph/pkg/config/defaults/defaultconfig.go
@@ -77,7 +77,7 @@ func DefaultConfig() *config.Config {
 		Identity: config.Identity{
 			Backend: "ldap",
 			LDAP: config.LDAP{
-				URI:                      "ldap://localhost:9235",
+				URI:                      "ldap://localhost:9236",
 				Insecure:                 false,
 				BindDN:                   "uid=libregraph,ou=sysusers,o=libregraph-idm",
 				UseServerUUID:            false,

--- a/services/groups/pkg/config/defaults/defaultconfig.go
+++ b/services/groups/pkg/config/defaults/defaultconfig.go
@@ -35,7 +35,7 @@ func DefaultConfig() *config.Config {
 		Driver: "ldap",
 		Drivers: config.Drivers{
 			LDAP: config.LDAPDriver{
-				URI:                      "ldap://localhost:9235",
+				URI:                      "ldap://localhost:9236",
 				Insecure:                 false,
 				UserBaseDN:               "ou=users,o=libregraph-idm",
 				GroupBaseDN:              "ou=groups,o=libregraph-idm",

--- a/services/groups/pkg/config/defaults/defaultconfig.go
+++ b/services/groups/pkg/config/defaults/defaultconfig.go
@@ -1,9 +1,6 @@
 package defaults
 
 import (
-	"path/filepath"
-
-	"github.com/opencloud-eu/opencloud/pkg/config/defaults"
 	"github.com/opencloud-eu/opencloud/pkg/shared"
 	"github.com/opencloud-eu/opencloud/pkg/structs"
 	"github.com/opencloud-eu/opencloud/services/groups/pkg/config"
@@ -38,8 +35,7 @@ func DefaultConfig() *config.Config {
 		Driver: "ldap",
 		Drivers: config.Drivers{
 			LDAP: config.LDAPDriver{
-				URI:                      "ldaps://localhost:9235",
-				CACert:                   filepath.Join(defaults.BaseDataPath(), "idm", "ldap.crt"),
+				URI:                      "ldap://localhost:9235",
 				Insecure:                 false,
 				UserBaseDN:               "ou=users,o=libregraph-idm",
 				GroupBaseDN:              "ou=groups,o=libregraph-idm",

--- a/services/idm/pkg/command/server.go
+++ b/services/idm/pkg/command/server.go
@@ -59,6 +59,8 @@ func Server(cfg *config.Config) *cobra.Command {
 
 				if cfg.IDM.LDAPSAddr != "" {
 					servercfg.LDAPSListenAddr = cfg.IDM.LDAPSAddr
+					servercfg.TLSCertFile = cfg.IDM.Cert
+					servercfg.TLSKeyFile = cfg.IDM.Key
 				}
 
 				if err := os.MkdirAll(path.Join(defaults.BaseDataPath(), "idm"), 0700); err != nil {

--- a/services/idm/pkg/command/server.go
+++ b/services/idm/pkg/command/server.go
@@ -8,10 +8,11 @@ import (
 	"html/template"
 	"os"
 	"os/signal"
+	"path"
 	"strings"
 
 	"github.com/opencloud-eu/opencloud/pkg/config/configlog"
-	pkgcrypto "github.com/opencloud-eu/opencloud/pkg/crypto"
+	"github.com/opencloud-eu/opencloud/pkg/config/defaults"
 	"github.com/opencloud-eu/opencloud/pkg/log"
 	"github.com/opencloud-eu/opencloud/pkg/runner"
 	"github.com/opencloud-eu/opencloud/services/idm"
@@ -47,23 +48,19 @@ func Server(cfg *config.Config) *cobra.Command {
 			gr := runner.NewGroup()
 			{
 				servercfg := server.Config{
-					Logger:          log.LogrusWrap(logger.Logger),
-					LDAPHandler:     "boltdb",
-					LDAPSListenAddr: cfg.IDM.LDAPSAddr,
-					TLSCertFile:     cfg.IDM.Cert,
-					TLSKeyFile:      cfg.IDM.Key,
-					LDAPBaseDN:      "o=libregraph-idm",
-					LDAPAdminDN:     "uid=libregraph,ou=sysusers,o=libregraph-idm",
+					Logger:         log.LogrusWrap(logger.Logger),
+					LDAPHandler:    "boltdb",
+					LDAPListenAddr: cfg.IDM.LDAPAddr,
+					LDAPBaseDN:     "o=libregraph-idm",
+					LDAPAdminDN:    "uid=libregraph,ou=sysusers,o=libregraph-idm",
 
 					BoltDBFile: cfg.IDM.DatabasePath,
 				}
 
-				if cfg.IDM.LDAPSAddr != "" {
-					// Generate a self-signing cert if no certificate is present
-					if err := pkgcrypto.GenCert(cfg.IDM.Cert, cfg.IDM.Key, logger); err != nil {
-						logger.Fatal().Err(err).Msgf("Could not generate test-certificate")
-					}
+				if err := os.MkdirAll(path.Join(defaults.BaseDataPath(), "idm"), 0700); err != nil {
+					logger.Fatal().Err(err).Msgf("Could not create data directory for idm")
 				}
+
 				if _, err := os.Stat(servercfg.BoltDBFile); errors.Is(err, os.ErrNotExist) {
 					logger.Debug().Msg("Bootstrapping IDM database")
 					if err = bootstrap(logger, cfg, servercfg); err != nil {

--- a/services/idm/pkg/command/server.go
+++ b/services/idm/pkg/command/server.go
@@ -57,6 +57,10 @@ func Server(cfg *config.Config) *cobra.Command {
 					BoltDBFile: cfg.IDM.DatabasePath,
 				}
 
+				if cfg.IDM.LDAPSAddr != "" {
+					servercfg.LDAPSListenAddr = cfg.IDM.LDAPSAddr
+				}
+
 				if err := os.MkdirAll(path.Join(defaults.BaseDataPath(), "idm"), 0700); err != nil {
 					logger.Fatal().Err(err).Msgf("Could not create data directory for idm")
 				}

--- a/services/idm/pkg/config/config.go
+++ b/services/idm/pkg/config/config.go
@@ -26,7 +26,7 @@ type Config struct {
 }
 
 type Settings struct {
-	LDAPSAddr    string `yaml:"ldaps_addr" env:"IDM_LDAPS_ADDR" desc:"Listen address for the LDAPS listener (ip-addr:port)." introductionVersion:"1.0.0"`
+	LDAPAddr     string `yaml:"ldaps_addr" env:"IDM_LDAPS_ADDR" desc:"Listen address for the LDAPS listener (ip-addr:port)." introductionVersion:"1.0.0"`
 	Cert         string `yaml:"cert" env:"IDM_LDAPS_CERT" desc:"File name of the TLS server certificate for the LDAPS listener. If not defined, the root directory derives from $OC_BASE_DATA_PATH/idm." introductionVersion:"1.0.0"`
 	Key          string `yaml:"key" env:"IDM_LDAPS_KEY" desc:"File name for the TLS certificate key for the server certificate. If not defined, the root directory derives from $OC_BASE_DATA_PATH/idm." introductionVersion:"1.0.0"`
 	DatabasePath string `yaml:"database" env:"IDM_DATABASE_PATH" desc:"Full path to the IDM backend database. If not defined, the root directory derives from $OC_BASE_DATA_PATH/idm." introductionVersion:"1.0.0"`

--- a/services/idm/pkg/config/config.go
+++ b/services/idm/pkg/config/config.go
@@ -26,7 +26,8 @@ type Config struct {
 }
 
 type Settings struct {
-	LDAPAddr     string `yaml:"ldaps_addr" env:"IDM_LDAPS_ADDR" desc:"Listen address for the LDAPS listener (ip-addr:port)." introductionVersion:"1.0.0"`
+	LDAPSAddr    string `yaml:"ldaps_addr" env:"IDM_LDAPS_ADDR" desc:"Listen address for the LDAPS listener (ip-addr:port)." introductionVersion:"1.0.0"`
+	LDAPAddr     string
 	Cert         string `yaml:"cert" env:"IDM_LDAPS_CERT" desc:"File name of the TLS server certificate for the LDAPS listener. If not defined, the root directory derives from $OC_BASE_DATA_PATH/idm." introductionVersion:"1.0.0"`
 	Key          string `yaml:"key" env:"IDM_LDAPS_KEY" desc:"File name for the TLS certificate key for the server certificate. If not defined, the root directory derives from $OC_BASE_DATA_PATH/idm." introductionVersion:"1.0.0"`
 	DatabasePath string `yaml:"database" env:"IDM_DATABASE_PATH" desc:"Full path to the IDM backend database. If not defined, the root directory derives from $OC_BASE_DATA_PATH/idm." introductionVersion:"1.0.0"`

--- a/services/idm/pkg/config/defaults/defaultconfig.go
+++ b/services/idm/pkg/config/defaults/defaultconfig.go
@@ -2,7 +2,6 @@ package defaults
 
 import (
 	"path"
-	"strings"
 
 	"github.com/opencloud-eu/opencloud/pkg/config/defaults"
 	"github.com/opencloud-eu/opencloud/services/idm/pkg/config"
@@ -31,7 +30,7 @@ func DefaultConfig() *config.Config {
 		CreateDemoUsers:    false,
 		DemoUsersIssuerUrl: "https://localhost:9200",
 		IDM: config.Settings{
-			LDAPAddr:     "127.0.0.1:9235",
+			LDAPAddr:     "127.0.0.1:9236",
 			DatabasePath: path.Join(defaults.BaseDataPath(), "idm", "idm.boltdb"),
 		},
 	}
@@ -50,10 +49,5 @@ func EnsureDefaults(cfg *config.Config) {
 
 // Sanitize sanitizes the configuration
 func Sanitize(cfg *config.Config) {
-	if cfg.IDM.LDAPSAddr == "" &&
-		cfg.IDM.LDAPAddr != "" &&
-		(!strings.Contains(cfg.IDM.LDAPAddr, "127.0.0.1") &&
-			!strings.Contains(cfg.IDM.LDAPAddr, "localhost")) {
-		panic("Invalid configuration: 'ldap_addr' is set but 'ldaps_addr' is not set. For security reasons, the 'ldap_addr' setting is only allowed to be used with loopback addresses. Please set 'ldaps_addr' to a valid address and port to listen for LDAPS connections.")
-	}
+	// nothing to do yet
 }

--- a/services/idm/pkg/config/defaults/defaultconfig.go
+++ b/services/idm/pkg/config/defaults/defaultconfig.go
@@ -30,9 +30,7 @@ func DefaultConfig() *config.Config {
 		CreateDemoUsers:    false,
 		DemoUsersIssuerUrl: "https://localhost:9200",
 		IDM: config.Settings{
-			LDAPSAddr:    "127.0.0.1:9235",
-			Cert:         path.Join(defaults.BaseDataPath(), "idm", "ldap.crt"),
-			Key:          path.Join(defaults.BaseDataPath(), "idm", "ldap.key"),
+			LDAPAddr:     "127.0.0.1:9235",
 			DatabasePath: path.Join(defaults.BaseDataPath(), "idm", "idm.boltdb"),
 		},
 	}

--- a/services/idm/pkg/config/defaults/defaultconfig.go
+++ b/services/idm/pkg/config/defaults/defaultconfig.go
@@ -2,6 +2,7 @@ package defaults
 
 import (
 	"path"
+	"strings"
 
 	"github.com/opencloud-eu/opencloud/pkg/config/defaults"
 	"github.com/opencloud-eu/opencloud/services/idm/pkg/config"
@@ -49,5 +50,10 @@ func EnsureDefaults(cfg *config.Config) {
 
 // Sanitize sanitizes the configuration
 func Sanitize(cfg *config.Config) {
-	// nothing to sanitize here
+	if cfg.IDM.LDAPSAddr == "" &&
+		cfg.IDM.LDAPAddr != "" &&
+		(!strings.Contains(cfg.IDM.LDAPAddr, "127.0.0.1") &&
+			!strings.Contains(cfg.IDM.LDAPAddr, "localhost")) {
+		panic("Invalid configuration: 'ldap_addr' is set but 'ldaps_addr' is not set. For security reasons, the 'ldap_addr' setting is only allowed to be used with loopback addresses. Please set 'ldaps_addr' to a valid address and port to listen for LDAPS connections.")
+	}
 }

--- a/services/idm/pkg/config/parser/parse.go
+++ b/services/idm/pkg/config/parser/parse.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"errors"
+	"net"
 
 	occfg "github.com/opencloud-eu/opencloud/pkg/config"
 	"github.com/opencloud-eu/opencloud/pkg/shared"
@@ -51,6 +52,26 @@ func Validate(cfg *config.Config) error {
 
 	if cfg.ServiceUserPasswords.Reva == "" {
 		return shared.MissingServiceUserPassword(cfg.Service.Name, "REVA")
+	}
+
+	ip, err := net.ResolveTCPAddr("tcp", cfg.IDM.LDAPAddr) // validate the LDAP address if set
+
+	if err != nil {
+		return errors.New("invalid configuration: 'ldap_addr' is not a valid address")
+	}
+
+	if !ip.IP.IsLoopback() {
+		// loopback addresses are allowed to be used with ldap_addr, but not with ldaps_addr, for security reasons
+		return errors.New("invalid configuration: 'ldap_addr' is set but 'ldaps_addr' is not set. For security reasons, the 'ldap_addr' setting is only allowed to be used with loopback addresses. Please set 'ldaps_addr' to a valid address and port to listen for LDAPS connections")
+	}
+
+	if cfg.IDM.LDAPSAddr != "" {
+		if cfg.IDM.Cert == "" {
+			return errors.New("invalid configuration: 'ldaps_addr' is set but 'cert' is not set. Please set 'cert' to a valid path to a TLS certificate")
+		}
+		if cfg.IDM.Key == "" {
+			return errors.New("invalid configuration: 'ldaps_addr' is set but 'key' is not set. Please set 'key' to a valid path to a TLS certificate key")
+		}
 	}
 
 	return nil

--- a/services/idp/pkg/config/defaults/defaultconfig.go
+++ b/services/idp/pkg/config/defaults/defaultconfig.go
@@ -119,7 +119,7 @@ func DefaultConfig() *config.Config {
 			},
 		},
 		Ldap: config.Ldap{
-			URI:                  "ldap://localhost:9235",
+			URI:                  "ldap://localhost:9236",
 			BindDN:               "uid=idp,ou=sysusers,o=libregraph-idm",
 			BaseDN:               "ou=users,o=libregraph-idm",
 			Scope:                "sub",

--- a/services/idp/pkg/config/defaults/defaultconfig.go
+++ b/services/idp/pkg/config/defaults/defaultconfig.go
@@ -119,8 +119,7 @@ func DefaultConfig() *config.Config {
 			},
 		},
 		Ldap: config.Ldap{
-			URI:                  "ldaps://localhost:9235",
-			TLSCACert:            filepath.Join(defaults.BaseDataPath(), "idm", "ldap.crt"),
+			URI:                  "ldap://localhost:9235",
 			BindDN:               "uid=idp,ou=sysusers,o=libregraph-idm",
 			BaseDN:               "ou=users,o=libregraph-idm",
 			Scope:                "sub",

--- a/services/users/pkg/config/defaults/defaultconfig.go
+++ b/services/users/pkg/config/defaults/defaultconfig.go
@@ -35,7 +35,7 @@ func DefaultConfig() *config.Config {
 		Driver: "ldap",
 		Drivers: config.Drivers{
 			LDAP: config.LDAPDriver{
-				URI:                      "ldap://localhost:9235",
+				URI:                      "ldap://localhost:9236",
 				Insecure:                 false,
 				UserBaseDN:               "ou=users,o=libregraph-idm",
 				GroupBaseDN:              "ou=groups,o=libregraph-idm",

--- a/services/users/pkg/config/defaults/defaultconfig.go
+++ b/services/users/pkg/config/defaults/defaultconfig.go
@@ -1,9 +1,6 @@
 package defaults
 
 import (
-	"path/filepath"
-
-	"github.com/opencloud-eu/opencloud/pkg/config/defaults"
 	"github.com/opencloud-eu/opencloud/pkg/shared"
 	"github.com/opencloud-eu/opencloud/pkg/structs"
 	"github.com/opencloud-eu/opencloud/services/users/pkg/config"
@@ -38,8 +35,7 @@ func DefaultConfig() *config.Config {
 		Driver: "ldap",
 		Drivers: config.Drivers{
 			LDAP: config.LDAPDriver{
-				URI:                      "ldaps://localhost:9235",
-				CACert:                   filepath.Join(defaults.BaseDataPath(), "idm", "ldap.crt"),
+				URI:                      "ldap://localhost:9235",
 				Insecure:                 false,
 				UserBaseDN:               "ou=users,o=libregraph-idm",
 				GroupBaseDN:              "ou=groups,o=libregraph-idm",


### PR DESCRIPTION
This PR removes the internal ssl of the idm, since this is never used externally but only on loopback.