### PR TITLE
feat(search): freetext and name queries include metadata fields

### DIFF
--- a/services/search/pkg/query/bleve/compiler.go
+++ b/services/search/pkg/query/bleve/compiler.go
@@ -102,7 +102,10 @@ func walk(offset int, nodes []ast.Node) (bleveQuery.Query, int, error) {
 				v = bleveEscaper.Replace(n.Value)
 			}
 
-			if _, ok := lowercaseFields[k]; ok {
+			if k == "" {
+				// Freetext: lowercase for _all field matching
+				v = strings.ToLower(v)
+			} else if _, ok := lowercaseFields[k]; ok {
 				v = strings.ToLower(v)
 			}
 
@@ -115,7 +118,20 @@ func walk(offset int, nodes []ast.Node) (bleveQuery.Query, int, error) {
 					isGroup = group
 				}
 			default:
-				q = bleveQuery.NewQueryStringQuery(k + ":" + v)
+				if k == "" {
+					q = bleveQuery.NewQueryStringQuery(v)
+				} else if k == "Name" {
+					// Also search Metadata fields when searching by name
+					nameQ := bleveQuery.NewQueryStringQuery(k + ":" + v)
+					metaQ := bleveQuery.NewQueryStringQuery(strings.ToLower(strings.Trim(v, `*\"`)))
+					q = bleveQuery.NewDisjunctionQuery([]bleveQuery.Query{nameQ, metaQ})
+					group = true
+					if prev == nil {
+						isGroup = true
+					}
+				} else {
+					q = bleveQuery.NewQueryStringQuery(k + ":" + v)
+				}
 			}
 
 			if prev == nil {
@@ -279,7 +295,7 @@ func mapBinary(operator *ast.OperatorNode, ln, rn bleveQuery.Query, leftIsGroup 
 
 func getField(name string) string {
 	if name == "" {
-		return "Name"
+		return ""
 	}
 	if _, ok := _fields[strings.ToLower(name)]; ok {
 		return _fields[strings.ToLower(name)]

--- a/services/search/pkg/query/bleve/compiler_test.go
+++ b/services/search/pkg/query/bleve/compiler_test.go
@@ -33,7 +33,7 @@ func Test_compile(t *testing.T) {
 				},
 			},
 			want: query.NewConjunctionQuery([]query.Query{
-				query.NewQueryStringQuery(`Name:federated`),
+				query.NewQueryStringQuery(`federated`),
 			}),
 			wantErr: false,
 		},
@@ -45,7 +45,7 @@ func Test_compile(t *testing.T) {
 				},
 			},
 			want: query.NewConjunctionQuery([]query.Query{
-				query.NewQueryStringQuery(`Name:john\ smith`),
+				query.NewQueryStringQuery(`john\ smith`),
 			}),
 			wantErr: false,
 		},


### PR DESCRIPTION
## Summary

Companion to #2987 (metadata indexing). Extends the Bleve query compiler so that freetext and name queries also search indexed metadata fields.

## Changes

| File | Change |
|---|---|
| `compiler.go` | Freetext queries use `_all` field (includes Metadata) instead of only `Name` |
| `compiler.go` | Name queries expanded to disjunction: `Name:*term* OR _all:term` |
| `compiler_test.go` | Updated expected queries for freetext |

## Motivation

The Web UI sends `name:"*term*"` KQL queries. Without this change, searching for a metadata value like `11.12.01` (a file reference) returns no results even though the metadata is indexed. With this change, both freetext and name queries search the `_all` field which includes all dynamic metadata.

## Test plan

- [x] Freetext search for a metadata value returns matching resources
- [x] Name search (`name:"*11.12*"`) returns resources with matching metadata
- [x] Normal name search still works as before
- [x] Existing unit tests updated and passing