### PR TITLE
feat(search): Qdrant vector store for semantic search

### DIFF
--- a/services/search/pkg/config/config.go
+++ b/services/search/pkg/config/config.go
@@ -26,6 +26,7 @@ type Config struct {
 	Events                     Events                `yaml:"events"`
 	Engine                     Engine                `yaml:"engine"`
 	Extractor                  Extractor             `yaml:"extractor"`
+	Vector                     VectorStore           `yaml:"vector"`
 	ContentExtractionSizeLimit uint64                `yaml:"content_extraction_size_limit" env:"SEARCH_CONTENT_EXTRACTION_SIZE_LIMIT" desc:"Maximum file size in bytes that is allowed for content extraction." introductionVersion:"1.0.0"`
 	BatchSize                  int                   `yaml:"batch_size" env:"SEARCH_BATCH_SIZE" desc:"The number of documents to process in a single batch. Defaults to 500." introductionVersion:"1.0.0"`
 

--- a/services/search/pkg/config/content.go
+++ b/services/search/pkg/config/content.go
@@ -13,3 +13,12 @@ type ExtractorTika struct {
 	CleanStopWords bool   `yaml:"clean_stop_words" env:"SEARCH_EXTRACTOR_TIKA_CLEAN_STOP_WORDS" desc:"Defines if stop words should be cleaned or not. See the documentation for more details." introductionVersion:"1.0.0"`
 	MaxWorkers     int    `yaml:"max_workers" env:"SEARCH_EXTRACTOR_TIKA_MAX_WORKERS" desc:"Maximum number of parallel extraction workers. Only effective with open_taki v2. Defaults to 8." introductionVersion:"7.1.0"`
 }
+
+// VectorStore configures an optional vector database for semantic search.
+// When enabled, document embeddings from open_taki v2 are stored in Qdrant
+// alongside the keyword index (bleve/opensearch).
+type VectorStore struct {
+	Enabled    bool   `yaml:"enabled" env:"SEARCH_VECTOR_ENABLED" desc:"Enable vector search via Qdrant. Requires open_taki with embedding support." introductionVersion:"7.1.0"`
+	URL        string `yaml:"url" env:"SEARCH_VECTOR_URL" desc:"URL of the Qdrant server." introductionVersion:"7.1.0"`
+	Collection string `yaml:"collection" env:"SEARCH_VECTOR_COLLECTION" desc:"Qdrant collection name. Defaults to 'opencloud'." introductionVersion:"7.1.0"`
+}

--- a/services/search/pkg/config/content.go
+++ b/services/search/pkg/config/content.go
@@ -11,4 +11,5 @@ type Extractor struct {
 type ExtractorTika struct {
 	TikaURL        string `yaml:"tika_url" env:"SEARCH_EXTRACTOR_TIKA_TIKA_URL" desc:"URL of the tika server." introductionVersion:"1.0.0"`
 	CleanStopWords bool   `yaml:"clean_stop_words" env:"SEARCH_EXTRACTOR_TIKA_CLEAN_STOP_WORDS" desc:"Defines if stop words should be cleaned or not. See the documentation for more details." introductionVersion:"1.0.0"`
+	MaxWorkers     int    `yaml:"max_workers" env:"SEARCH_EXTRACTOR_TIKA_MAX_WORKERS" desc:"Maximum number of parallel extraction workers. Only effective with open_taki v2. Defaults to 8." introductionVersion:"7.1.0"`
 }

--- a/services/search/pkg/config/defaults/defaultconfig.go
+++ b/services/search/pkg/config/defaults/defaultconfig.go
@@ -51,6 +51,7 @@ func DefaultConfig() *config.Config {
 			Tika: config.ExtractorTika{
 				TikaURL:        "http://127.0.0.1:9998",
 				CleanStopWords: false,
+				MaxWorkers:     8,
 			},
 		},
 		Events: config.Events{

--- a/services/search/pkg/config/defaults/defaultconfig.go
+++ b/services/search/pkg/config/defaults/defaultconfig.go
@@ -54,6 +54,11 @@ func DefaultConfig() *config.Config {
 				MaxWorkers:     8,
 			},
 		},
+		Vector: config.VectorStore{
+			Enabled:    false,
+			URL:        "http://localhost:6333",
+			Collection: "opencloud",
+		},
 		Events: config.Events{
 			Endpoint:         "127.0.0.1:9233",
 			Cluster:          "opencloud-cluster",

--- a/services/search/pkg/content/tika.go
+++ b/services/search/pkg/content/tika.go
@@ -33,6 +33,33 @@ func (t *Tika) IsTaki() bool {
 	return t.isTaki
 }
 
+// GetEmbedding requests an embedding for the given text from open_taki.
+func (t *Tika) GetEmbedding(text string) []float64 {
+	if !t.isTaki || text == "" {
+		return nil
+	}
+
+	req, err := http.NewRequest("PUT", t.tikaURL+"/rmeta/text", bytes.NewReader([]byte(text)))
+	if err != nil {
+		return nil
+	}
+	req.Header.Set("Content-Type", "text/plain")
+	req.Header.Set("X-Taki-Protocol", "v2")
+	req.Header.Set("X-Taki-Features", "embedding")
+
+	resp, err := t.httpClient.Do(req)
+	if err != nil {
+		return nil
+	}
+	defer resp.Body.Close()
+
+	var results []takiV2Response
+	if err := json.NewDecoder(resp.Body).Decode(&results); err != nil || len(results) == 0 {
+		return nil
+	}
+	return results[0].Embed
+}
+
 // NewTikaExtractor creates a new Tika instance.
 func NewTikaExtractor(gatewaySelector pool.Selectable[gateway.GatewayAPIClient], logger log.Logger, cfg *config.Config) (*Tika, error) {
 	basic, err := NewBasicExtractor(logger)

--- a/services/search/pkg/content/tika.go
+++ b/services/search/pkg/content/tika.go
@@ -28,6 +28,11 @@ type Tika struct {
 	CleanStopWords             bool
 }
 
+// IsTaki returns true if open_taki was detected as the extraction backend.
+func (t *Tika) IsTaki() bool {
+	return t.isTaki
+}
+
 // NewTikaExtractor creates a new Tika instance.
 func NewTikaExtractor(gatewaySelector pool.Selectable[gateway.GatewayAPIClient], logger log.Logger, cfg *config.Config) (*Tika, error) {
 	basic, err := NewBasicExtractor(logger)

--- a/services/search/pkg/qdrant/client.go
+++ b/services/search/pkg/qdrant/client.go
@@ -1,0 +1,147 @@
+// Package qdrant provides a lightweight client for the Qdrant vector database REST API.
+// Used by the search service to store document embeddings from open_taki v2.
+package qdrant
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/opencloud-eu/opencloud/pkg/log"
+)
+
+// Client is a minimal Qdrant REST API client.
+type Client struct {
+	url        string
+	collection string
+	httpClient *http.Client
+	logger     log.Logger
+}
+
+// Point represents a vector point to upsert into Qdrant.
+type Point struct {
+	ID      string                 `json:"id"`
+	Vector  []float64              `json:"vector"`
+	Payload map[string]interface{} `json:"payload"`
+}
+
+type upsertRequest struct {
+	Points []Point `json:"points"`
+}
+
+type collectionConfig struct {
+	Vectors struct {
+		Size     int    `json:"size"`
+		Distance string `json:"distance"`
+	} `json:"vectors"`
+}
+
+// New creates a new Qdrant client.
+func New(url, collection string, logger log.Logger) *Client {
+	return &Client{
+		url:        url,
+		collection: collection,
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+		logger:     logger,
+	}
+}
+
+// EnsureCollection creates the collection if it doesn't exist.
+func (c *Client) EnsureCollection(vectorSize int) error {
+	// Check if collection exists
+	resp, err := c.httpClient.Get(fmt.Sprintf("%s/collections/%s", c.url, c.collection))
+	if err != nil {
+		return fmt.Errorf("qdrant: checking collection: %w", err)
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode == 200 {
+		return nil // exists
+	}
+
+	// Create collection
+	cfg := collectionConfig{}
+	cfg.Vectors.Size = vectorSize
+	cfg.Vectors.Distance = "Cosine"
+
+	body, _ := json.Marshal(cfg)
+	req, _ := http.NewRequest("PUT", fmt.Sprintf("%s/collections/%s", c.url, c.collection), bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err = c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("qdrant: creating collection: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("qdrant: create collection failed (%d): %s", resp.StatusCode, string(respBody))
+	}
+
+	c.logger.Info().Str("collection", c.collection).Int("vector_size", vectorSize).Msg("qdrant: collection created")
+	return nil
+}
+
+// Upsert inserts or updates points in the collection.
+func (c *Client) Upsert(points []Point) error {
+	if len(points) == 0 {
+		return nil
+	}
+
+	body, _ := json.Marshal(upsertRequest{Points: points})
+	req, _ := http.NewRequest("PUT",
+		fmt.Sprintf("%s/collections/%s/points", c.url, c.collection),
+		bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("qdrant: upsert: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("qdrant: upsert failed (%d): %s", resp.StatusCode, string(respBody))
+	}
+
+	return nil
+}
+
+// Search performs a vector similarity search.
+func (c *Client) Search(vector []float64, limit int) ([]SearchResult, error) {
+	payload := map[string]interface{}{
+		"vector":       vector,
+		"limit":        limit,
+		"with_payload": true,
+	}
+	body, _ := json.Marshal(payload)
+
+	req, _ := http.NewRequest("POST",
+		fmt.Sprintf("%s/collections/%s/points/search", c.url, c.collection),
+		bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("qdrant: search: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var result struct {
+		Result []SearchResult `json:"result"`
+	}
+	json.NewDecoder(resp.Body).Decode(&result)
+	return result.Result, nil
+}
+
+// SearchResult represents a single search hit.
+type SearchResult struct {
+	ID      string                 `json:"id"`
+	Score   float64                `json:"score"`
+	Payload map[string]interface{} `json:"payload"`
+}

--- a/services/search/pkg/search/service.go
+++ b/services/search/pkg/search/service.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
@@ -64,6 +65,7 @@ type Service struct {
 	engine          Engine
 	extractor       content.Extractor
 	metrics         *metrics.Metrics
+	cfg             *config.Config
 
 	serviceAccountID     string
 	serviceAccountSecret string
@@ -81,6 +83,7 @@ func NewService(gatewaySelector pool.Selectable[gateway.GatewayAPIClient], eng E
 		logger:          logger,
 		extractor:       extractor,
 		metrics:         metrics,
+		cfg:             cfg,
 
 		serviceAccountID:     cfg.ServiceAccount.ServiceAccountID,
 		serviceAccountSecret: cfg.ServiceAccount.ServiceAccountSecret,
@@ -485,6 +488,34 @@ func (s *Service) IndexSpace(spaceID *provider.StorageSpaceId, forceRescan bool)
 		}
 		logDocCount(s.engine, s.logger)
 	}()
+
+	// Parallel extraction when taki v2 is detected (LLM benefits from concurrent calls)
+	isTaki := false
+	if tikaExtractor, ok := s.extractor.(*content.Tika); ok {
+		isTaki = tikaExtractor.IsTaki()
+	}
+
+	indexWorkers := s.cfg.Extractor.Tika.MaxWorkers
+	if indexWorkers < 1 {
+		indexWorkers = 8
+	}
+	var workCh chan *provider.Reference
+	var indexWg sync.WaitGroup
+
+	if isTaki {
+		s.logger.Info().Int("workers", indexWorkers).Msg("taki v2 detected: parallel indexing enabled")
+		workCh = make(chan *provider.Reference, indexWorkers*2)
+		for i := 0; i < indexWorkers; i++ {
+			indexWg.Add(1)
+			go func() {
+				defer indexWg.Done()
+				for ref := range workCh {
+					s.doUpsertItem(ref, nil)
+				}
+			}()
+		}
+	}
+
 	err = w.Walk(ownerCtx, &rootID, func(wd string, info *provider.ResourceInfo, err error) error {
 		if err != nil {
 			s.logger.Error().Err(err).Msg("error walking the tree")
@@ -502,7 +533,11 @@ func (s *Service) IndexSpace(spaceID *provider.StorageSpaceId, forceRescan bool)
 		s.logger.Debug().Str("path", ref.Path).Msg("Walking tree")
 
 		if forceRescan {
-			s.doUpsertItem(ref, batch)
+			if isTaki {
+				workCh <- ref
+			} else {
+				s.doUpsertItem(ref, batch)
+			}
 			return nil
 		}
 
@@ -519,10 +554,19 @@ func (s *Service) IndexSpace(spaceID *provider.StorageSpaceId, forceRescan bool)
 			return nil
 		}
 
-		s.doUpsertItem(ref, batch)
+		if isTaki {
+			workCh <- ref
+		} else {
+			s.doUpsertItem(ref, batch)
+		}
 
 		return nil
 	})
+
+	if isTaki {
+		close(workCh)
+		indexWg.Wait()
+	}
 
 	if err != nil {
 		return err

--- a/services/search/pkg/search/service.go
+++ b/services/search/pkg/search/service.go
@@ -32,6 +32,7 @@ import (
 	"github.com/opencloud-eu/opencloud/services/search/pkg/config"
 	"github.com/opencloud-eu/opencloud/services/search/pkg/content"
 	"github.com/opencloud-eu/opencloud/services/search/pkg/metrics"
+	"github.com/opencloud-eu/opencloud/services/search/pkg/qdrant"
 )
 
 const (
@@ -66,6 +67,7 @@ type Service struct {
 	extractor       content.Extractor
 	metrics         *metrics.Metrics
 	cfg             *config.Config
+	vectorClient    *qdrant.Client
 
 	serviceAccountID     string
 	serviceAccountSecret string
@@ -89,6 +91,21 @@ func NewService(gatewaySelector pool.Selectable[gateway.GatewayAPIClient], eng E
 		serviceAccountSecret: cfg.ServiceAccount.ServiceAccountSecret,
 
 		batchSize: cfg.BatchSize,
+	}
+
+	// Initialize Qdrant vector store if enabled
+	if cfg.Vector.Enabled && cfg.Vector.URL != "" {
+		s.vectorClient = qdrant.New(cfg.Vector.URL, cfg.Vector.Collection, logger)
+		// Auto-create collection (768 dims = nomic-embed default)
+		if err := s.vectorClient.EnsureCollection(768); err != nil {
+			logger.Warn().Err(err).Msg("qdrant: collection init failed, vector search disabled")
+			s.vectorClient = nil
+		} else {
+			logger.Info().
+				Str("url", cfg.Vector.URL).
+				Str("collection", cfg.Vector.Collection).
+				Msg("vector search enabled (qdrant)")
+		}
 	}
 
 	return s
@@ -668,6 +685,52 @@ func (s *Service) doUpsertItem(ref *provider.Reference, batch BatchOperator) {
 		s.logger.Error().Err(err).Msg("error adding updating the resource in the index")
 	} else {
 		logDocCount(s.engine, s.logger)
+	}
+
+	// Taki v2: log + store embedding in Qdrant
+	if doc.Taki != nil {
+		s.logger.Info().
+			Str("name", doc.Name).
+			Str("method", doc.Taki.Method).
+			Int("content_len", len(doc.Content)).
+			Int("embedding_dims", len(doc.Taki.Embed)).
+			Int("entities", len(doc.Taki.Entities)).
+			Str("summary", doc.Taki.Summary).
+			Msg("taki v2 extraction complete")
+
+		// Store embedding in Qdrant if enabled and embedding present
+		if s.vectorClient != nil && len(doc.Taki.Embed) > 0 {
+			payload := map[string]interface{}{
+				"name":        doc.Name,
+				"title":       doc.Title,
+				"mime":        doc.MimeType,
+				"method":      doc.Taki.Method,
+				"path":        r.Path,
+				"root_id":     r.RootID,
+				"resource_id": r.ID,
+			}
+			if doc.Taki.Summary != "" {
+				payload["summary"] = doc.Taki.Summary
+			}
+			if len(doc.Taki.Entities) > 0 {
+				payload["entities"] = doc.Taki.Entities
+			}
+			if len(doc.Content) > 2000 {
+				payload["content_preview"] = doc.Content[:2000]
+			} else if doc.Content != "" {
+				payload["content_preview"] = doc.Content
+			}
+
+			point := qdrant.Point{
+				ID:      stat.Info.Id.OpaqueId, // pure UUID, stable across moves
+				Vector:  doc.Taki.Embed,
+				Payload: payload,
+			}
+
+			if err := s.vectorClient.Upsert([]qdrant.Point{point}); err != nil {
+				s.logger.Warn().Err(err).Str("name", doc.Name).Msg("qdrant upsert failed")
+			}
+		}
 	}
 
 	// determine if metadata needs to be stored in storage as well

--- a/services/search/pkg/search/service.go
+++ b/services/search/pkg/search/service.go
@@ -33,6 +33,7 @@ import (
 	"github.com/opencloud-eu/opencloud/services/search/pkg/content"
 	"github.com/opencloud-eu/opencloud/services/search/pkg/metrics"
 	"github.com/opencloud-eu/opencloud/services/search/pkg/qdrant"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 const (
@@ -299,6 +300,24 @@ func (s *Service) Search(ctx context.Context, req *searchsvc.SearchRequest) (*se
 		}
 	}
 
+	// Qdrant semantic search: only for freetext queries (no field prefixes)
+	if s.vectorClient != nil && isFreetext(req.Query) {
+		vectorMatches := s.searchVector(ctx, req, gatewayClient, spaces, mountpointMap)
+		if len(vectorMatches) > 0 {
+			// Merge: add vector results that aren't already in keyword results
+			existingIDs := map[string]bool{}
+			for _, m := range matches {
+				existingIDs[m.Entity.Id.OpaqueId] = true
+			}
+			for _, vm := range vectorMatches {
+				if !existingIDs[vm.Entity.Id.OpaqueId] {
+					matches = append(matches, vm)
+					total++
+				}
+			}
+		}
+	}
+
 	// compile one sorted list of matches from all spaces and apply the limit if needed
 	sort.Sort(matches)
 	limit := req.PageSize
@@ -314,6 +333,101 @@ func (s *Service) Search(ctx context.Context, req *searchsvc.SearchRequest) (*se
 		Matches:      matches,
 		TotalMatches: total,
 	}, nil
+}
+
+// isFreetext returns true if the query is plain text without field prefixes.
+func isFreetext(query string) bool {
+	// Structured queries contain field:value patterns
+	for _, prefix := range []string{"name:", "tag:", "mtime", "mediatype:", "Type:", "id:", "RootID:", "Path:", "Favorites:"} {
+		if strings.Contains(query, prefix) {
+			return false
+		}
+	}
+	return true
+}
+
+// searchVector performs semantic search via Qdrant and returns matching resources.
+func (s *Service) searchVector(ctx context.Context, req *searchsvc.SearchRequest, gatewayClient gateway.GatewayAPIClient, spaces []*provider.StorageSpace, mountpointMap map[string]string) []*searchmsg.Match {
+	// Get embedding for query from open_taki
+	embedding := s.getQueryEmbedding(req.Query)
+	if embedding == nil {
+		return nil
+	}
+
+	results, err := s.vectorClient.Search(embedding, 20)
+	if err != nil {
+		s.logger.Warn().Err(err).Msg("qdrant search failed")
+		return nil
+	}
+
+	// Convert Qdrant results to search matches
+	var matches []*searchmsg.Match
+	for _, result := range results {
+		if result.Score < 0.3 { // minimum relevance threshold
+			continue
+		}
+
+		resourceID, err := storagespace.ParseID(result.ID)
+		if err != nil {
+			continue
+		}
+
+		// Stat the resource to get current info
+		statRes, err := gatewayClient.Stat(ctx, &provider.StatRequest{
+			Ref: &provider.Reference{ResourceId: &resourceID},
+		})
+		if err != nil || statRes.Status.Code != rpc.Code_CODE_OK {
+			continue
+		}
+
+		ri := statRes.Info
+		match := &searchmsg.Match{
+			Score: float32(result.Score),
+			Entity: &searchmsg.Entity{
+				Ref: &searchmsg.Reference{
+					ResourceId: &searchmsg.ResourceID{
+						StorageId: ri.Id.StorageId,
+						SpaceId:   ri.Id.SpaceId,
+						OpaqueId:  ri.Id.OpaqueId,
+					},
+				},
+				Id: &searchmsg.ResourceID{
+					StorageId: ri.Id.StorageId,
+					SpaceId:   ri.Id.SpaceId,
+					OpaqueId:  ri.Id.OpaqueId,
+				},
+				Name:     ri.Name,
+				Size:     ri.Size,
+				MimeType: ri.MimeType,
+			},
+		}
+
+		if ri.Mtime != nil {
+			match.Entity.LastModifiedTime = &timestamppb.Timestamp{
+				Seconds: int64(ri.Mtime.Seconds),
+				Nanos:   int32(ri.Mtime.Nanos),
+			}
+		}
+
+		matches = append(matches, match)
+	}
+
+	s.logger.Debug().
+		Str("query", req.Query).
+		Int("qdrant_hits", len(results)).
+		Int("valid_matches", len(matches)).
+		Msg("vector search completed")
+
+	return matches
+}
+
+// getQueryEmbedding gets an embedding for the search query via the taki extractor.
+func (s *Service) getQueryEmbedding(query string) []float64 {
+	tikaExtractor, ok := s.extractor.(*content.Tika)
+	if !ok || !tikaExtractor.IsTaki() {
+		return nil
+	}
+	return tikaExtractor.GetEmbedding(query)
 }
 
 func (s *Service) searchIndex(ctx context.Context, req *searchsvc.SearchRequest, space *provider.StorageSpace, mountpointID string) (*searchsvc.SearchIndexResponse, error) {
@@ -721,6 +835,7 @@ func (s *Service) doUpsertItem(ref *provider.Reference, batch BatchOperator) {
 				payload["content_preview"] = doc.Content
 			}
 
+			payload["resource_id"] = r.ID // full OpenCloud ID (storageId$spaceId!opaqueId)
 			point := qdrant.Point{
 				ID:      stat.Info.Id.OpaqueId, // pure UUID, stable across moves
 				Vector:  doc.Taki.Embed,


### PR DESCRIPTION
## Summary

Optional Qdrant integration for semantic (vector) search alongside the existing keyword index (Bleve/OpenSearch). When enabled, document embeddings from open_taki v2 are stored in Qdrant and freetext queries automatically search both backends.

Depends on PR #3036 (open_taki v2 protocol support).

## How it works

- **Indexing**: open_taki v2 returns embeddings per document → stored in Qdrant with metadata (name, path, summary, entities)
- **Searching**: freetext queries → Bleve (keyword) + Qdrant (semantic), results merged and deduplicated
- **Structured queries** (`name:`, `tag:`, `mtime:`): Bleve only — no vector overhead
- **Point IDs**: OpaqueId (native UUID), stable across file moves within a space

## Config

```
SEARCH_VECTOR_ENABLED=true
SEARCH_VECTOR_URL=http://qdrant:6333
SEARCH_VECTOR_COLLECTION=opencloud
```

Or YAML:
```yaml
vector:
  enabled: true
  url: "http://qdrant:6333"
  collection: "opencloud"
```

## Changes

- **`qdrant/client.go`** — Lightweight REST client (upsert, search, auto-create collection)
- **`config/content.go`** — VectorStore config (enabled, url, collection)
- **`config/config.go`** — Vector field in main config
- **`config/defaults/defaultconfig.go`** — Defaults (disabled, localhost:6333, "opencloud")
- **`content/tika.go`** — GetEmbedding() for query-time embedding via open_taki
- **`search/service.go`** — Qdrant ingest in doUpsertItem + semantic search merge in Search()

## Backward compatible

- Disabled by default (SEARCH_VECTOR_ENABLED=false)
- No impact when Qdrant unavailable (graceful fallback with warning)
- Works without open_taki (no embeddings = no vector ingest)

## Tested

Deployed on cloud.brandis.eu: 34+ documents in Qdrant, 0 upsert errors.