### PR TITLE
[full-ci] chore: bump web to v7.1.3

### DIFF
--- a/.woodpecker.env
+++ b/.woodpecker.env
@@ -1,4 +1,4 @@
 # The test runner source for UI tests
-WEB_COMMITID=096ba683b62ab19ee7ff5dabe1225506ef50713c
+WEB_COMMITID=64d2c423e298b227c13d63285e1c0cabb6b81d78
 WEB_BRANCH=stable-7.1
 

--- a/services/web/Makefile
+++ b/services/web/Makefile
@@ -1,6 +1,6 @@
 SHELL := bash
 NAME := web
-WEB_ASSETS_VERSION = v7.1.2
+WEB_ASSETS_VERSION = v7.1.3
 WEB_ASSETS_BRANCH = stable-7.1
 
 ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI


### PR DESCRIPTION
### 🐛 Bug Fixes

- [stable-7.1] fix (tiptap): don't render html files via html strategy [[#2776](https://github.com/opencloud-eu/web/pull/2776)]
- fix: isolate module federation shared scope per app [[#2770](https://github.com/opencloud-eu/web/pull/2770)]
