### PR TITLE
Revert "fix: disallow thumbnails for tiff and jpeg2000 images"

### DIFF
--- a/services/thumbnails/pkg/thumbnail/mimetypes_vips.go
+++ b/services/thumbnails/pkg/thumbnail/mimetypes_vips.go
@@ -2,15 +2,6 @@
 
 package thumbnail
 
-import "github.com/davidbyttow/govips/v2/vips"
-
-func init() {
-	// temporary remove TIFF and JP2K from go-vips' list of supported
-	// imagetypes
-	delete(vips.ImageTypes, vips.ImageTypeTIFF)
-	delete(vips.ImageTypes, vips.ImageTypeJP2K)
-}
-
 var (
 	// SupportedMimeTypes contains an all mimetypes which are supported by the thumbnailer.
 	SupportedMimeTypes = map[string]struct{}{
@@ -20,6 +11,7 @@ var (
 		"image/gif":                         {},
 		"image/bmp":                         {},
 		"image/x-ms-bmp":                    {},
+		"image/tiff":                        {},
 		"text/plain":                        {},
 		"audio/flac":                        {},
 		"audio/mpeg":                        {},


### PR DESCRIPTION
The alpine base images now has a fixed libvips. So we can enable previews for these formats again.

This reverts commit c40629dd8532d94861506bd2597557c24c6c9bcf.
