### PR TITLE
test(apiArchiver): the single-resource archive is named after the resource

### DIFF
--- a/tests/acceptance/features/apiArchiver/downloadById.feature
+++ b/tests/acceptance/features/apiArchiver/downloadById.feature
@@ -172,3 +172,18 @@ Feature: download multiple resources bundled into an archive
       | user-agent | archive-type |
       | Linux      | tar          |
       | Windows NT | zip          |
+
+
+  Scenario Outline: download a single folder into an archive named after it
+    Given user "Alice" has created folder "my_data"
+    And user "Alice" has uploaded file with content "some data" to "my_data/textfile0.txt"
+    When user "Alice" downloads the <archive-type> archive of "my_data" using the resource id and setting these headers:
+      | header     | value |
+      | User-Agent | Linux |
+    Then the HTTP status code should be "200"
+    And the following headers should match these regular expressions
+      | Content-Disposition | /filename="my_data\.<archive-type>"/ |
+    Examples:
+      | archive-type |
+      | zip          |
+      | tar          |


### PR DESCRIPTION
## Description

Adds one scenario to `tests/acceptance/features/apiArchiver/downloadById.feature`: the archive of a single folder carries a `Content-Disposition` filename of the folder (for example `my_data.zip`), not the constant `download.zip`.

It reuses existing steps only: the archiver download step (which stores the response) and the generic `the following headers should match these regular expressions` assertion. No new step-def.

## Related Issue

Enhancement tracked in reva:

- https://github.com/opencloud-eu/reva/issues/308

The fix is reva:

- https://github.com/opencloud-eu/reva/pull/661

## Motivation and Context

A single-folder archive download was always named `download.zip`/`download.tar` until the handler resolved the resource name for the `Content-Disposition` header. The existing `apiArchiver` scenarios assert only the archive contents, never the filename, so this pins the naming at the product boundary.

## How Has This Been Tested?

Locally, the feature against a running server, on two builds and both storages:

- **opencloud on the shipped reva (has the change):** `downloadById.feature` passes on posix and decomposed (11/11), the new scenario green on zip and tar.
- **opencloud built on a reva with the change reverted:** only the new scenario fails, the archive coming back as `download.zip`, on posix.

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:

- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation added (n/a: tests-only, no changelog fragment)

<sub>🤖 drafted with Claude Code, reviewed before submitting.</sub>
