### PR TITLE
fix(search): use MustNot query for Deleted filter in bleve

### DIFF
--- a/services/search/pkg/bleve/backend.go
+++ b/services/search/pkg/bleve/backend.go
@@ -51,12 +51,18 @@ func (b *Backend) Search(_ context.Context, sir *searchService.SearchIndexReques
 		return nil, err
 	}
 
+	// Exclude documents that have been explicitly marked as deleted.
+	// We use a negation (MustNot) rather than matching Deleted==false,
+	// because bleve does not index zero-value bools, so documents where
+	// Deleted was never explicitly set would be excluded from results.
+	deletedQuery := bleve.NewBooleanQuery()
+	deletedQuery.AddMustNot(&query.BoolFieldQuery{
+		Bool:     true,
+		FieldVal: "Deleted",
+	})
+
 	q := bleve.NewConjunctionQuery(
-		// Skip documents that have been marked as deleted
-		&query.BoolFieldQuery{
-			Bool:     false,
-			FieldVal: "Deleted",
-		},
+		deletedQuery,
 		createdQuery,
 	)
 


### PR DESCRIPTION
## Summary

The search service uses a `BoolFieldQuery{Bool: false, Field: "Deleted"}` to exclude trashed documents from results. However, bleve does not index zero-value bools by default. This means documents where `Deleted` was never explicitly set (i.e., all non-trashed documents) lack this field in the index and are excluded from every query.

**Impact:** After an index rebuild or on fresh installations, search returns 0 results for all queries.

## Root cause

When a `Resource` is indexed with `Deleted: false` (Go zero value), bleve's default mapping does not store the bool field. The existing `BoolFieldQuery{Bool: false}` then finds no matching documents, causing the conjunction query to return empty results.

## Fix

Replace `BoolFieldQuery{Bool: false}` with a `BooleanQuery.MustNot(BoolFieldQuery{Bool: true})`. This correctly:
- Includes documents where `Deleted` is absent (never set)
- Includes documents where `Deleted` is explicitly `false`
- Excludes only documents where `Deleted` is explicitly `true`

## Test plan

- [x] Reproduced: deleted bleve index, rebuilt from scratch, confirmed 0 search results
- [x] Applied fix, confirmed search returns results after rebuild
- [x] Verified trashed documents are still excluded (MustNot semantics)

## Changes

`services/search/pkg/bleve/backend.go`: 1 file, +11/-5