### PR TITLE
fix: make the collaboration service events optional

### DIFF
--- a/services/collaboration/pkg/command/server.go
+++ b/services/collaboration/pkg/command/server.go
@@ -176,7 +176,9 @@ func Server(cfg *config.Config) *cobra.Command {
 
 			var optionalHTTPServerOptions []http.Option
 			var notificationService notification.Service
-			if cfg.Events.Endpoint != "" { // notifications are optional
+			if cfg.Events.Endpoint == "" {
+				logger.Warn().Msg("Events endpoint is not configured, notifications from the collaboration service will not work")
+			} else {
 				connName := generators.GenerateConnectionName(cfg.Service.Name, generators.NTypeBus)
 				natsStream, err := stream.NatsFromConfig(connName, true, stream.NatsConfig(cfg.Events))
 				if err != nil {

--- a/services/collaboration/pkg/command/server.go
+++ b/services/collaboration/pkg/command/server.go
@@ -12,7 +12,6 @@ import (
 	"github.com/opencloud-eu/reva/v2/pkg/rgrpc/todo/pool"
 	"github.com/opencloud-eu/reva/v2/pkg/store"
 	"github.com/spf13/afero"
-
 	"github.com/spf13/cobra"
 	"go-micro.dev/v4/selector"
 	microstore "go-micro.dev/v4/store"
@@ -175,8 +174,9 @@ func Server(cfg *config.Config) *cobra.Command {
 				}
 			}
 
+			var optionalHTTPServerOptions []http.Option
 			var notificationService notification.Service
-			{
+			if cfg.Events.Endpoint != "" { // notifications are optional
 				connName := generators.GenerateConnectionName(cfg.Service.Name, generators.NTypeBus)
 				natsStream, err := stream.NatsFromConfig(connName, true, stream.NatsConfig(cfg.Events))
 				if err != nil {
@@ -192,10 +192,12 @@ func Server(cfg *config.Config) *cobra.Command {
 				if err != nil {
 					return err
 				}
+
+				optionalHTTPServerOptions = append(optionalHTTPServerOptions, http.NotificationService(&notificationService))
 			}
 
 			// start HTTP server
-			httpServer, err := http.Server(
+			httpServer, err := http.Server(append([]http.Option{
 				http.Adapter(connector.NewHttpAdapter(gatewaySelector, cfg, st, selector.NewSelector(selector.Registry(registry.GetRegistry())))),
 				http.Logger(logger),
 				http.Config(cfg),
@@ -203,8 +205,7 @@ func Server(cfg *config.Config) *cobra.Command {
 				http.TracerProvider(traceProvider),
 				http.Store(st),
 				http.FontService(fontService),
-				http.NotificationService(notificationService),
-			)
+			}, optionalHTTPServerOptions...)...)
 			if err != nil {
 				logger.Info().Err(err).Str("transport", "http").Msg("Failed to initialize server")
 				return err

--- a/services/collaboration/pkg/server/http/option.go
+++ b/services/collaboration/pkg/server/http/option.go
@@ -25,7 +25,7 @@ type Options struct {
 	TracerProvider      trace.TracerProvider
 	Store               microstore.Store
 	FontService         font.Service
-	NotificationService notification.Service
+	NotificationService *notification.Service
 }
 
 // newOptions initializes the available default options.
@@ -89,7 +89,7 @@ func FontService(val font.Service) Option {
 }
 
 // NotificationService provides a function to set the NotificationService option
-func NotificationService(val notification.Service) Option {
+func NotificationService(val *notification.Service) Option {
 	return func(o *Options) {
 		o.NotificationService = val
 	}

--- a/services/collaboration/pkg/server/http/server.go
+++ b/services/collaboration/pkg/server/http/server.go
@@ -22,6 +22,10 @@ import (
 func Server(opts ...Option) (http.Service, error) {
 	options := newOptions(opts...)
 
+	if options.NotificationService == nil {
+		options.Logger.Warn().Msg("running without notification service: no notifications will be sent, set the events endpoint to enable them")
+	}
+
 	service, err := http.NewService(
 		http.TLSConfig(options.Config.HTTP.TLS),
 		http.Logger(options.Logger),
@@ -219,9 +223,6 @@ func prepareRoutes(r *chi.Mux, options Options) {
 			account.Logger(options.Logger),
 			account.JWTSecret(options.Config.TokenManager.JWTSecret),
 		)
-		r.With(auth).Route("/notify", func(r chi.Router) {
-			r.Post("/", notificationService.HandleNotification)
-		})
 		r.Route("/fonts", func(r chi.Router) {
 			r.Get("/", fontService.ListFonts)
 			r.Get("/{id}", fontService.GetFont)
@@ -231,5 +232,11 @@ func prepareRoutes(r *chi.Mux, options Options) {
 				r.Delete("/{id}", fontService.DeleteFont)
 			})
 		})
+
+		if notificationService != nil { // optional
+			r.With(auth).Route("/notify", func(r chi.Router) {
+				r.Post("/", notificationService.HandleNotification)
+			})
+		}
 	})
 }


### PR DESCRIPTION
## Description

the collaboration service died without OC_EVENTS_ENDPOINT set,
this pr makes setting (and enabling) the endpoint optional.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/opencloud-eu/opencloud/issues/2966#issuecomment-4751775996

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
- [X] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added
