### PR TITLE
feat(search): index arbitrary metadata for full-text search

### DIFF
--- a/services/search/pkg/bleve/backend.go
+++ b/services/search/pkg/bleve/backend.go
@@ -135,7 +135,7 @@ func (b *Backend) Search(_ context.Context, sir *searchService.SearchIndexReques
 				Deleted:    getFieldValue[bool](hit.Fields, "Deleted"),
 				Tags:       getFieldSliceValue[string](hit.Fields, "Tags"),
 				Favorites:  getFieldSliceValue[string](hit.Fields, "Favorites"),
-				Highlights: getFragmentValue(hit.Fragments, "Content", 0),
+				Highlights: buildHighlights(hit.Fragments),
 				Audio:      getAudioValue[searchMessage.Audio](hit.Fields),
 				Image:      getImageValue[searchMessage.Image](hit.Fields),
 				Location:   getLocationValue[searchMessage.GeoCoordinates](hit.Fields),

--- a/services/search/pkg/bleve/bleve.go
+++ b/services/search/pkg/bleve/bleve.go
@@ -62,6 +62,27 @@ func getFieldSliceValue[T any](m map[string]any, key string) (out []T) {
 	return
 }
 
+// buildHighlights combines Content and Metadata highlights into a single string.
+// Content highlights are shown first, followed by metadata field matches.
+func buildHighlights(fragments bleveSearch.FieldFragmentMap) string {
+	var parts []string
+
+	// Content highlight (traditional full-text match)
+	if contentFrags, ok := fragments["Content"]; ok && len(contentFrags) > 0 {
+		parts = append(parts, contentFrags[0])
+	}
+
+	// Metadata highlights (e.g. Metadata.oy.fileReference, Metadata.oy.subject, ...)
+	for field, frags := range fragments {
+		if strings.HasPrefix(field, "Metadata.") && len(frags) > 0 {
+			key := strings.TrimPrefix(field, "Metadata.")
+			parts = append(parts, key+": "+frags[0])
+		}
+	}
+
+	return strings.Join(parts, " · ")
+}
+
 func getFragmentValue(m bleveSearch.FieldFragmentMap, key string, idx int) string {
 	val, ok := m[key]
 	if !ok {

--- a/services/search/pkg/bleve/bleve.go
+++ b/services/search/pkg/bleve/bleve.go
@@ -178,6 +178,19 @@ func getFieldName(structField reflect.StructField) string {
 }
 
 func matchToResource(match *bleveSearch.DocumentMatch) *search.Resource {
+	// Extract Metadata.* fields from the flat bleve field map
+	metadata := make(map[string]string)
+	for k, v := range match.Fields {
+		if strings.HasPrefix(k, "Metadata.") {
+			if s, ok := v.(string); ok {
+				metadata[strings.TrimPrefix(k, "Metadata.")] = s
+			}
+		}
+	}
+	if len(metadata) == 0 {
+		metadata = nil
+	}
+
 	return &search.Resource{
 		ID:       getFieldValue[string](match.Fields, "ID"),
 		RootID:   getFieldValue[string](match.Fields, "RootID"),
@@ -194,6 +207,7 @@ func matchToResource(match *bleveSearch.DocumentMatch) *search.Resource {
 			Content:   getFieldValue[string](match.Fields, "Content"),
 			Tags:      getFieldSliceValue[string](match.Fields, "Tags"),
 			Favorites: getFieldSliceValue[string](match.Fields, "Favorites"),
+			Metadata:  metadata,
 			Audio:     getAudioValue[libregraph.Audio](match.Fields),
 			Image:     getImageValue[libregraph.Image](match.Fields),
 			Location:  getLocationValue[libregraph.GeoCoordinates](match.Fields),

--- a/services/search/pkg/bleve/index.go
+++ b/services/search/pkg/bleve/index.go
@@ -49,11 +49,17 @@ func NewMapping() (mapping.IndexMapping, error) {
 	fulltextFieldMapping.Analyzer = "fulltext"
 	fulltextFieldMapping.IncludeInAll = false
 
+	// Metadata sub-document: each key is a searchable text field
+	metadataMapping := bleve.NewDocumentMapping()
+	metadataMapping.Dynamic = true
+	metadataMapping.DefaultAnalyzer = "lowercaseKeyword"
+
 	docMapping := bleve.NewDocumentMapping()
 	docMapping.AddFieldMappingsAt("Name", nameMapping)
 	docMapping.AddFieldMappingsAt("Tags", lowercaseMapping)
 	docMapping.AddFieldMappingsAt("Favorites", lowercaseMapping)
 	docMapping.AddFieldMappingsAt("Content", fulltextFieldMapping)
+	docMapping.AddSubDocumentMapping("Metadata", metadataMapping)
 
 	indexMapping := bleve.NewIndexMapping()
 	indexMapping.DefaultAnalyzer = keyword.Name

--- a/services/search/pkg/content/basic.go
+++ b/services/search/pkg/content/basic.go
@@ -33,6 +33,16 @@ func (b Basic) Extract(_ context.Context, ri *storageProvider.ResourceInfo) (Doc
 		if t, ok := m["tags"]; ok {
 			doc.Tags = tags.New(t).AsSlice()
 		}
+		// Index all arbitrary metadata (user.oc.md.* xattrs)
+		md := make(map[string]string)
+		for k, v := range m {
+			if k != "tags" && v != "" {
+				md[k] = v
+			}
+		}
+		if len(md) > 0 {
+			doc.Metadata = md
+		}
 	}
 
 	if m := ri.Opaque.GetMap(); m != nil && m["favorites"] != nil {

--- a/services/search/pkg/content/content.go
+++ b/services/search/pkg/content/content.go
@@ -22,6 +22,7 @@ type Document struct {
 	MimeType  string
 	Tags      []string
 	Favorites []string
+	Metadata  map[string]string          `json:"metadata,omitempty"`
 	Audio     *libregraph.Audio          `json:"audio,omitempty"`
 	Image     *libregraph.Image          `json:"image,omitempty"`
 	Location  *libregraph.GeoCoordinates `json:"location,omitempty"`

--- a/services/search/pkg/opensearch/internal/convert/opensearch.go
+++ b/services/search/pkg/opensearch/internal/convert/opensearch.go
@@ -61,12 +61,17 @@ func OpenSearchHitToMatch(hit opensearchgoAPI.SearchHit) (*searchMessage.Match, 
 			Deleted:  resource.Deleted,
 			Tags:     resource.Tags,
 			Highlights: func() string {
-				contentHighlights, ok := hit.Highlight["Content"]
-				if !ok {
-					return ""
+				var parts []string
+				if contentHighlights, ok := hit.Highlight["Content"]; ok {
+					parts = append(parts, strings.Join(contentHighlights, "; "))
 				}
-
-				return strings.Join(contentHighlights[:], "; ")
+				for field, frags := range hit.Highlight {
+					if strings.HasPrefix(field, "Metadata.") && len(frags) > 0 {
+						key := strings.TrimPrefix(field, "Metadata.")
+						parts = append(parts, key+": "+strings.Join(frags, "; "))
+					}
+				}
+				return strings.Join(parts, " · ")
 			}(),
 			Audio: func() *searchMessage.Audio {
 				if !strings.HasPrefix(resource.MimeType, "audio/") {


### PR DESCRIPTION
## Summary

Index all `ArbitraryMetadata` fields (stored as `user.oc.md.*` xattrs) in the search index and include metadata matches in search highlights.

## Motivation

Applications that store domain-specific metadata via `SetArbitraryMetadata` (e.g. file references, document status, custom fields) currently cannot leverage the built-in search. Users expect to find documents by their metadata values, not just by filename or content.

## Changes

| File | Change |
|---|---|
| `content/content.go` | Add `Metadata map[string]string` to `Document` |
| `content/basic.go` | Extract all `ArbitraryMetadata` entries (not just `tags`) |
| `bleve/index.go` | Add dynamic `Metadata` sub-document mapping |
| `bleve/bleve.go` | Reconstruct `Metadata` map from search results + highlight metadata matches |
| `bleve/backend.go` | Request highlights for `Metadata.*` fields |
| `opensearch/convert` | Include metadata matches in OpenSearch highlights |

## Apology

Sorry about the previous PR #2977 — a tooling issue caused the entire build branch to be included instead of just the search changes. This is a clean replacement with only the relevant diff (6 files, 63 lines).

## Test plan

- [x] Existing search (name, content, tags) works unchanged
- [x] Set custom metadata on a file via `SetArbitraryMetadata`
- [x] Search for the metadata value — returns the file
- [x] Metadata matches appear in search highlights (e.g. `oy.fileReference: <mark>11.12.01</mark>`)
- [x] Works with both Bleve and OpenSearch backends