### PR TITLE
chore: reduce build context for docker

### DIFF
--- a/.woodpecker.star
+++ b/.woodpecker.star
@@ -1813,7 +1813,7 @@ def dockerRelease(ctx, repo, build_type):
                 "name": "dryrun",
                 "image": PLUGINS_DOCKER_BUILDX,
                 "settings": {
-                    "context": "..",
+                    "context": ".",
                     "dry_run": True,
                     "platforms": "linux/amd64",  # do dry run only on the native platform
                     "repo": "%s,quay.io/%s,registry.heinlein.group/%s" % (repo, repo, repo),
@@ -1836,7 +1836,7 @@ def dockerRelease(ctx, repo, build_type):
                 "name": "build-and-push",
                 "image": PLUGINS_DOCKER_BUILDX,
                 "settings": {
-                    "context": "..",
+                    "context": ".",
                     "repo": "%s,quay.io/%s,registry.heinlein.group/%s" % (repo, repo, repo),
                     "platforms": "linux/amd64,linux/arm64",  # we can add remote builders
                     "auto_tag": False if build_type == "daily" else True,

--- a/opencloud/Makefile
+++ b/opencloud/Makefile
@@ -17,7 +17,10 @@ include ../.make/docs.mk
 
 .PHONY: dev-docker
 dev-docker:
-	docker build -f docker/Dockerfile.multiarch -t opencloudeu/opencloud:dev ../..
+	docker build -f docker/Dockerfile.multiarch -t opencloudeu/opencloud:dev ..
+
+dev-docker-with-workspace:
+	docker build -f docker/Dockerfile.multiarch -t opencloudeu/opencloud:dev --build-arg SRCDIR=opencloud ../..
 
 .PHONY: dev-docker-multiarch
 dev-docker-multiarch:
@@ -28,7 +31,7 @@ dev-docker-multiarch:
 	docker buildx rm opencloudbuilder || true
 	docker buildx create --platform linux/arm64,linux/amd64 --name opencloudbuilder
 	docker buildx use opencloudbuilder
-	docker buildx build --platform linux/arm64,linux/amd64 --output type=docker --file docker/Dockerfile.multiarch --tag opencloudeu/opencloud:dev-multiarch ../..
+	docker buildx build --platform linux/arm64,linux/amd64 --output type=docker --file docker/Dockerfile.multiarch --tag opencloudeu/opencloud:dev-multiarch ..
 	docker buildx rm opencloudbuilder
 
 .PHONY: debug-docker

--- a/opencloud/docker/Dockerfile.multiarch
+++ b/opencloud/docker/Dockerfile.multiarch
@@ -4,6 +4,7 @@ ARG TARGETARCH
 ARG VERSION
 ARG STRING
 ARG EDITION="dev"
+ARG SRCDIR
 
 RUN apk add bash make git curl gcc musl-dev libc-dev binutils-gold inotify-tools vips-dev
 
@@ -12,7 +13,7 @@ RUN --mount=type=bind,target=/build,rw \
     --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache \
     GOOS="${TARGETOS:-linux}" GOARCH="${TARGETARCH:-amd64}" ; \
-    make -C opencloud/opencloud release-linux-docker-${TARGETARCH} ENABLE_VIPS=true DIST=/dist
+    make -C ${SRCDIR:-.}/opencloud release-linux-docker-${TARGETARCH} ENABLE_VIPS=true DIST=/dist
 
 FROM alpine:3.23
 ARG VERSION


### PR DESCRIPTION
Always including the parent directory into the build context was a bad idea. This reverts the change and only add the opencloud tree to the build context by default.
To build a docker image with workspaces enabled a new make target "dev-docker-with-workspace" is introduced that adjusts the docker build call accordingly (by setting the right build context and the new SRCDIR arg to point to the correct directory for the opencloud tree).
