### PR TITLE
ci: refactor nightly ci pipelines matrix for API tests

### DIFF
--- a/.woodpecker.star
+++ b/.woodpecker.star
@@ -122,7 +122,6 @@ config = {
                 "apiSettings",
             ],
             "skip": False,
-            "withRemotePhp": [False],
             "emailNeeded": True,
             "extraTestEnvironment": {
                 "EMAIL_HOST": "email",
@@ -145,14 +144,12 @@ config = {
                 #"collaborativePosix",
             ],
             "skip": False,
-            "withRemotePhp": [False],
         },
         "graphUserGroup": {
             "suites": [
                 "apiGraphUserGroup",
             ],
             "skip": False,
-            "withRemotePhp": [False],
         },
         "spaces": {
             "suites": [
@@ -210,7 +207,6 @@ config = {
                 "apiNotification",
             ],
             "skip": False,
-            "withRemotePhp": [False],
             "emailNeeded": True,
             "extraTestEnvironment": {
                 "EMAIL_HOST": "email",
@@ -252,7 +248,6 @@ config = {
                 "apiOcm",
             ],
             "skip": False,
-            "withRemotePhp": [False],
             "federationServer": True,
             "emailNeeded": True,
             "extraTestEnvironment": {
@@ -288,14 +283,12 @@ config = {
                 "apiAuthApp",
             ],
             "skip": False,
-            "withRemotePhp": [False],
         },
         "cliCommands": {
             "suites": [
                 "cliCommands",
             ],
             "skip": False,
-            "withRemotePhp": [False],
             "antivirusNeeded": True,
             "extraServerEnvironment": {
                 "ANTIVIRUS_SCANNER_TYPE": "clamav",
@@ -310,7 +303,6 @@ config = {
                 "apiTenancy",
             ],
             "skip": False,
-            "withRemotePhp": [False],
             "ldapNeeded": True,
             "extraTestEnvironment": {
                 "USE_PREPARED_LDAP_USERS": True,
@@ -1205,6 +1197,18 @@ def localApiTestPipeline(ctx):
         "ldapNeeded": False,
     }
 
+    nightly_matrix = {
+        "storages": ["posix", "decomposed"],
+        "posix": {
+            "withRemotePhp": [False],
+            "enableWatchFs": [False, True],
+        },
+        "decomposed": {
+            "withRemotePhp": [False, True],
+            "enableWatchFs": [False],
+        },
+    }
+
     if "localApiTests" in config:
         for name, matrix in config["localApiTests"].items():
             if "skip" not in matrix or not matrix["skip"]:
@@ -1212,29 +1216,35 @@ def localApiTestPipeline(ctx):
                 for item in defaults:
                     params[item] = matrix[item] if item in matrix else defaults[item]
 
+                if ctx.build.event == "cron":
+                    params["storages"] = nightly_matrix["storages"]
+
                 # use decomposed storage if specified in the PR title
                 # run CLI tests only with decomposed storage
                 if "[decomposed]" in ctx.build.title.lower() or name.startswith("cli"):
                     params["storages"] = ["decomposed"]
 
-                if ctx.build.event == "cron":
-                    params["withRemotePhp"] = [True, False]
-                    params["enableWatchFs"] = [True, False]
-
-                # override withRemotePhp if specified in the suite config
-                if "withRemotePhp" in matrix:
-                    params["withRemotePhp"] = matrix["withRemotePhp"]
-
                 for storage in params["storages"]:
+                    # override with nightly matrix
+                    if ctx.build.event == "cron":
+                        params["withRemotePhp"] = nightly_matrix[storage]["withRemotePhp"]
+                        params["enableWatchFs"] = nightly_matrix[storage]["enableWatchFs"]
+
+                    # override configs if specified in the suite config
+                    if "withRemotePhp" in matrix:
+                        params["withRemotePhp"] = matrix["withRemotePhp"]
+                    if "enableWatchFs" in matrix:
+                        params["enableWatchFs"] = matrix["enableWatchFs"]
+
                     for run_with_remote_php in params["withRemotePhp"]:
                         for run_with_watch_fs_enabled in params["enableWatchFs"]:
                             pipeline_name = "test-API"
                             if name.startswith("cli"):
                                 pipeline_name = "test-CLI"
                             pipeline_name += "-%s" % name
-                            if not run_with_remote_php:
-                                pipeline_name += "-withoutRemotePhp"
                             pipeline_name += "-%s" % storage
+                            if run_with_remote_php:
+                                pipeline_name += "-withRemotePhp"
                             if run_with_watch_fs_enabled:
                                 pipeline_name += "-watchfs"
 
@@ -1325,6 +1335,18 @@ def coreApiTestPipeline(ctx):
         "skip": False,
     }
 
+    nightly_matrix = {
+        "storages": ["posix", "decomposed"],
+        "posix": {
+            "withRemotePhp": [False],
+            "enableWatchFs": [False, True],
+        },
+        "decomposed": {
+            "withRemotePhp": [False, True],
+            "enableWatchFs": [False],
+        },
+    }
+
     pipelines = []
     if "coreApiTests" in config:
         matrix = config["coreApiTests"]
@@ -1335,30 +1357,35 @@ def coreApiTestPipeline(ctx):
         for item in defaults:
             params[item] = matrix[item] if item in matrix else defaults[item]
 
+        if ctx.build.event == "cron":
+            params["storages"] = nightly_matrix["storages"]
+
         # use decomposed storage if specified in the PR title
         if "[decomposed]" in ctx.build.title.lower():
             params["storages"] = ["decomposed"]
-
-        if ctx.build.event == "cron":
-            params["withRemotePhp"] = [True, False]
-            params["enableWatchFs"] = [True, False]
-
-        # override withRemotePhp if specified in the suite config
-        if "withRemotePhp" in matrix:
-            params["withRemotePhp"] = matrix["withRemotePhp"]
 
         debugParts = params["skipExceptParts"]
         debugPartsEnabled = (len(debugParts) != 0)
 
         for storage in params["storages"]:
+            # override with nightly matrix
+            if ctx.build.event == "cron":
+                params["withRemotePhp"] = nightly_matrix[storage]["withRemotePhp"]
+                params["enableWatchFs"] = nightly_matrix[storage]["enableWatchFs"]
+
+            # override configs if specified in the suite config
+            if "withRemotePhp" in matrix:
+                params["withRemotePhp"] = matrix["withRemotePhp"]
+            if "enableWatchFs" in matrix:
+                params["enableWatchFs"] = matrix["enableWatchFs"]
             for runPart in range(1, params["numberOfParts"] + 1):
                 for run_with_remote_php in params["withRemotePhp"]:
                     for run_with_watch_fs_enabled in params["enableWatchFs"]:
                         if not debugPartsEnabled or (debugPartsEnabled and runPart in debugParts):
                             pipeline_name = "test-Core-API-%s" % runPart
-                            if not run_with_remote_php:
-                                pipeline_name += "-withoutRemotePhp"
                             pipeline_name += "-%s" % storage
+                            if run_with_remote_php:
+                                pipeline_name += "-withRemotePhp"
                             if run_with_watch_fs_enabled:
                                 pipeline_name += "-watchfs"
 

--- a/.woodpecker.star
+++ b/.woodpecker.star
@@ -90,6 +90,30 @@ event = {
     },
 }
 
+OPENCLOUD_STORAGES = ["posix", "decomposed"]
+API_NIGHTLY_MATRIX = {
+    "posix": [
+        {
+            "withRemotePhp": False,
+            "enableWatchFs": True,
+        },
+        {
+            "withRemotePhp": True,
+            "enableWatchFs": False,
+        },
+    ],
+    "decomposed": [
+        {
+            "withRemotePhp": False,
+            "enableWatchFs": False,
+        },
+        {
+            "withRemotePhp": True,
+            "enableWatchFs": False,
+        },
+    ],
+}
+
 # configuration
 config = {
     "cs3ApiTests": {
@@ -1192,21 +1216,9 @@ def localApiTestPipeline(ctx):
         "federationServer": False,
         "collaborationServiceNeeded": False,
         "extraCollaborationEnvironment": {},
-        "withRemotePhp": [False],
-        "enableWatchFs": [False],
+        "withRemotePhp": False,
+        "enableWatchFs": False,
         "ldapNeeded": False,
-    }
-
-    nightly_matrix = {
-        "storages": ["posix", "decomposed"],
-        "posix": {
-            "withRemotePhp": [False],
-            "enableWatchFs": [False, True],
-        },
-        "decomposed": {
-            "withRemotePhp": [False, True],
-            "enableWatchFs": [False],
-        },
     }
 
     if "localApiTests" in config:
@@ -1217,73 +1229,73 @@ def localApiTestPipeline(ctx):
                     params[item] = matrix[item] if item in matrix else defaults[item]
 
                 if ctx.build.event == "cron":
-                    params["storages"] = nightly_matrix["storages"]
+                    params["storages"] = OPENCLOUD_STORAGES
+
+                    # skip CLI tests in nightly pipeline
+                    if name.startswith("cli"):
+                        continue
 
                 # use decomposed storage if specified in the PR title
                 # run CLI tests only with decomposed storage
                 if "[decomposed]" in ctx.build.title.lower() or name.startswith("cli"):
                     params["storages"] = ["decomposed"]
 
+                feat_matrices = [{
+                    "withRemotePhp": params["withRemotePhp"],
+                    "enableWatchFs": params["enableWatchFs"],
+                }]
+
                 for storage in params["storages"]:
-                    # override with nightly matrix
-                    if ctx.build.event == "cron":
-                        params["withRemotePhp"] = nightly_matrix[storage]["withRemotePhp"]
-                        params["enableWatchFs"] = nightly_matrix[storage]["enableWatchFs"]
+                    for m in feat_matrices:
+                        run_with_remote_php = m["withRemotePhp"]
+                        run_with_watch_fs_enabled = m["enableWatchFs"]
 
-                    # override configs if specified in the suite config
-                    if "withRemotePhp" in matrix:
-                        params["withRemotePhp"] = matrix["withRemotePhp"]
-                    if "enableWatchFs" in matrix:
-                        params["enableWatchFs"] = matrix["enableWatchFs"]
+                        pipeline_name = "test-API"
+                        if name.startswith("cli"):
+                            pipeline_name = "test-CLI"
+                        pipeline_name += "-%s" % name
+                        pipeline_name += "-%s" % storage
+                        if run_with_remote_php:
+                            pipeline_name += "-withRemotePhp"
+                        if run_with_watch_fs_enabled:
+                            pipeline_name += "-watchfs"
 
-                    for run_with_remote_php in params["withRemotePhp"]:
-                        for run_with_watch_fs_enabled in params["enableWatchFs"]:
-                            pipeline_name = "test-API"
-                            if name.startswith("cli"):
-                                pipeline_name = "test-CLI"
-                            pipeline_name += "-%s" % name
-                            pipeline_name += "-%s" % storage
-                            if run_with_remote_php:
-                                pipeline_name += "-withRemotePhp"
-                            if run_with_watch_fs_enabled:
-                                pipeline_name += "-watchfs"
-
-                            pipeline = {
-                                "name": pipeline_name,
-                                "steps": skipCheckStep(ctx, "acceptance-tests") + evaluateWorkflowStep() + restoreBuildArtifactCache(ctx, dirs["opencloudBinArtifact"], dirs["opencloudBinPath"]) +
-                                         (tikaService() if params["tikaNeeded"] else []) +
-                                         (waitForWebOffices(["https://collabora:9980", "https://onlyoffice", "http://fakeoffice:8080"]) if params["collaborationServiceNeeded"] else []) +
-                                         (waitForClamavService() if params["antivirusNeeded"] else []) +
-                                         (waitForEmailService() if params["emailNeeded"] else []) +
-                                         (ldapService() if params["ldapNeeded"] else []) +
-                                         (waitForLdapService() if params["ldapNeeded"] else []) +
-                                         opencloudServer(
-                                             storage,
-                                             extra_server_environment = params["extraServerEnvironment"],
-                                             with_wrapper = True,
-                                             tika_enabled = params["tikaNeeded"],
-                                             watch_fs_enabled = run_with_watch_fs_enabled,
-                                         ) +
-                                         (opencloudServer(storage, deploy_type = "federation", extra_server_environment = params["extraServerEnvironment"], watch_fs_enabled = run_with_watch_fs_enabled) if params["federationServer"] else []) +
-                                         ((wopiCollaborationService("fakeoffice") + wopiCollaborationService("collabora") + wopiCollaborationService("onlyoffice")) if params["collaborationServiceNeeded"] else []) +
-                                         (openCloudHealthCheck("wopi", ["wopi-collabora:9304", "wopi-onlyoffice:9304", "wopi-fakeoffice:9304"]) if params["collaborationServiceNeeded"] else []) +
-                                         localApiTest(params["suites"], storage, params["extraTestEnvironment"], run_with_remote_php) +
-                                         logRequests(),
-                                "services": (emailService() if params["emailNeeded"] else []) +
-                                            (clamavService() if params["antivirusNeeded"] else []) +
-                                            ((fakeOffice() + collaboraService() + onlyofficeService()) if params["collaborationServiceNeeded"] else []),
-                                "depends_on": getPipelineNames(buildOpencloudBinaryForTesting(ctx)),
-                                "when": [
-                                    event["base"],
-                                    event["cron"],
-                                    event["pull_request"],
-                                ],
-                            }
-                            prefixStepCommands(pipeline, [
-                                ". ./.woodpecker.env",
-                                '[ "$SKIP_WORKFLOW" = "true" ] && exit 0',
-                            ])
-                            pipelines.append(pipeline)
+                        pipeline = {
+                            "name": pipeline_name,
+                            "steps": skipCheckStep(ctx, "acceptance-tests") + evaluateWorkflowStep() + restoreBuildArtifactCache(ctx, dirs["opencloudBinArtifact"], dirs["opencloudBinPath"]) +
+                                     (tikaService() if params["tikaNeeded"] else []) +
+                                     (waitForWebOffices(["https://collabora:9980", "https://onlyoffice", "http://fakeoffice:8080"]) if params["collaborationServiceNeeded"] else []) +
+                                     (waitForClamavService() if params["antivirusNeeded"] else []) +
+                                     (waitForEmailService() if params["emailNeeded"] else []) +
+                                     (ldapService() if params["ldapNeeded"] else []) +
+                                     (waitForLdapService() if params["ldapNeeded"] else []) +
+                                     opencloudServer(
+                                         storage,
+                                         extra_server_environment = params["extraServerEnvironment"],
+                                         with_wrapper = True,
+                                         tika_enabled = params["tikaNeeded"],
+                                         watch_fs_enabled = run_with_watch_fs_enabled,
+                                     ) +
+                                     (opencloudServer(storage, deploy_type = "federation", extra_server_environment = params["extraServerEnvironment"], watch_fs_enabled = run_with_watch_fs_enabled) if params["federationServer"] else []) +
+                                     ((wopiCollaborationService("fakeoffice") + wopiCollaborationService("collabora") + wopiCollaborationService("onlyoffice")) if params["collaborationServiceNeeded"] else []) +
+                                     (openCloudHealthCheck("wopi", ["wopi-collabora:9304", "wopi-onlyoffice:9304", "wopi-fakeoffice:9304"]) if params["collaborationServiceNeeded"] else []) +
+                                     localApiTest(params["suites"], storage, params["extraTestEnvironment"], run_with_remote_php) +
+                                     logRequests(),
+                            "services": (emailService() if params["emailNeeded"] else []) +
+                                        (clamavService() if params["antivirusNeeded"] else []) +
+                                        ((fakeOffice() + collaboraService() + onlyofficeService()) if params["collaborationServiceNeeded"] else []),
+                            "depends_on": getPipelineNames(buildOpencloudBinaryForTesting(ctx)),
+                            "when": [
+                                event["base"],
+                                event["cron"],
+                                event["pull_request"],
+                            ],
+                        }
+                        prefixStepCommands(pipeline, [
+                            ". ./.woodpecker.env",
+                            '[ "$SKIP_WORKFLOW" = "true" ] && exit 0',
+                        ])
+                        pipelines.append(pipeline)
     return pipelines
 
 def localApiTest(suites, storage = "decomposed", extra_environment = {}, with_remote_php = False):
@@ -1358,7 +1370,7 @@ def coreApiTestPipeline(ctx):
             params[item] = matrix[item] if item in matrix else defaults[item]
 
         if ctx.build.event == "cron":
-            params["storages"] = nightly_matrix["storages"]
+            params["storages"] = OPENCLOUD_STORAGES
 
         # use decomposed storage if specified in the PR title
         if "[decomposed]" in ctx.build.title.lower():
@@ -1367,58 +1379,54 @@ def coreApiTestPipeline(ctx):
         debugParts = params["skipExceptParts"]
         debugPartsEnabled = (len(debugParts) != 0)
 
+        feat_matrices = [{
+            "withRemotePhp": params["withRemotePhp"],
+            "enableWatchFs": params["enableWatchFs"],
+        }]
+
         for storage in params["storages"]:
-            # override with nightly matrix
-            if ctx.build.event == "cron":
-                params["withRemotePhp"] = nightly_matrix[storage]["withRemotePhp"]
-                params["enableWatchFs"] = nightly_matrix[storage]["enableWatchFs"]
-
-            # override configs if specified in the suite config
-            if "withRemotePhp" in matrix:
-                params["withRemotePhp"] = matrix["withRemotePhp"]
-            if "enableWatchFs" in matrix:
-                params["enableWatchFs"] = matrix["enableWatchFs"]
             for runPart in range(1, params["numberOfParts"] + 1):
-                for run_with_remote_php in params["withRemotePhp"]:
-                    for run_with_watch_fs_enabled in params["enableWatchFs"]:
-                        if not debugPartsEnabled or (debugPartsEnabled and runPart in debugParts):
-                            pipeline_name = "test-Core-API-%s" % runPart
-                            pipeline_name += "-%s" % storage
-                            if run_with_remote_php:
-                                pipeline_name += "-withRemotePhp"
-                            if run_with_watch_fs_enabled:
-                                pipeline_name += "-watchfs"
+                for m in feat_matrices:
+                    run_with_remote_php = m["withRemotePhp"]
+                    run_with_watch_fs_enabled = m["enableWatchFs"]
+                    if not debugPartsEnabled or (debugPartsEnabled and runPart in debugParts):
+                        pipeline_name = "test-Core-API-%s" % runPart
+                        pipeline_name += "-%s" % storage
+                        if run_with_remote_php:
+                            pipeline_name += "-withRemotePhp"
+                        if run_with_watch_fs_enabled:
+                            pipeline_name += "-watchfs"
 
-                            pipeline = {
-                                "name": pipeline_name,
-                                "steps": skipCheckStep(ctx, "acceptance-tests") +
-                                         evaluateWorkflowStep() +
-                                         restoreBuildArtifactCache(ctx, dirs["opencloudBinArtifact"], dirs["opencloudBinPath"]) +
-                                         opencloudServer(
-                                             storage,
-                                             with_wrapper = True,
-                                             watch_fs_enabled = run_with_watch_fs_enabled,
-                                         ) +
-                                         coreApiTest(
-                                             runPart,
-                                             params["numberOfParts"],
-                                             run_with_remote_php,
-                                             storage,
-                                         ) +
-                                         logRequests(),
-                                "services": redisForOCStorage(storage),
-                                "depends_on": getPipelineNames(buildOpencloudBinaryForTesting(ctx)),
-                                "when": [
-                                    event["base"],
-                                    event["cron"],
-                                    event["pull_request"],
-                                ],
-                            }
-                            prefixStepCommands(pipeline, [
-                                ". ./.woodpecker.env",
-                                '[ "$SKIP_WORKFLOW" = "true" ] && exit 0',
-                            ])
-                            pipelines.append(pipeline)
+                        pipeline = {
+                            "name": pipeline_name,
+                            "steps": skipCheckStep(ctx, "acceptance-tests") +
+                                     evaluateWorkflowStep() +
+                                     restoreBuildArtifactCache(ctx, dirs["opencloudBinArtifact"], dirs["opencloudBinPath"]) +
+                                     opencloudServer(
+                                         storage,
+                                         with_wrapper = True,
+                                         watch_fs_enabled = run_with_watch_fs_enabled,
+                                     ) +
+                                     coreApiTest(
+                                         runPart,
+                                         params["numberOfParts"],
+                                         run_with_remote_php,
+                                         storage,
+                                     ) +
+                                     logRequests(),
+                            "services": redisForOCStorage(storage),
+                            "depends_on": getPipelineNames(buildOpencloudBinaryForTesting(ctx)),
+                            "when": [
+                                event["base"],
+                                event["cron"],
+                                event["pull_request"],
+                            ],
+                        }
+                        prefixStepCommands(pipeline, [
+                            ". ./.woodpecker.env",
+                            '[ "$SKIP_WORKFLOW" = "true" ] && exit 0',
+                        ])
+                        pipelines.append(pipeline)
     return pipelines
 
 def coreApiTest(part_number = 1, number_of_parts = 1, with_remote_php = False, storage = "posix"):

--- a/.woodpecker.star
+++ b/.woodpecker.star
@@ -91,7 +91,7 @@ event = {
 }
 
 OPENCLOUD_STORAGES = ["posix", "decomposed"]
-API_NIGHTLY_MATRIX = {
+API_TEST_NIGHTLY_CI_MATRIX = {
     "posix": [
         {
             "withRemotePhp": False,
@@ -146,6 +146,8 @@ config = {
                 "apiSettings",
             ],
             "skip": False,
+            "withRemotePhp": False,
+            "enableWatchFs": False,
             "emailNeeded": True,
             "extraTestEnvironment": {
                 "EMAIL_HOST": "email",
@@ -168,12 +170,14 @@ config = {
                 #"collaborativePosix",
             ],
             "skip": False,
+            "withRemotePhp": False,
         },
         "graphUserGroup": {
             "suites": [
                 "apiGraphUserGroup",
             ],
             "skip": False,
+            "withRemotePhp": False,
         },
         "spaces": {
             "suites": [
@@ -231,6 +235,7 @@ config = {
                 "apiNotification",
             ],
             "skip": False,
+            "withRemotePhp": False,
             "emailNeeded": True,
             "extraTestEnvironment": {
                 "EMAIL_HOST": "email",
@@ -272,6 +277,7 @@ config = {
                 "apiOcm",
             ],
             "skip": False,
+            "withRemotePhp": False,
             "federationServer": True,
             "emailNeeded": True,
             "extraTestEnvironment": {
@@ -307,12 +313,15 @@ config = {
                 "apiAuthApp",
             ],
             "skip": False,
+            "withRemotePhp": False,
+            "enableWatchFs": False,
         },
         "cliCommands": {
             "suites": [
                 "cliCommands",
             ],
             "skip": False,
+            "withRemotePhp": False,
             "antivirusNeeded": True,
             "extraServerEnvironment": {
                 "ANTIVIRUS_SCANNER_TYPE": "clamav",
@@ -327,6 +336,7 @@ config = {
                 "apiTenancy",
             ],
             "skip": False,
+            "withRemotePhp": False,
             "ldapNeeded": True,
             "extraTestEnvironment": {
                 "USE_PREPARED_LDAP_USERS": True,
@@ -1201,6 +1211,60 @@ def wopiValidatorTests(ctx, storage, wopiServerType):
     ])
     return [pipeline]
 
+def build_api_test_workflow_matrix(ctx, storage, suite_cfg, default_cfg):
+    """
+    Generates a matrix of feature combinations to run API tests with.
+
+    Args:
+        ctx: woodpecker context
+        storage: opencloud storage type
+        suite_cfg: suite config. E.g.: config["localApiTests"]["spaces"]
+        default_cfg: default suite config values
+
+    Returns:
+        A matrix to run API tests with. E.g.:
+        [
+            {
+                "withRemotePhp": False,
+                "enableWatchFs": False,
+            },
+            {
+                "withRemotePhp": True,
+                "enableWatchFs": False,
+            },
+        ]
+    """
+
+    # default for PRs and commit push events
+    matrices = [{
+        "withRemotePhp": default_cfg["withRemotePhp"],
+        "enableWatchFs": default_cfg["enableWatchFs"],
+    }]
+    if ctx.build.event == "cron":
+        matrices = API_TEST_NIGHTLY_CI_MATRIX[storage]
+
+    override_with_remote_php = None
+    override_enable_watch_fs = None
+    if "withRemotePhp" in suite_cfg:
+        override_with_remote_php = suite_cfg["withRemotePhp"]
+    if "enableWatchFs" in suite_cfg:
+        override_enable_watch_fs = suite_cfg["enableWatchFs"]
+
+    workflow_metrices = []
+    for m in matrices:
+        matrix = {
+            "withRemotePhp": m["withRemotePhp"],
+            "enableWatchFs": m["enableWatchFs"],
+        }
+        if override_with_remote_php != None:
+            matrix["withRemotePhp"] = override_with_remote_php
+        if override_enable_watch_fs != None:
+            matrix["enableWatchFs"] = override_enable_watch_fs
+
+        if matrix not in workflow_metrices and matrix in matrices:
+            workflow_metrices.append(matrix)
+    return workflow_metrices
+
 def localApiTestPipeline(ctx):
     pipelines = []
 
@@ -1240,15 +1304,11 @@ def localApiTestPipeline(ctx):
                 if "[decomposed]" in ctx.build.title.lower() or name.startswith("cli"):
                     params["storages"] = ["decomposed"]
 
-                feat_matrices = [{
-                    "withRemotePhp": params["withRemotePhp"],
-                    "enableWatchFs": params["enableWatchFs"],
-                }]
-
                 for storage in params["storages"]:
-                    for m in feat_matrices:
+                    matrices = build_api_test_workflow_matrix(ctx, storage, matrix, defaults)
+                    for m in matrices:
                         run_with_remote_php = m["withRemotePhp"]
-                        run_with_watch_fs_enabled = m["enableWatchFs"]
+                        run_with_watch_fs = m["enableWatchFs"]
 
                         pipeline_name = "test-API"
                         if name.startswith("cli"):
@@ -1257,7 +1317,7 @@ def localApiTestPipeline(ctx):
                         pipeline_name += "-%s" % storage
                         if run_with_remote_php:
                             pipeline_name += "-withRemotePhp"
-                        if run_with_watch_fs_enabled:
+                        if run_with_watch_fs:
                             pipeline_name += "-watchfs"
 
                         pipeline = {
@@ -1274,9 +1334,9 @@ def localApiTestPipeline(ctx):
                                          extra_server_environment = params["extraServerEnvironment"],
                                          with_wrapper = True,
                                          tika_enabled = params["tikaNeeded"],
-                                         watch_fs_enabled = run_with_watch_fs_enabled,
+                                         watch_fs_enabled = run_with_watch_fs,
                                      ) +
-                                     (opencloudServer(storage, deploy_type = "federation", extra_server_environment = params["extraServerEnvironment"], watch_fs_enabled = run_with_watch_fs_enabled) if params["federationServer"] else []) +
+                                     (opencloudServer(storage, deploy_type = "federation", extra_server_environment = params["extraServerEnvironment"], watch_fs_enabled = run_with_watch_fs) if params["federationServer"] else []) +
                                      ((wopiCollaborationService("fakeoffice") + wopiCollaborationService("collabora") + wopiCollaborationService("onlyoffice")) if params["collaborationServiceNeeded"] else []) +
                                      (openCloudHealthCheck("wopi", ["wopi-collabora:9304", "wopi-onlyoffice:9304", "wopi-fakeoffice:9304"]) if params["collaborationServiceNeeded"] else []) +
                                      localApiTest(params["suites"], storage, params["extraTestEnvironment"], run_with_remote_php) +
@@ -1339,24 +1399,12 @@ def localApiTest(suites, storage = "decomposed", extra_environment = {}, with_re
 
 def coreApiTestPipeline(ctx):
     defaults = {
-        "withRemotePhp": [False],
-        "enableWatchFs": [False],
+        "withRemotePhp": False,
+        "enableWatchFs": False,
         "storages": ["posix"],
         "numberOfParts": 7,
         "skipExceptParts": [],
         "skip": False,
-    }
-
-    nightly_matrix = {
-        "storages": ["posix", "decomposed"],
-        "posix": {
-            "withRemotePhp": [False],
-            "enableWatchFs": [False, True],
-        },
-        "decomposed": {
-            "withRemotePhp": [False, True],
-            "enableWatchFs": [False],
-        },
     }
 
     pipelines = []
@@ -1379,22 +1427,18 @@ def coreApiTestPipeline(ctx):
         debugParts = params["skipExceptParts"]
         debugPartsEnabled = (len(debugParts) != 0)
 
-        feat_matrices = [{
-            "withRemotePhp": params["withRemotePhp"],
-            "enableWatchFs": params["enableWatchFs"],
-        }]
-
         for storage in params["storages"]:
             for runPart in range(1, params["numberOfParts"] + 1):
-                for m in feat_matrices:
+                matrices = build_api_test_workflow_matrix(ctx, storage, matrix, defaults)
+                for m in matrices:
                     run_with_remote_php = m["withRemotePhp"]
-                    run_with_watch_fs_enabled = m["enableWatchFs"]
+                    run_with_watch_fs = m["enableWatchFs"]
                     if not debugPartsEnabled or (debugPartsEnabled and runPart in debugParts):
                         pipeline_name = "test-Core-API-%s" % runPart
                         pipeline_name += "-%s" % storage
                         if run_with_remote_php:
                             pipeline_name += "-withRemotePhp"
-                        if run_with_watch_fs_enabled:
+                        if run_with_watch_fs:
                             pipeline_name += "-watchfs"
 
                         pipeline = {
@@ -1405,7 +1449,7 @@ def coreApiTestPipeline(ctx):
                                      opencloudServer(
                                          storage,
                                          with_wrapper = True,
-                                         watch_fs_enabled = run_with_watch_fs_enabled,
+                                         watch_fs_enabled = run_with_watch_fs,
                                      ) +
                                      coreApiTest(
                                          runPart,


### PR DESCRIPTION
## Description
PR and push pipelines matrix:
```
api-X-posix
cli-X-decomposed
core-api-X-posix
```

Nightly (cron) matrix:
> [!NOTE]
> Some test suites will have less combination based on their test nature
> Example: graph test suite will not have withRemotePhp combination
>
> cli-X will not run in nightly as per https://github.com/opencloud-eu/opencloud/pull/2939#issuecomment-4690377548
```
api-X-posix-withRemotePhp
api-X-posix-watchfs
api-X-decomposed
api-X-decomposed-withRemotePhp

core-api-X-posix-withRemotePhp
core-api-X-posix-watchfs
core-api-X-decomposed
core-api-X-decomposed-withRemotePhp
```

## Related Issue
- Resolves https://github.com/opencloud-eu/qa/issues/84

## Motivation and Context

## How Has This Been Tested?
- test environment:
  - PR/Push Workflows: https://ci.opencloud.rocks/repos/3/pipeline/245
  - Nightly Workflows: https://ci.opencloud.rocks/repos/3/pipeline/243

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added
