### PR TITLE
Bump alpine base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,15 +21,14 @@ COPY ./ /opencloud/
 WORKDIR /opencloud/opencloud
 RUN make node-generate-prod
 
-FROM golang:1.24-alpine AS build
-RUN apk add bash make git curl gcc musl-dev libc-dev binutils-gold inotify-tools vips-dev
+FROM quay.io/opencloudeu/golang-ci:1.25 AS build
 
 COPY --from=generate /opencloud /opencloud
 
 WORKDIR /opencloud/opencloud
 RUN make go-generate build ENABLE_VIPS=true
 
-FROM alpine:3.23
+FROM alpine:3.24
 
 RUN apk add --no-cache attr ca-certificates curl mailcap tree vips && \
 	echo 'hosts: files dns' >| /etc/nsswitch.conf

--- a/opencloud/docker/Dockerfile.multiarch
+++ b/opencloud/docker/Dockerfile.multiarch
@@ -1,12 +1,10 @@
-FROM golang:alpine3.23 AS build
+FROM quay.io/opencloudeu/golang-ci:1.25 AS build
 ARG TARGETOS
 ARG TARGETARCH
 ARG VERSION
 ARG STRING
 ARG EDITION="dev"
 ARG SRCDIR
-
-RUN apk add bash make git curl gcc musl-dev libc-dev binutils-gold inotify-tools vips-dev
 
 WORKDIR /build
 RUN --mount=type=bind,target=/build,rw \
@@ -15,7 +13,7 @@ RUN --mount=type=bind,target=/build,rw \
     GOOS="${TARGETOS:-linux}" GOARCH="${TARGETARCH:-amd64}" ; \
     make -C ${SRCDIR:-.}/opencloud release-linux-docker-${TARGETARCH} ENABLE_VIPS=true DIST=/dist
 
-FROM alpine:3.23
+FROM alpine:3.24
 ARG VERSION
 ARG REVISION
 ARG TARGETOS


### PR DESCRIPTION
Also adjust the build image to use the opencloudeu/golang image. So we're in sync with how the binaries are built in CI. It already contains all the required dependencies.
