### PR TITLE
🎉 Release 4.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug Fixes
 
+- Prevent access to internal files and folders [[#3018](https://github.com/opencloud-eu/opencloud/pull/3018)]
 - [stable-4.0] Revert "fix: disallow thumbnails for tiff and jpeg2000 images" [[#3009](https://github.com/opencloud-eu/opencloud/pull/3009)]
 - [stable-4.0] Bump alpine base image [[#2965](https://github.com/opencloud-eu/opencloud/pull/2965)]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [4.0.8](https://github.com/opencloud-eu/opencloud/releases/tag/v4.0.8) - 2026-06-23
+
+### ❤️ Thanks to all contributors! ❤️
+
+@rhafer
+
+
+
 ## [4.0.7](https://github.com/opencloud-eu/opencloud/releases/tag/v4.0.7) - 2026-05-18
 
 ### ❤️ Thanks to all contributors! ❤️

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,15 @@
 # Changelog
 
-## [4.0.8](https://github.com/opencloud-eu/opencloud/releases/tag/v4.0.8) - 2026-06-23
+## [4.0.8](https://github.com/opencloud-eu/opencloud/releases/tag/v4.0.8) - 2026-06-24
 
 ### ❤️ Thanks to all contributors! ❤️
 
 @rhafer
 
+### 🐛 Bug Fixes
 
+- [stable-4.0] Revert "fix: disallow thumbnails for tiff and jpeg2000 images" [[#3009](https://github.com/opencloud-eu/opencloud/pull/3009)]
+- [stable-4.0] Bump alpine base image [[#2965](https://github.com/opencloud-eu/opencloud/pull/2965)]
 
 ## [4.0.7](https://github.com/opencloud-eu/opencloud/releases/tag/v4.0.7) - 2026-05-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug Fixes
 
-- Prevent access to internal files and folders [[#3018](https://github.com/opencloud-eu/opencloud/pull/3018)]
+- bump reva 2.40.5 [[#3018](https://github.com/opencloud-eu/opencloud/pull/3018)]
 - [stable-4.0] Revert "fix: disallow thumbnails for tiff and jpeg2000 images" [[#3009](https://github.com/opencloud-eu/opencloud/pull/3009)]
 - [stable-4.0] Bump alpine base image [[#2965](https://github.com/opencloud-eu/opencloud/pull/2965)]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
-## [4.0.8](https://github.com/opencloud-eu/opencloud/releases/tag/v4.0.8) - 2026-06-24
+## [4.0.8](https://github.com/opencloud-eu/opencloud/releases/tag/v4.0.8) - 2026-06-25
 
 ### ❤️ Thanks to all contributors! ❤️
 
-@rhafer
+@ScharfViktor, @rhafer
 
 ### 🐛 Bug Fixes
 


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `4.0.8` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `stable-4.0` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [4.0.8](https://github.com/opencloud-eu/opencloud/releases/tag/v4.0.8) - 2026-06-25

### 🐛 Bug Fixes

- bump reva 2.40.5 [[#3018](https://github.com/opencloud-eu/opencloud/pull/3018)]
- [stable-4.0] Revert "fix: disallow thumbnails for tiff and jpeg2000 images" [[#3009](https://github.com/opencloud-eu/opencloud/pull/3009)]
- [stable-4.0] Bump alpine base image [[#2965](https://github.com/opencloud-eu/opencloud/pull/2965)]