### PR TITLE
test(apiSpaces): a space admin can delete a space with no manager

### DIFF
--- a/tests/acceptance/features/apiSpaces/disableEnableDeleteSpaces.feature
+++ b/tests/acceptance/features/apiSpaces/disableEnableDeleteSpaces.feature
@@ -248,3 +248,27 @@ Feature: Disabling, restoring and deleting space
       | user-role  |
       | User       |
       | User Light |
+
+  @issue-1878
+  Scenario: a space admin can list and delete a project space whose manager was deleted
+    Given the administrator has assigned the role "Space Admin" to user "Brian" using the Graph API
+    When the administrator deletes user "Alice" using the provisioning API
+    Then the HTTP status code should be "204"
+    When user "Brian" lists all spaces via the Graph API with query "$filter=driveType eq 'project'"
+    Then the HTTP status code should be "200"
+    And the JSON response should contain space called "Project Moon" and match
+      """
+      {
+        "type": "object",
+        "required": ["name", "id", "driveType"],
+        "properties": {
+          "name": { "type": "string", "enum": ["Project Moon"] },
+          "driveType": { "type": "string", "enum": ["project"] }
+        }
+      }
+      """
+    When user "Brian" disables a space "Project Moon" owned by user "Alice"
+    Then the HTTP status code should be "204"
+    When user "Brian" deletes a space "Project Moon" owned by user "Alice"
+    Then the HTTP status code should be "204"
+    And the user "Brian" should not have a space called "Project Moon"


### PR DESCRIPTION
## Description

Adds one acceptance scenario to `apiSpaces/disableEnableDeleteSpaces.feature`. After the only manager of a project space is deleted, a space admin must still be able to list the space and delete it (disable, then purge).

All steps reuse existing step definitions. The change adds no step code.

## Related Issue

- Part of https://github.com/opencloud-eu/opencloud/issues/1878

## Motivation and Context

#1877 reordered the api-test teardown to delete spaces before users. As a result, the suite no longer exercises the state where a project space's manager has been deleted, even incidentally, and no explicit scenario covers it.

Deleting a user who manages a project space is a normal operation. It happens on every user removal, including out-of-band removal via an external IdP. The space must stay manageable by a space admin afterwards. This scenario pins that behavior so a later change cannot regress it.

> [!NOTE]
> The scenario exercises the read path for a space whose manager is gone. On a server without the reva read-path fixes, that path logs `could not read node` and `error while indexing a space` (the subject of #1878, addressed by opencloud-eu/reva#710 and opencloud-eu/reva#713). The scenario is green regardless: the space stays listable and deletable. The log noise is a server-side concern, not an API status.

## How Has This Been Tested?

behat acceptance, run against a stock `opencloud-rolling:7.2.0` container on both storage drivers:

- posix: 14/14 steps pass
- decomposed: 14/14 steps pass

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:

- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised:

<sub>🤖 drafted with Claude Code, reviewed before submitting.</sub>
