### PR TITLE
skip rolling release for production tags

### DIFF
--- a/.woodpecker.star
+++ b/.woodpecker.star
@@ -405,7 +405,7 @@ config = {
             # NOTE: need to be updated if new production releases are determined
             "tags": ["2.0", "4.0", "7.2"],
             # NOTE: need to be set to true if patch releases are made from stable-X-branches
-            "skip_rolling": False,
+            "skip_rolling": True,
             "skip_daily": True,
             "repo": docker_repo_slug,
             "build_type": "production",


### PR DESCRIPTION
we builded and pushed last tag`7.2.0` to `opencloud-rolling` and `opencloud`

for next patch tags we don't need push to `opencloud-rolling`