### PR TITLE
feat(search): index ArbitraryMetadataUpdated events

### DIFF
--- a/services/search/pkg/service/event/service.go
+++ b/services/search/pkg/service/event/service.go
@@ -60,6 +60,7 @@ func New(ctx context.Context, stream raw.Stream, logger log.Logger, tp trace.Tra
 			events.FileVersionRestored{},
 			events.TagsAdded{},
 			events.TagsRemoved{},
+			events.ArbitraryMetadataUpdated{},
 			events.SpaceRenamed{},
 			events.LabelAdded{},
 			events.LabelRemoved{},
@@ -192,6 +193,9 @@ func (s Service) processEvent(e raw.Event) error {
 		s.index.UpsertItem(ev.Ref)
 		s.indexSpaceDebouncer.Debounce(getSpaceID(ev.Ref), e.Ack)
 	case events.TagsRemoved:
+		s.index.UpsertItem(ev.Ref)
+		s.indexSpaceDebouncer.Debounce(getSpaceID(ev.Ref), e.Ack)
+	case events.ArbitraryMetadataUpdated:
 		s.index.UpsertItem(ev.Ref)
 		s.indexSpaceDebouncer.Debounce(getSpaceID(ev.Ref), e.Ack)
 	case events.FileUploaded:


### PR DESCRIPTION
## Summary

Subscribe to the new `ArbitraryMetadataUpdated` event and trigger `UpsertItem` + `IndexSpace` debounce in the search service. This matches the existing pattern for `TagsAdded`/`TagsRemoved`.

## Motivation

Custom metadata set via WebDAV PROPPATCH or the Graph Metadata API was invisible to search until the next full space re-index, because `SetArbitraryMetadata` did not emit any event. This was the only write operation missing from the event pipeline.

## Depends on

- **opencloud-eu/reva#712** — adds the `ArbitraryMetadataUpdated` event type and emits it from the events middleware interceptor. This PR will not build until reva#712 is merged and the reva dependency is updated.

## Changes

- `services/search/pkg/service/event/service.go`: add `events.ArbitraryMetadataUpdated{}` to subscribe list, add case to event handler (+4 lines)

## Test plan

- [x] Deployed reva patch on kosmos instance, verified event is published on NATS after PROPPATCH
- [ ] End-to-end: set metadata via PROPPATCH, verify search finds it (requires reva#712 merge)