### PR TITLE
feat: support admin password file env

### DIFF
--- a/opencloud/pkg/command/init.go
+++ b/opencloud/pkg/command/init.go
@@ -38,7 +38,11 @@ func InitCommand(_ *config.Config) *cobra.Command {
 			quietFlag, _ := cmd.Flags().GetBool("quiet")
 			configPathFlag := viper.GetString("config-path")
 			adminPasswordFlag := viper.GetString("admin-password")
-			err := ocinit.CreateConfig(insecure, forceOverwriteFlag, diffFlag, configPathFlag, adminPasswordFlag, quietFlag)
+			adminPasswordFlag, _, err := config.ReadFileEnv(adminPasswordFlag, "ADMIN_PASSWORD_FILE", "IDM_ADMIN_PASSWORD_FILE")
+			if err != nil {
+				return err
+			}
+			err = ocinit.CreateConfig(insecure, forceOverwriteFlag, diffFlag, configPathFlag, adminPasswordFlag, quietFlag)
 			if err != nil {
 				log.Fatalf("Could not create config: %s", err)
 			}

--- a/pkg/config/helpers.go
+++ b/pkg/config/helpers.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"io/fs"
 	"os"
 	"path"
@@ -49,6 +50,29 @@ func bindSourcesToStructs(fileSystem fs.FS, filePath, service string, dst any) e
 	}
 
 	return nil
+}
+
+// ReadFileEnv returns value or the trimmed contents of the first set file env var.
+func ReadFileEnv(value string, fileEnvNames ...string) (string, bool, error) {
+	for _, name := range fileEnvNames {
+		file, ok := os.LookupEnv(name)
+		if !ok {
+			continue
+		}
+
+		if value != "" {
+			return "", true, fmt.Errorf("%s cannot be used together with direct value", name)
+		}
+
+		content, err := os.ReadFile(file)
+		if err != nil {
+			return "", true, fmt.Errorf("read %s: %w", name, err)
+		}
+
+		return strings.TrimRight(string(content), "\r\n"), true, nil
+	}
+
+	return value, false, nil
 }
 
 // LocalEndpoint returns the local endpoint for a given protocol and address.

--- a/pkg/config/helpers_test.go
+++ b/pkg/config/helpers_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"os"
 	"testing"
 	"testing/fstest"
 
@@ -11,6 +12,64 @@ type TestConfig struct {
 	A string `yaml:"a"`
 	B string `yaml:"b"`
 	C string `yaml:"c"`
+}
+
+func TestReadFileEnv(t *testing.T) {
+	t.Run("no file env", func(t *testing.T) {
+		value, ok, err := ReadFileEnv("direct", "MISSING_FILE")
+		assert.NilError(t, err)
+		assert.Equal(t, ok, false)
+		assert.Equal(t, value, "direct")
+	})
+
+	t.Run("reads file", func(t *testing.T) {
+		file := writeTempSecret(t, "secret")
+		t.Setenv("SECRET_FILE", file)
+
+		value, ok, err := ReadFileEnv("", "SECRET_FILE")
+		assert.NilError(t, err)
+		assert.Equal(t, ok, true)
+		assert.Equal(t, value, "secret")
+	})
+
+	t.Run("trims trailing newlines", func(t *testing.T) {
+		file := writeTempSecret(t, "secret\r\n\n")
+		t.Setenv("SECRET_FILE", file)
+
+		value, ok, err := ReadFileEnv("", "SECRET_FILE")
+		assert.NilError(t, err)
+		assert.Equal(t, ok, true)
+		assert.Equal(t, value, "secret")
+	})
+
+	t.Run("conflicts with direct value", func(t *testing.T) {
+		file := writeTempSecret(t, "secret")
+		t.Setenv("SECRET_FILE", file)
+
+		_, ok, err := ReadFileEnv("direct", "SECRET_FILE")
+		assert.Equal(t, ok, true)
+		assert.ErrorContains(t, err, "SECRET_FILE cannot be used together with direct value")
+	})
+
+	t.Run("missing file", func(t *testing.T) {
+		t.Setenv("SECRET_FILE", t.TempDir()+"/missing")
+
+		_, ok, err := ReadFileEnv("", "SECRET_FILE")
+		assert.Equal(t, ok, true)
+		assert.ErrorContains(t, err, "read SECRET_FILE")
+	})
+}
+
+func writeTempSecret(t *testing.T, content string) string {
+	t.Helper()
+
+	file, err := os.CreateTemp(t.TempDir(), "secret")
+	assert.NilError(t, err)
+	_, err = file.WriteString(content)
+	assert.NilError(t, err)
+	assert.NilError(t, file.Close())
+
+	return file.Name()
 }
 
 func TestBindSourcesToStructs(t *testing.T) {

--- a/services/idm/pkg/config/parser/parse.go
+++ b/services/idm/pkg/config/parser/parse.go
@@ -28,6 +28,12 @@ func ParseConfig(cfg *config.Config) error {
 		}
 	}
 
+	adminPassword, _, err := occfg.ReadFileEnv(cfg.ServiceUserPasswords.OCAdmin, "IDM_ADMIN_PASSWORD_FILE")
+	if err != nil {
+		return err
+	}
+	cfg.ServiceUserPasswords.OCAdmin = adminPassword
+
 	defaults.Sanitize(cfg)
 
 	return Validate(cfg)

--- a/services/idm/pkg/config/parser/parse_test.go
+++ b/services/idm/pkg/config/parser/parse_test.go
@@ -1,0 +1,29 @@
+package parser
+
+import (
+	"os"
+	"testing"
+
+	"github.com/opencloud-eu/opencloud/services/idm/pkg/config/defaults"
+	"gotest.tools/v3/assert"
+)
+
+func TestParseConfigReadsAdminPasswordFile(t *testing.T) {
+	file, err := os.CreateTemp(t.TempDir(), "admin-password")
+	assert.NilError(t, err)
+	_, err = file.WriteString("secret\n")
+	assert.NilError(t, err)
+	assert.NilError(t, file.Close())
+
+	t.Setenv("IDM_ADMIN_PASSWORD_FILE", file.Name())
+	t.Setenv("IDM_SVC_PASSWORD", "idm")
+	t.Setenv("IDM_IDPSVC_PASSWORD", "idp")
+	t.Setenv("IDM_REVASVC_PASSWORD", "reva")
+	t.Setenv("OC_ADMIN_USER_ID", "admin")
+
+	cfg := defaults.DefaultConfig()
+	err = ParseConfig(cfg)
+
+	assert.NilError(t, err)
+	assert.Equal(t, cfg.ServiceUserPasswords.OCAdmin, "secret")
+}


### PR DESCRIPTION
Adds file-based admin password support for the IDM admin user.

   Supported env vars:

   - `ADMIN_PASSWORD_FILE` for `opencloud init`
   - `IDM_ADMIN_PASSWORD_FILE` for `opencloud init`
   - `IDM_ADMIN_PASSWORD_FILE` for the IDM service config parser

   The file content is read and trailing `\n` / `\r\n` is trimmed. Supplying both a direct password env var and a password file env
 var returns a config error.

   ## Related Issue

   - Fixes https://github.com/opencloud-eu/opencloud/issues/2982

   ## Motivation and Context

   This allows deployments to provide the IDM admin password via Docker secrets or mounted secret files instead of exposing the
 password directly through environment variables.

   ## How Has This Been Tested?

   - test environment: local checkout on branch `feat/2982_idm_admin_passwort_file`
   - test case 1: helper tests for no file env, file env, trailing newline trimming, direct-value conflict, and missing file
   - test case 2: IDM parser test for `IDM_ADMIN_PASSWORD_FILE`
   - test case 3:

   ```sh
   go test ./pkg/config ./opencloud/pkg/command ./services/idm/pkg/...
 ```

 Screenshots (if appropriate):

 N/A

 Types of changes

 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)
 - [ ] Technical debt
 - [ ] Tests only (no source changes)

 Checklist:

 - [x] Code changes
 - [x] Unit tests added
 - [ ] Acceptance tests added
 - [ ] Documentation added
 ```