### PR TITLE
test(coreApiWebdavUploadTUS): assert etag and permissions on the finalizing TUS chunk

### DIFF
--- a/tests/acceptance/features/coreApiWebdavUploadTUS/lowLevelUpload.feature
+++ b/tests/acceptance/features/coreApiWebdavUploadTUS/lowLevelUpload.feature
@@ -90,3 +90,23 @@ Feature: low level tests for upload of chunks
       | old              |
       | new              |
       | spaces           |
+
+  @issue-2409
+  Scenario Outline: finalize a chunked upload and get the etag and permissions
+    Given using <dav-path-version> DAV path
+    And user "Alice" has created a new TUS resource on the WebDAV API with these headers:
+      | Upload-Length   | 10                    |
+      #    ZmlsZS50eHQ= is the base64 encode of file.txt
+      | Upload-Metadata | filename ZmlsZS50eHQ= |
+    When user "Alice" sends a chunk to the last created TUS Location with offset "0" and data "123" using the WebDAV API
+    And user "Alice" sends a chunk to the last created TUS Location with offset "3" and data "4567890" using the WebDAV API
+    Then the HTTP status code should be "204"
+    And the following headers should match these regular expressions
+      | OC-ETag | /^"[^"]*"$/   |
+      | ETag    | /^"[^"]*"$/   |
+      | OC-Perm | /^[A-Za-z]+$/ |
+    Examples:
+      | dav-path-version |
+      | old              |
+      | new              |
+      | spaces           |

--- a/tests/acceptance/features/coreApiWebdavUploadTUS/lowLevelUpload.feature
+++ b/tests/acceptance/features/coreApiWebdavUploadTUS/lowLevelUpload.feature
@@ -101,10 +101,12 @@ Feature: low level tests for upload of chunks
     When user "Alice" sends a chunk to the last created TUS Location with offset "0" and data "123" using the WebDAV API
     And user "Alice" sends a chunk to the last created TUS Location with offset "3" and data "4567890" using the WebDAV API
     Then the HTTP status code should be "204"
+    And the following headers should be set
+      | header  | value   |
+      | OC-Perm | RDNVWZP |
     And the following headers should match these regular expressions
-      | OC-ETag | /^"[^"]*"$/   |
-      | ETag    | /^"[^"]*"$/   |
-      | OC-Perm | /^[A-Za-z]+$/ |
+      | OC-ETag | /^"[a-f0-9:.]{1,32}"$/ |
+      | ETag    | /^"[a-f0-9:.]{1,32}"$/ |
     Examples:
       | dav-path-version |
       | old              |


### PR DESCRIPTION
> [!WARNING]
> This scenario asserts headers that only a reva carrying the following change returns on the chunked TUS finalize:
>
> - https://github.com/opencloud-eu/reva/pull/718
>
> This repo's reva pin (`v2.46.4-0.20260625152426-8cff2a7032ec`, 2026-06-25) predates that merge, so the scenario is red until the pin is bumped past it. It goes green with the bump; no code change here.

## Description

Adds one scenario to `tests/acceptance/features/coreApiWebdavUploadTUS/lowLevelUpload.feature`: after a chunked TUS upload's finalizing PATCH, the response carries `OC-ETag`, `ETag` and `OC-Perm`, so a client does not need a follow-up PROPFIND for the new etag and permissions.

Reuses existing step definitions only (TUS create + `sends a chunk` + `the following headers should match these regular expressions`); the etag is a dynamic quoted hash, hence the regex assertion.

## Related Issue

Locks the behaviour from #2409 (closed) in the acceptance suite. The fix itself is in reva:

- https://github.com/opencloud-eu/reva/pull/718

## Motivation and Context

The chunked finalize returning the etag was covered only by a reva unit test. This pins it at the product boundary so a later regression fails the suite, and states the intended behaviour as an executable spec rather than an implicit claim.

## How Has This Been Tested?

Locally, one feature against a running server, on two builds:

- **stock `opencloud-rolling:7.1` (before the reva change):** create, chunks and `204` pass; the three header rows fail because the headers are absent.
- **opencloud built on a reva carrying the change:** the whole `lowLevelUpload.feature` passes on posix and decomposed, the new scenario on old/new/spaces.

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:

- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation added (n/a: tests-only, no changelog fragment)

<sub>🤖 drafted with Claude Code, reviewed before submitting.</sub>
