### PR TITLE
test(coreApiWebdavOperations): download a file with a literal "%" via its oc:downloadURL

### DIFF
--- a/tests/acceptance/bootstrap/WebDavPropertiesContext.php
+++ b/tests/acceptance/bootstrap/WebDavPropertiesContext.php
@@ -141,6 +141,27 @@ class WebDavPropertiesContext implements Context {
 	}
 
 	/**
+	 * @param string $user
+	 * @param string $path
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	#[When('/^user "([^"]*)" downloads the "([^"]*)" file via its oc:downloadURL$/')]
+	public function userDownloadsFileViaItsDownloadUrl(string $user, string $path): void {
+		$propertiesTable = new TableNode([["propertyName"], ["oc:downloadURL"]]);
+		$propfindResponse = $this->getPropertiesOfFolder($user, $path, null, $propertiesTable);
+		$downloadUrl = (string)$this->checkResponseContainsProperty($propfindResponse, "oc:downloadURL");
+		// GET the server-built URL as-is, the way the web client does: the signature
+		// in the URL authenticates the request, so no credentials are sent.
+		$response = HttpRequestHelper::get(
+			$downloadUrl,
+			$this->featureContext->getStepLineRef()
+		);
+		$this->featureContext->setResponse($response);
+	}
+
+	/**
 	 *
 	 * @param string $username
 	 * @param string $path

--- a/tests/acceptance/features/coreApiWebdavOperations/downloadFile.feature
+++ b/tests/acceptance/features/coreApiWebdavOperations/downloadFile.feature
@@ -316,3 +316,16 @@ Feature: download file
       | spaces           | "C++ file.cpp"   |
       | spaces           | "file #2.txt"    |
       | spaces           | "file ?2.pdf"    |
+
+  @issue-2852
+  Scenario Outline: download a file whose name contains a literal "%" via its oc:downloadURL
+    Given using <dav-path-version> DAV path
+    And user "Alice" has uploaded file with content "test file" to "firstword%20secondword.txt"
+    When user "Alice" downloads the "firstword%20secondword.txt" file via its oc:downloadURL
+    Then the HTTP status code should be "200"
+    And the downloaded content should be "test file"
+    Examples:
+      | dav-path-version |
+      | old              |
+      | new              |
+      | spaces           |


### PR DESCRIPTION
## Description

Adds one scenario to `tests/acceptance/features/coreApiWebdavOperations/downloadFile.feature`: a file whose name contains a literal `%` downloads via its `oc:downloadURL`, returning `200` and the content.

It mirrors the web client's download flow: read the server-built `oc:downloadURL` from a PROPFIND and GET it as-is (the signature in the URL authenticates the request, so no credentials are sent). A plain WebDAV `downloads file` step would not cover this, because it builds and encodes the request path itself, whereas the bug is in the server-generated `oc:downloadURL`.

One new step-def in `WebDavPropertiesContext`, `user "X" downloads the "P" file via its oc:downloadURL`, reuses the existing PROPFIND helper and `HttpRequestHelper::get`. It uses a regex annotation because the `:` in `oc:downloadURL` collides with the turnip `:placeholder` syntax.

## Related Issue

Locks the behaviour from #2852 (closed) in the acceptance suite. The fix itself is in reva:

- https://github.com/opencloud-eu/reva/pull/653

## Motivation and Context

A name with a literal `%` (for example `firstword%20secondword.txt`) 404'd on download because the `oc:downloadURL` did not percent-encode the path, so a URL parser collapsed the `%20` back to a space. The reva fix corrected it; this pins the round-trip at the product boundary so a regression fails the suite.

## How Has This Been Tested?

Locally, the feature against a running server, on two builds and both storages:

- **opencloud on the shipped reva (has the fix):** `downloadFile.feature` passes on posix and decomposed (81/81), the new scenario green on old/new/spaces.
- **opencloud built on a reva with the fix reverted:** only the new scenario fails, with the download returning `404` (the reporter's exact symptom), on posix.

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:

- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation added (n/a: tests-only, no changelog fragment)

<sub>🤖 drafted with Claude Code, reviewed before submitting.</sub>
