### PR TITLE
feat(proxy): add PROXY_USERS_DEFAULT_QUOTA for personal spaces

### DIFF
--- a/services/proxy/pkg/command/server.go
+++ b/services/proxy/pkg/command/server.go
@@ -394,6 +394,7 @@ func loadMiddlewares(logger log.Logger, cfg *config.Config,
 			middleware.TraceProvider(traceProvider),
 			middleware.WithRevaGatewaySelector(gatewaySelector),
 			middleware.RoleQuotas(cfg.RoleQuotas),
+			middleware.DefaultUsersQuota(cfg.DefaultUsersQuota),
 		),
 	)
 }

--- a/services/proxy/pkg/config/config.go
+++ b/services/proxy/pkg/config/config.go
@@ -24,6 +24,7 @@ type Config struct {
 	GrpcClient    client.Client         `yaml:"-"`
 
 	RoleQuotas                    map[string]uint64   `yaml:"role_quotas"`
+	DefaultUsersQuota             uint64              `yaml:"default_users_quota" env:"PROXY_USERS_DEFAULT_QUOTA" desc:"The default quota in bytes for personal spaces of new users. A value of 0 means unlimited. This quota is used as a fallback when no role-specific quota is configured." introductionVersion:"7.2.0"`
 	Policies                      []Policy            `yaml:"policies"`
 	AdditionalPolicies            []Policy            `yaml:"additional_policies"`
 	OIDC                          OIDC                `yaml:"oidc"`

--- a/services/proxy/pkg/middleware/create_home.go
+++ b/services/proxy/pkg/middleware/create_home.go
@@ -32,6 +32,7 @@ func CreateHome(optionSetters ...Option) func(next http.Handler) http.Handler {
 			tracer:              tracer,
 			revaGatewaySelector: options.RevaGatewaySelector,
 			roleQuotas:          options.RoleQuotas,
+			defaultUsersQuota:   options.DefaultUsersQuota,
 		}
 	}
 }
@@ -42,6 +43,7 @@ type createHome struct {
 	tracer              trace.Tracer
 	revaGatewaySelector pool.Selectable[gateway.GatewayAPIClient]
 	roleQuotas          map[string]uint64
+	defaultUsersQuota   uint64
 }
 
 func (m createHome) ServeHTTP(w http.ResponseWriter, req *http.Request) {
@@ -71,6 +73,8 @@ func (m createHome) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		}
 		if limit, hasLimit := m.checkRoleQuotaLimit(roleIDs); hasLimit {
 			createHomeReq.Opaque = utils.AppendPlainToOpaque(nil, "quota", strconv.FormatUint(limit, 10))
+		} else if m.defaultUsersQuota > 0 {
+			createHomeReq.Opaque = utils.AppendPlainToOpaque(nil, "quota", strconv.FormatUint(m.defaultUsersQuota, 10))
 		}
 	}
 

--- a/services/proxy/pkg/middleware/options.go
+++ b/services/proxy/pkg/middleware/options.go
@@ -70,6 +70,8 @@ type Options struct {
 	// RoleQuotas hold userid:quota mappings. These will be used when provisioning new users.
 	// The users will get as much quota as is set for their role.
 	RoleQuotas map[string]uint64
+	// DefaultUsersQuota is the fallback quota for personal spaces when no role-specific quota is set.
+	DefaultUsersQuota uint64
 	// TraceProvider sets the tracing provider.
 	TraceProvider trace.TracerProvider
 	// SkipUserInfo prevents the oidc middleware from querying the userinfo endpoint and read any claims directly from the access token instead
@@ -239,6 +241,13 @@ func AccessTokenVerifyMethod(method string) Option {
 func RoleQuotas(roleQuotas map[string]uint64) Option {
 	return func(o *Options) {
 		o.RoleQuotas = roleQuotas
+	}
+}
+
+// DefaultUsersQuota sets the default quota for personal spaces when no role-specific quota is configured.
+func DefaultUsersQuota(quota uint64) Option {
+	return func(o *Options) {
+		o.DefaultUsersQuota = quota
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds a new `PROXY_USERS_DEFAULT_QUOTA` environment variable (config: `default_users_quota`) that sets a default quota in bytes for newly created personal spaces
- This quota acts as a fallback when no role-specific quota is configured via `role_quotas`
- A value of `0` (default) preserves the existing behavior (unlimited quota)

## Motivation

Currently, personal spaces are created without any quota unless a role-specific quota mapping is configured. This means that by default, every user gets unlimited storage on their personal space. On systems with limited storage (e.g. a 100GB volume), a single user can fill the entire disk -- which is what happened on our production system, causing a full outage.

The existing `GRAPH_SPACES_DEFAULT_QUOTA` only applies to project spaces created via the Graph API. There was no equivalent for personal spaces created during user login.

## Usage

```
PROXY_USERS_DEFAULT_QUOTA=1000000000  # 1 GB default for new personal spaces
```

Or in `proxy.yaml`:
```yaml
default_users_quota: 1000000000
```

## Changes

| File | Change |
|------|--------|
| `services/proxy/pkg/config/config.go` | New config field `DefaultUsersQuota` with env `PROXY_USERS_DEFAULT_QUOTA` |
| `services/proxy/pkg/middleware/options.go` | New middleware option + setter function |
| `services/proxy/pkg/middleware/create_home.go` | Fallback to `defaultUsersQuota` when no role quota matches |
| `services/proxy/pkg/command/server.go` | Wire config to middleware |

## Test plan

- [ ] Set `PROXY_USERS_DEFAULT_QUOTA=1000000000` and create a new user -- personal space should have 1GB quota
- [ ] Without the env var set (or set to 0) -- existing behavior, unlimited quota
- [ ] With both role quota and default quota configured -- role quota takes precedence
- [ ] Existing personal spaces are not affected (quota is only applied on creation)

With support of [Claude Code](https://claude.com/claude-code)