### PR TITLE
fix(proxy): honor access token cache ttl

### DIFF
--- a/services/proxy/pkg/middleware/oidc_auth.go
+++ b/services/proxy/pkg/middleware/oidc_auth.go
@@ -34,6 +34,7 @@ func NewOIDCAuthenticator(opts ...Option) *OIDCAuthenticator {
 		userInfoCache:           options.UserInfoCache,
 		HTTPClient:              options.HTTPClient,
 		OIDCIss:                 options.OIDCIss,
+		DefaultTokenCacheTTL:    options.DefaultAccessTokenTTL,
 		oidcClient:              options.OIDCClient,
 		AccessTokenVerifyMethod: options.AccessTokenVerifyMethod,
 		skipUserInfo:            options.SkipUserInfo,

--- a/services/proxy/pkg/middleware/oidc_auth_test.go
+++ b/services/proxy/pkg/middleware/oidc_auth_test.go
@@ -53,6 +53,14 @@ var _ = Describe("Authenticating requests", Label("OIDCAuthenticator"), func() {
 		}
 	})
 
+	It("should apply the default access token ttl option", func() {
+		ttl := 5 * time.Minute
+
+		authenticator := NewOIDCAuthenticator(DefaultAccessTokenTTL(ttl))
+
+		Expect(authenticator.DefaultTokenCacheTTL).To(Equal(ttl))
+	})
+
 	When("the request contains correct data", func() {
 		It("should successfully authenticate", func() {
 			req := httptest.NewRequest(http.MethodGet, "http://example.com/example/path", http.NoBody)


### PR DESCRIPTION
## Description

Pass the configured fallback access token TTL into the OIDC authenticator.

When the proxy cannot derive an expiration from the access token, for example with opaque tokens and `PROXY_OIDC_ACCESS_TOKEN_VERIFY_METHOD=none`, it should use `PROXY_OIDC_USERINFO_CACHE_TTL` for userinfo cache entries. The option was parsed and passed into the middleware setup, but not copied onto the authenticator, causing cache entries to expire immediately.

This change makes the implementation match the documented fallback behavior.

## Related Issue
- Fixes #3050

## Motivation and Context
I maintain Pocket ID and ran into this while setting up OpenCloud on my own server. Desktop sync stalled because OpenCloud repeatedly called Pocket ID’s `userinfo` endpoint until Pocket ID started rate limiting those requests.

The setup uses opaque access tokens with `PROXY_OIDC_ACCESS_TOKEN_VERIFY_METHOD=none`, so OpenCloud cannot derive an expiration from the access token and should fall back to `PROXY_OIDC_USERINFO_CACHE_TTL`. That fallback TTL was configured, but it was not applied by the OIDC authenticator, causing userinfo cache entries to expire immediately.

## How Has This Been Tested?
I have created a custom image with this change, deployed it on my server and I can confirm that the TTL is now correctly respected and Pocket ID doesn't get spammed anymore with `userinfo` requests.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added
