### PR TITLE
[full-ci] gherkin steps refactoring. cleaning code

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "alexkrechik.cucumberautocomplete"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,16 @@
+{
+  "cucumberautocomplete.steps": [
+    "tests/acceptance/bootstrap/*.php"
+  ],
+  "cucumberautocomplete.syncfeatures": "tests/acceptance/features/**/*.feature",
+  "cucumberautocomplete.strictGherkinCompletion": false,
+  "cucumberautocomplete.strictGherkinValidation": false,
+  "cucumberautocomplete.customParameters": [
+    { "parameter": ":string", "value": "\"([^\"]*)\"" },
+    { "parameter": "'/\\^(.*)\\$/'", "value": "'^$1$$'", "isRegex": true, "flags": "g" },
+    { "parameter": "\\$\\w+", "value": "(.*)", "isRegex": true, "flags": "g" },
+    { "parameter": "(?<!\\?):[a-zA-Z_][a-zA-Z0-9_]*", "value": "\"([^\"]*)\"", "isRegex": true, "flags": "g" }
+  ],
+  "cucumberautocomplete.gherkinDefinitionPart": "(Given|When|Then|But)\\(",
+  "cucumberautocomplete.pureTextSteps": false
+}

--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,7 @@ help:
 	@echo -e "${GREEN}Tools for linting gherkin feature files:\n${RESET}"
 	@echo -e "\tmake test-gherkin-lint\t\t${BLUE}run lint checks on Gherkin feature files${RESET}"
 	@echo -e "\tmake test-gherkin-lint-fix\t${BLUE}apply lint fixes to gherkin feature files${RESET}"
+	@echo -e "\tmake find-unused-steps\t\t${BLUE}list Behat step definitions unused by any .feature file${RESET}"
 	@echo
 
 .PHONY: clean-tests
@@ -227,6 +228,10 @@ test-gherkin-lint:
 .PHONY: test-gherkin-lint-fix
 test-gherkin-lint-fix:
 	gherlint --fix tests/acceptance/features -c tests/acceptance/config/.gherlintrc.json
+
+.PHONY: find-unused-steps
+find-unused-steps: vendor-bin/behat/vendor
+	tests/acceptance/scripts/find-unused-steps.sh
 
 .PHONY: bingo-update
 bingo-update: $(BINGO)

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -86,5 +86,6 @@
 			<property name="lineLimit" value="120" />
 			<property name="absoluteLineLimit" value="120" />
 		</properties>
+		<exclude-pattern>*/tests/acceptance/bootstrap/*</exclude-pattern>
 	</rule>
 </ruleset>

--- a/tests/acceptance/bootstrap/ArchiverContext.php
+++ b/tests/acceptance/bootstrap/ArchiverContext.php
@@ -29,6 +29,8 @@ use Psr\Http\Message\ResponseInterface;
 use splitbrain\PHPArchive\Tar;
 use splitbrain\PHPArchive\Zip;
 use splitbrain\PHPArchive\Archive;
+use Behat\Step\Then;
+use Behat\Step\When;
 
 require_once 'bootstrap.php';
 
@@ -133,7 +135,6 @@ class ArchiverContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" downloads the (zip|tar) archive of "([^"]*)" using the resource (id|ids|path|paths) and setting these headers:$/
 	 *
 	 * @param string $user
 	 * @param string $archiveType
@@ -146,6 +147,7 @@ class ArchiverContext implements Context {
 	 * @throws GuzzleException
 	 * @throws Exception
 	 */
+	#[When('/^user "([^"]*)" downloads the (zip|tar) archive of "([^"]*)" using the resource (id|ids|path|paths) and setting these headers:$/')]
 	public function userDownloadsTheZipOrTarArchiveOfResourceUsingResourceIdOrPathAndSettingTheseHeaders(
 		string $user,
 		string $archiveType,
@@ -167,7 +169,6 @@ class ArchiverContext implements Context {
 	}
 
 	/**
-	 * @When user :downloader downloads the archive of :item of user :owner using the resource :addressType
 	 *
 	 * @param string $downloader Who sends the request
 	 * @param string $resource
@@ -179,6 +180,7 @@ class ArchiverContext implements Context {
 	 * @throws GuzzleException
 	 * @throws Exception
 	 */
+	#[When('user :downloader downloads the archive of :item of user :owner using the resource :addressType')]
 	public function userDownloadsTheArchiveOfItemOfUser(
 		string $downloader,
 		string $resource,
@@ -224,7 +226,6 @@ class ArchiverContext implements Context {
 	}
 
 	/**
-	 * @When user :user downloads the archive of these items using the resource :addressType
 	 *
 	 * @param string $user
 	 * @param string $addressType ids|paths
@@ -234,6 +235,7 @@ class ArchiverContext implements Context {
 	 *
 	 * @throws GuzzleException|Exception
 	 */
+	#[When('user :user downloads the archive of these items using the resource :addressType')]
 	public function userDownloadsTheArchiveOfTheseItems(
 		string $user,
 		string $addressType,
@@ -257,7 +259,6 @@ class ArchiverContext implements Context {
 	}
 
 	/**
-	 * @Then the downloaded :type archive should contain these files:
 	 *
 	 * @param string $type
 	 * @param TableNode $expectedFiles
@@ -266,6 +267,7 @@ class ArchiverContext implements Context {
 	 *
 	 * @throws Exception
 	 */
+	#[Then('the downloaded :type archive should contain these files:')]
 	public function theDownloadedArchiveShouldContainTheseFiles(string $type, TableNode $expectedFiles): void {
 		$this->featureContext->verifyTableNodeColumns($expectedFiles, ['name', 'content']);
 		$contents = $this->featureContext->getResponse()->getBody()->getContents();

--- a/tests/acceptance/bootstrap/AuthAppContext.php
+++ b/tests/acceptance/bootstrap/AuthAppContext.php
@@ -22,6 +22,8 @@ use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use TestHelpers\BehatHelper;
 use TestHelpers\AuthAppHelper;
+use Behat\Step\Given;
+use Behat\Step\When;
 
 require_once 'bootstrap.php';
 
@@ -46,13 +48,13 @@ class AuthAppContext implements Context {
 	}
 
 	/**
-	 * @When user :user creates app token with expiration time :expiration using the auth-app API
 	 *
 	 * @param string $user
 	 * @param string $expiration
 	 *
 	 * @return void
 	 */
+	#[When('user :user creates app token with expiration time :expiration using the auth-app API')]
 	public function userCreatesAppTokenWithExpirationTimeUsingTheAuthAppApi(string $user, string $expiration): void {
 		$this->featureContext->setResponse(
 			AuthAppHelper::createAppAuthToken(
@@ -65,13 +67,13 @@ class AuthAppContext implements Context {
 	}
 
 	/**
-	 * @Given user :user has created app token with expiration time :expiration using the auth-app API
 	 *
 	 * @param string $user
 	 * @param string $expiration
 	 *
 	 * @return void
 	 */
+	#[Given('user :user has created app token with expiration time :expiration using the auth-app API')]
 	public function userHasCreatedAppTokenWithExpirationTime(string $user, string $expiration): void {
 		$response = AuthAppHelper::createAppAuthToken(
 			$this->featureContext->getBaseUrl(),
@@ -83,12 +85,12 @@ class AuthAppContext implements Context {
 	}
 
 	/**
-	 * @When user :user lists all created tokens using the auth-app API
 	 *
 	 * @param string $user
 	 *
 	 * @return void
 	 */
+	#[When('user :user lists all created tokens using the auth-app API')]
 	public function userListsAllCreatedTokensUsingTheAuthAppApi(string $user): void {
 		$this->featureContext->setResponse(
 			AuthAppHelper::listAllAppAuthTokensForUser(
@@ -100,13 +102,13 @@ class AuthAppContext implements Context {
 	}
 
 	/**
-	 * @Given the administrator has created app token for user :impersonatedUser with expiration time :expiration using the auth-app API
 	 *
 	 * @param string $impersonatedUser
 	 * @param string $expiration
 	 *
 	 * @return void
 	 */
+	#[Given('the administrator has created app token for user :impersonatedUser with expiration time :expiration using the auth-app API')]
 	public function theAdministratorHasCreatedAppTokenWithExpirationTimeImpersonatingUserUsingTheAuthAppApi(
 		string $impersonatedUser,
 		string $expiration,
@@ -129,13 +131,13 @@ class AuthAppContext implements Context {
 	}
 
 	/**
-	 * @When the administrator creates app token for user :impersonatedUser with expiration time :expiration using the auth-app API
 	 *
 	 * @param string $impersonatedUser
 	 * @param string $expiration
 	 *
 	 * @return void
 	 */
+	#[When('the administrator creates app token for user :impersonatedUser with expiration time :expiration using the auth-app API')]
 	public function theAdministratorCreatesAppTokenForUserWithExpirationTimeViaAuthAppApi(
 		string $impersonatedUser,
 		string $expiration,

--- a/tests/acceptance/bootstrap/AuthContext.php
+++ b/tests/acceptance/bootstrap/AuthContext.php
@@ -27,6 +27,7 @@ use TestHelpers\HttpRequestHelper;
 use TestHelpers\BehatHelper;
 use TestHelpers\TokenHelper;
 use TestHelpers\WebDavHelper;
+use Behat\Step\When;
 
 /**
  * Authentication functions
@@ -135,19 +136,18 @@ class AuthContext implements Context {
 	}
 
 	/**
-	 * @When a user requests :url with :method and no authentication
 	 *
 	 * @param string $url
 	 * @param string $method
 	 *
 	 * @return void
 	 */
+	#[When('a user requests :url with :method and no authentication')]
 	public function userRequestsURLWithNoAuth(string $url, string $method): void {
 		$this->featureContext->setResponse($this->sendRequest($url, $method));
 	}
 
 	/**
-	 * @When a user requests these endpoints with :method with body :body and no authentication about user :user
 	 *
 	 * @param string $method
 	 * @param string $body
@@ -157,6 +157,7 @@ class AuthContext implements Context {
 	 * @return void
 	 * @throws JsonException
 	 */
+	#[When('a user requests these endpoints with :method with body :body and no authentication about user :user')]
 	public function userRequestsEndpointsWithBodyAndNoAuthThenStatusCodeAboutUser(
 		string $method,
 		string $body,
@@ -177,7 +178,6 @@ class AuthContext implements Context {
 	}
 
 	/**
-	 * @When a user requests these endpoints with :method with no authentication about user :user
 	 *
 	 * @param string $method
 	 * @param string $ofUser
@@ -186,6 +186,7 @@ class AuthContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('a user requests these endpoints with :method with no authentication about user :user')]
 	public function userRequestsEndpointsWithoutBodyAndNoAuthAboutUser(
 		string $method,
 		string $ofUser,
@@ -205,7 +206,6 @@ class AuthContext implements Context {
 	}
 
 	/**
-	 * @When a user requests these endpoints with :method and no authentication
 	 *
 	 * @param string $method
 	 * @param TableNode $table
@@ -213,6 +213,7 @@ class AuthContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('a user requests these endpoints with :method and no authentication')]
 	public function userRequestsEndpointsWithNoAuthentication(string $method, TableNode $table): void {
 		$this->featureContext->verifyTableNodeColumns($table, ['endpoint']);
 		foreach ($table->getHash() as $row) {
@@ -227,7 +228,6 @@ class AuthContext implements Context {
 	}
 
 	/**
-	 * @When a user requests these URLs with :method and no authentication
 	 *
 	 * @param $method
 	 * @param TableNode $table
@@ -235,6 +235,7 @@ class AuthContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('a user requests these URLs with :method and no authentication')]
 	public function aUserRequestsTheseUrlsWithAndNoAuthentication($method, TableNode $table): void {
 		$this->featureContext->verifyTableNodeColumns($table, ['endpoint'], ['service']);
 		foreach ($table->getHash() as $row) {
@@ -250,7 +251,6 @@ class AuthContext implements Context {
 	}
 
 	/**
-	 * @When the user :user requests these endpoints with :method with basic auth
 	 *
 	 * @param string $user
 	 * @param string $method
@@ -259,6 +259,7 @@ class AuthContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('the user :user requests these endpoints with :method with basic auth')]
 	public function userRequestsEndpointsWithBasicAuth(string $user, string $method, TableNode $table): void {
 		$this->featureContext->verifyTableNodeColumns($table, ['endpoint']);
 		foreach ($table->getHash() as $row) {
@@ -269,7 +270,6 @@ class AuthContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" requests these endpoints with "([^"]*)" to (?:get|set) property "([^"]*)" about user "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $method
@@ -280,6 +280,7 @@ class AuthContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('/^user "([^"]*)" requests these endpoints with "([^"]*)" to (?:get|set) property "([^"]*)" about user "([^"]*)"$/')]
 	public function theUserRequestsTheseEndpointsToGetOrSetPropertyAboutUser(
 		string $user,
 		string $method,
@@ -301,7 +302,6 @@ class AuthContext implements Context {
 	}
 
 	/**
-	 * @When the administrator requests these endpoints with :method
 	 *
 	 * @param string $method
 	 * @param TableNode $table
@@ -309,6 +309,7 @@ class AuthContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('the administrator requests these endpoints with :method')]
 	public function theAdminRequestsTheseEndpointsWithMethod(string $method, TableNode $table): void {
 		$this->featureContext->verifyTableNodeColumns($table, ['endpoint']);
 		foreach ($table->getHash() as $row) {
@@ -323,7 +324,6 @@ class AuthContext implements Context {
 	}
 
 	/**
-	 * @When user :user requests :url with :method using basic auth
 	 *
 	 * @param string $user
 	 * @param string $url
@@ -331,6 +331,7 @@ class AuthContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[When('user :user requests :url with :method using basic auth')]
 	public function userRequestsURLUsingBasicAuth(
 		string $user,
 		string $url,
@@ -341,7 +342,6 @@ class AuthContext implements Context {
 	}
 
 	/**
-	 * @When user :user requests :url with :method using basic auth and with headers
 	 *
 	 * @param string $user
 	 * @param string $url
@@ -351,6 +351,7 @@ class AuthContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('user :user requests :url with :method using basic auth and with headers')]
 	public function userRequestsURLWithUsingBasicAuthAndDepthHeader(
 		string $user,
 		string $url,
@@ -382,7 +383,6 @@ class AuthContext implements Context {
 	}
 
 	/**
-	 * @When user :user requests these endpoints with :method using password :password
 	 *
 	 * @param string $user
 	 * @param string $method
@@ -392,6 +392,7 @@ class AuthContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('user :user requests these endpoints with :method using password :password')]
 	public function userRequestsTheseEndpointsWithPassword(
 		string $user,
 		string $method,
@@ -411,7 +412,6 @@ class AuthContext implements Context {
 	}
 
 	/**
-	 * @When user :user requests these endpoints with :method using password :password about user :ofUser
 	 *
 	 * @param string $user
 	 * @param string $method
@@ -422,6 +422,7 @@ class AuthContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('user :user requests these endpoints with :method using password :password about user :ofUser')]
 	public function userRequestsTheseEndpointsUsingPasswordAboutUser(
 		string $user,
 		string $method,
@@ -460,7 +461,6 @@ class AuthContext implements Context {
 	}
 
 	/**
-	 * @When user :user requests these endpoints with :method including body :body using password :password about user :ofUser
 	 *
 	 * @param string $user
 	 * @param string $method
@@ -472,6 +472,7 @@ class AuthContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('user :user requests these endpoints with :method including body :body using password :password about user :ofUser')]
 	public function userRequestsTheseEndpointsWithBodyUsingPasswordAboutUser(
 		string $user,
 		string $method,
@@ -511,7 +512,6 @@ class AuthContext implements Context {
 	}
 
 	/**
-	 * @When user :user requests these endpoints with :method including body :body about user :ofUser
 	 *
 	 * @param string $user
 	 * @param string $method
@@ -522,6 +522,7 @@ class AuthContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('user :user requests these endpoints with :method including body :body about user :ofUser')]
 	public function userRequestsTheseEndpointsIncludingBodyAboutUser(
 		string $user,
 		string $method,
@@ -556,7 +557,6 @@ class AuthContext implements Context {
 	}
 
 	/**
-	 * @When user :asUser requests these endpoints with :method using the password of user :ofUser
 	 *
 	 * @param string $asUser
 	 * @param string $method
@@ -566,6 +566,7 @@ class AuthContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('user :asUser requests these endpoints with :method using the password of user :ofUser')]
 	public function userRequestsTheseEndpointsWithoutBodyUsingThePasswordOfUser(
 		string $asUser,
 		string $method,
@@ -596,7 +597,6 @@ class AuthContext implements Context {
 	}
 
 	/**
-	 * @When user :asUser requests these endpoints with :method including body :body using the password of user :user
 	 *
 	 * @param string $asUser
 	 * @param string $method
@@ -607,6 +607,7 @@ class AuthContext implements Context {
 	 * @return void
 	 * @throws JsonException
 	 */
+	#[When('user :asUser requests these endpoints with :method including body :body using the password of user :user')]
 	public function userRequestsTheseEndpointsIncludingBodyUsingPasswordOfUser(
 		string $asUser,
 		string $method,
@@ -638,7 +639,6 @@ class AuthContext implements Context {
 	}
 
 	/**
-	 * @When user :user requests these endpoints with :method about user :ofUser
 	 *
 	 * @param string $user
 	 * @param string $method
@@ -648,6 +648,7 @@ class AuthContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('user :user requests these endpoints with :method about user :ofUser')]
 	public function userRequestsTheseEndpointsAboutUser(
 		string $user,
 		string $method,
@@ -683,7 +684,6 @@ class AuthContext implements Context {
 	}
 
 	/**
-	 * @When user :user requests :endpoint with :method without retrying
 	 *
 	 * @param string $user
 	 * @param string $endpoint
@@ -691,6 +691,7 @@ class AuthContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[When('user :user requests :endpoint with :method without retrying')]
 	public function userRequestsURLWithoutRetry(
 		string $user,
 		string $endpoint,
@@ -717,13 +718,13 @@ class AuthContext implements Context {
 	}
 
 	/**
-	 * @When user :user should not be able to log in with wrong password :password
 	 *
 	 * @param string $user
 	 * @param string $password
 	 *
 	 * @return void
 	 */
+	#[When('user :user should not be able to log in with wrong password :password')]
 	public function userShouldNotBeAbleToLogInWithWrongPassword(
 		string $user,
 		string $password

--- a/tests/acceptance/bootstrap/CapabilitiesContext.php
+++ b/tests/acceptance/bootstrap/CapabilitiesContext.php
@@ -28,6 +28,8 @@ use PHPUnit\Framework\Assert;
 use TestHelpers\OcsApiHelper;
 use TestHelpers\BehatHelper;
 use TestHelpers\HttpRequestHelper;
+use Behat\Step\Then;
+use Behat\Step\When;
 
 require_once 'bootstrap.php';
 
@@ -133,7 +135,6 @@ class CapabilitiesContext implements Context {
 	}
 
 	/**
-	 * @When user :username retrieves the capabilities using the capabilities API
 	 *
 	 * @param string $username
 	 *
@@ -141,27 +142,28 @@ class CapabilitiesContext implements Context {
 	 * @throws GuzzleException
 	 * @throws JsonException
 	 */
+	#[When('user :username retrieves the capabilities using the capabilities API')]
 	public function userRetrievesCapabilities(string $username): void {
 		$user = $this->featureContext->getActualUsername($username);
 		$this->featureContext->setResponse($this->userGetsCapabilities($user, true));
 	}
 
 	/**
-	 * @When the administrator retrieves the capabilities using the capabilities API
 	 *
 	 * @return void
 	 */
+	#[When('the administrator retrieves the capabilities using the capabilities API')]
 	public function theAdministratorGetsCapabilities(): void {
 		$user = $this->getAdminUsernameForCapabilitiesCheck();
 		$this->featureContext->setResponse($this->userGetsCapabilities($user, true));
 	}
 
 	/**
-	 * @Then the major-minor-micro version data in the response should match the version string
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('the major-minor-micro version data in the response should match the version string')]
 	public function checkVersionMajorMinorMicroResponse(): void {
 		$jsonResponse = $this->featureContext->getJsonDecodedResponseBodyContent();
 		$versionData = $jsonResponse->ocs->data->version;
@@ -199,13 +201,13 @@ class CapabilitiesContext implements Context {
 	}
 
 	/**
-	 * @Then the status.php response should include
 	 *
 	 * @param PyStringNode $jsonExpected
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('the status.php response should include')]
 	public function statusPhpRespondedShouldMatch(PyStringNode $jsonExpected): void {
 		$jsonExpectedDecoded = \json_decode($jsonExpected->getRaw(), true);
 		$jsonRespondedDecoded = $this->featureContext->getJsonDecodedResponse();

--- a/tests/acceptance/bootstrap/ChecksumContext.php
+++ b/tests/acceptance/bootstrap/ChecksumContext.php
@@ -26,6 +26,9 @@ use Psr\Http\Message\ResponseInterface;
 use TestHelpers\WebDavHelper;
 use TestHelpers\BehatHelper;
 use TestHelpers\UploadHelper;
+use Behat\Step\Given;
+use Behat\Step\Then;
+use Behat\Step\When;
 
 require_once 'bootstrap.php';
 
@@ -62,7 +65,6 @@ class ChecksumContext implements Context {
 	}
 
 	/**
-	 * @When user :user uploads file :source to :destination with checksum :checksum using the WebDAV API
 	 *
 	 * @param string $user
 	 * @param string $source
@@ -71,6 +73,7 @@ class ChecksumContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[When('user :user uploads file :source to :destination with checksum :checksum using the WebDAV API')]
 	public function userUploadsFileToWithChecksumUsingTheAPI(
 		string $user,
 		string  $source,
@@ -83,7 +86,6 @@ class ChecksumContext implements Context {
 	}
 
 	/**
-	 * @Given user :user has uploaded file :source to :destination with checksum :checksum
 	 *
 	 * @param string $user
 	 * @param string $source
@@ -92,6 +94,7 @@ class ChecksumContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[Given('user :user has uploaded file :source to :destination with checksum :checksum')]
 	public function userHasUploadedFileToWithChecksumUsingTheAPI(
 		string $user,
 		string $source,
@@ -132,7 +135,6 @@ class ChecksumContext implements Context {
 	}
 
 	/**
-	 * @Given user :user has uploaded file with content :content and checksum :checksum to :destination
 	 *
 	 * @param string $user
 	 * @param string $content
@@ -141,6 +143,7 @@ class ChecksumContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[Given('user :user has uploaded file with content :content and checksum :checksum to :destination')]
 	public function userHasUploadedFileWithContentAndChecksumToUsingTheAPI(
 		string $user,
 		string $content,
@@ -153,13 +156,13 @@ class ChecksumContext implements Context {
 	}
 
 	/**
-	 * @When user :user requests the checksum of :path via propfind
 	 *
 	 * @param string $user
 	 * @param string $path
 	 *
 	 * @return void
 	 */
+	#[When('user :user requests the checksum of :path via propfind')]
 	public function userRequestsTheChecksumOfViaPropfind(string $user, string $path): void {
 		$this->featureContext->setResponse($this->propfindResourceChecksum($user, $path));
 	}
@@ -195,20 +198,19 @@ class ChecksumContext implements Context {
 	}
 
 	/**
-	 * @Then the webdav checksum should match :expectedChecksum
 	 *
 	 * @param string $expectedChecksum
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('the webdav checksum should match :expectedChecksum')]
 	public function theWebdavChecksumShouldMatch(string $expectedChecksum): void {
 		$bodyContents = $this->featureContext->getResponse()->getBody()->getContents();
 		$this->validateChecksum($bodyContents, $expectedChecksum);
 	}
 
 	/**
-	 * @Then as user :user the webdav checksum of :path via propfind should match :expectedChecksum
 	 *
 	 * @param string $user
 	 * @param string $path
@@ -217,6 +219,7 @@ class ChecksumContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('as user :user the webdav checksum of :path via propfind should match :expectedChecksum')]
 	public function asUserTheWebdavChecksumOfPathViaPropfindShouldMatch(
 		string $user,
 		string $path,
@@ -321,13 +324,13 @@ class ChecksumContext implements Context {
 	}
 
 	/**
-	 * @Then the header checksum should match :expectedChecksum
 	 *
 	 * @param string $expectedChecksum
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('the header checksum should match :expectedChecksum')]
 	public function theHeaderChecksumShouldMatch(string $expectedChecksum): void {
 		$headerChecksums
 			= $this->featureContext->getResponse()->getHeader('OC-Checksum');
@@ -359,7 +362,6 @@ class ChecksumContext implements Context {
 	}
 
 	/**
-	 * @Then the header checksum when user :arg1 downloads file :arg2 using the WebDAV API should match :arg3
 	 *
 	 * @param string $user
 	 * @param string $fileName
@@ -368,6 +370,7 @@ class ChecksumContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('the header checksum when user :arg1 downloads file :arg2 using the WebDAV API should match :arg3')]
 	public function theHeaderChecksumWhenUserDownloadsFileUsingTheWebdavApiShouldMatch(
 		string $user,
 		string $fileName,
@@ -433,7 +436,6 @@ class ChecksumContext implements Context {
 	}
 
 	/**
-	 * @When user :user uploads chunk file :num of :total with :data to :destination with checksum :expectedChecksum using the WebDAV API
 	 *
 	 * @param string $user
 	 * @param int $num
@@ -444,6 +446,7 @@ class ChecksumContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[When('user :user uploads chunk file :num of :total with :data to :destination with checksum :expectedChecksum using the WebDAV API')]
 	public function userUploadsChunkFileOfWithToWithChecksum(
 		string $user,
 		int $num,
@@ -464,7 +467,6 @@ class ChecksumContext implements Context {
 	}
 
 	/**
-	 * @Given user :user has uploaded chunk file :num of :total with :data to :destination with checksum :expectedChecksum
 	 *
 	 * @param string $user
 	 * @param int $num
@@ -475,6 +477,7 @@ class ChecksumContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[Given('user :user has uploaded chunk file :num of :total with :data to :destination with checksum :expectedChecksum')]
 	public function userHasUploadedChunkFileOfWithToWithChecksum(
 		string $user,
 		int $num,

--- a/tests/acceptance/bootstrap/CliContext.php
+++ b/tests/acceptance/bootstrap/CliContext.php
@@ -26,6 +26,9 @@ use TestHelpers\CliHelper;
 use TestHelpers\OcConfigHelper;
 use TestHelpers\BehatHelper;
 use Psr\Http\Message\ResponseInterface;
+use Behat\Step\Given;
+use Behat\Step\Then;
+use Behat\Step\When;
 
 /**
  * CLI context
@@ -120,27 +123,26 @@ class CliContext implements Context {
 	}
 
 	/**
-	 * @Given the administrator has stopped the server
 	 *
 	 * @return void
 	 */
+	#[Given('the administrator has stopped the server')]
 	public function theAdministratorHasStoppedTheServer(): void {
 		$response = OcConfigHelper::stopOpencloud();
 		$this->featureContext->theHTTPStatusCodeShouldBe(200, '', $response);
 	}
 
 	/**
-	 * @Given /^the administrator (?:starts|has started) the server$/
 	 *
 	 * @return void
 	 */
+	#[Given('/^the administrator (?:starts|has started) the server$/')]
 	public function theAdministratorHasStartedTheServer(): void {
 		$response = OcConfigHelper::startOpencloud();
 		$this->featureContext->theHTTPStatusCodeShouldBe(200, '', $response);
 	}
 
 	/**
-	 * @When /^the administrator resets the password of (non-existing|existing) user "([^"]*)" to "([^"]*)" using the CLI$/
 	 *
 	 * @param string $status
 	 * @param string $user
@@ -148,6 +150,7 @@ class CliContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[When('/^the administrator resets the password of (non-existing|existing) user "([^"]*)" to "([^"]*)" using the CLI$/')]
 	public function theAdministratorResetsThePasswordOfUserUsingTheCLI(
 		string $status,
 		string $user,
@@ -167,10 +170,10 @@ class CliContext implements Context {
 	}
 
 	/**
-	 * @When the administrator deletes the empty trashbin folders using the CLI
 	 *
 	 * @return void
 	 */
+	#[When('the administrator deletes the empty trashbin folders using the CLI')]
 	public function theAdministratorDeletesEmptyTrashbinFoldersUsingTheCli(): void {
 		$path = $this->featureContext->getStorageUsersRoot();
 		$command = "trash purge-empty-dirs -p $path --dry-run=false";
@@ -181,10 +184,10 @@ class CliContext implements Context {
 	}
 
 	/**
-	 * @When the administrator checks the backup consistency using the CLI
 	 *
 	 * @return void
 	 */
+	#[When('the administrator checks the backup consistency using the CLI')]
 	public function theAdministratorChecksTheBackupConsistencyUsingTheCli(): void {
 		$path = $this->featureContext->getStorageUsersRoot();
 		$command = "backup consistency -p $path";
@@ -195,13 +198,13 @@ class CliContext implements Context {
 	}
 
 	/**
-	 * @When the administrator creates app token for user :user with expiration time :expirationTime using the auth-app CLI
 	 *
 	 * @param string $user
 	 * @param string $expirationTime
 	 *
 	 * @return void
 	 */
+	#[When('the administrator creates app token for user :user with expiration time :expirationTime using the auth-app CLI')]
 	public function theAdministratorCreatesAppTokenForUserWithExpirationTimeUsingTheAuthAppCLI(
 		string $user,
 		string $expirationTime
@@ -215,13 +218,13 @@ class CliContext implements Context {
 	}
 
 	/**
-	 * @Given user :user has created app token with expiration time :expirationTime using the auth-app CLI
 	 *
 	 * @param string $user
 	 * @param string $expirationTime
 	 *
 	 * @return void
 	 */
+	#[Given('user :user has created app token with expiration time :expirationTime using the auth-app CLI')]
 	public function userHasCreatedAppTokenWithExpirationTimeUsingTheAuthAppCLI(
 		string $user,
 		string $expirationTime
@@ -244,10 +247,10 @@ class CliContext implements Context {
 	}
 
 	/**
-	 * @When the administrator removes all the file versions using the CLI
 	 *
 	 * @return void
 	 */
+	#[When('the administrator removes all the file versions using the CLI')]
 	public function theAdministratorRemovesAllVersionsOfResources() {
 		$path = $this->featureContext->getStorageUsersRoot();
 		$command = "revisions purge -p $path --dry-run=false";
@@ -258,7 +261,6 @@ class CliContext implements Context {
 	}
 
 	/**
-	 * @When the administrator removes the versions of file :file of user :user from space :space using the CLI
 	 *
 	 * @param string $file
 	 * @param string $user
@@ -266,6 +268,7 @@ class CliContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[When('the administrator removes the versions of file :file of user :user from space :space using the CLI')]
 	public function theAdministratorRemovesTheVersionsOfFileUsingFileId($file, $user, $space) {
 		$path = $this->featureContext->getStorageUsersRoot();
 		$fileId = $this->spacesContext->getFileId($user, $space, $file);
@@ -277,10 +280,10 @@ class CliContext implements Context {
 	}
 
 	/**
-	 * @When /^the administrator reindexes all spaces using the CLI$/
 	 *
 	 * @return void
 	 */
+	#[When('the administrator reindexes all spaces using the CLI')]
 	public function theAdministratorReindexesAllSpacesUsingTheCli(): void {
 		$endpoint = $this->featureContext->getBaseUrlHostName();
 		$command = "search index --all-spaces --endpoint $endpoint:9220 --insecure";
@@ -291,12 +294,12 @@ class CliContext implements Context {
 	}
 
 	/**
-	 * @When /^the administrator reindexes a space "([^"]*)" using the CLI$/
 	 *
 	 * @param string $spaceName
 	 *
 	 * @return void
 	 */
+	#[When('the administrator reindexes a space :spaceName using the CLI')]
 	public function theAdministratorReindexesASpaceUsingTheCli(string $spaceName): void {
 		$spaceId = $this->spacesContext->getSpaceIdByName($this->featureContext->getAdminUsername(), $spaceName);
 		$endpoint = $this->featureContext->getBaseUrlHostName();
@@ -308,12 +311,12 @@ class CliContext implements Context {
 	}
 
 	/**
-	 * @When the administrator removes the file versions of space :space using the CLI
 	 *
 	 * @param string $space
 	 *
 	 * @return void
 	 */
+	#[When('the administrator removes the file versions of space :space using the CLI')]
 	public function theAdministratorRemovesTheVersionsOfFilesInSpaceUsingSpaceId(string $space): void {
 		$path = $this->featureContext->getStorageUsersRoot();
 		$adminUsername = $this->featureContext->getAdminUsername();
@@ -326,10 +329,10 @@ class CliContext implements Context {
 	}
 
 	/**
-	 * @When the administrator purges the expired trash-bin items using the CLI
 	 *
 	 * @return void
 	 */
+	#[When('the administrator purges the expired trash-bin items using the CLI')]
 	public function theAdministratorPurgesExpiredTrashBinItemsUsingTheCli(): void {
 		$command = "storage-users trash-bin purge-expired";
 		$body = [
@@ -340,12 +343,12 @@ class CliContext implements Context {
 	}
 
 	/**
-	 * @When the administrator lists the trash-bin items of space :space using the CLI
 	 *
 	 * @param string $space
 	 *
 	 * @return void
 	 */
+	#[When('the administrator lists the trash-bin items of space :space using the CLI')]
 	public function theAdministratorListsTrashBinItemsOfSpaceUsingTheCli(string $space): void {
 		$adminUsername = $this->featureContext->getAdminUsername();
 		$spaceId = $this->spacesContext->getSpaceIdByName($adminUsername, $space);
@@ -357,12 +360,12 @@ class CliContext implements Context {
 	}
 
 	/**
-	 * @When the administrator lists the trash-bin items of the personal space of user :user using the CLI
 	 *
 	 * @param string $user
 	 *
 	 * @return void
 	 */
+	#[When('the administrator lists the trash-bin items of the personal space of user :user using the CLI')]
 	public function theAdministratorListsTrashBinItemsOfPersonalSpaceUsingTheCli(string $user): void {
 		$spaceId = $this->spacesContext->getSpaceIdByName($user, 'Personal');
 		$command = "storage-users trash-bin list $spaceId";
@@ -373,12 +376,12 @@ class CliContext implements Context {
 	}
 
 	/**
-	 * @When the administrator restores all the trash-bin items of space :space using the CLI
 	 *
 	 * @param string $space
 	 *
 	 * @return void
 	 */
+	#[When('the administrator restores all the trash-bin items of space :space using the CLI')]
 	public function theAdministratorRestoresAllTrashBinItemsOfSpaceUsingTheCli(string $space): void {
 		$adminUsername = $this->featureContext->getAdminUsername();
 		$spaceId = $this->spacesContext->getSpaceIdByName($adminUsername, $space);
@@ -390,12 +393,12 @@ class CliContext implements Context {
 	}
 
 	/**
-	 * @When the administrator restores all the trash-bin items of the personal space of user :user using the CLI
 	 *
 	 * @param string $user
 	 *
 	 * @return void
 	 */
+	#[When('the administrator restores all the trash-bin items of the personal space of user :user using the CLI')]
 	public function theAdministratorRestoresAllTrashBinItemsOfPersonalSpaceUsingTheCli(string $user): void {
 		$spaceId = $this->spacesContext->getSpaceIdByName($user, 'Personal');
 		$command = "storage-users trash-bin restore-all $spaceId --yes";
@@ -406,13 +409,13 @@ class CliContext implements Context {
 	}
 
 	/**
-	 * @When the administrator restores the trash-bin item with file-id :fileId of space :space using the CLI
 	 *
 	 * @param string $fileId
 	 * @param string $space
 	 *
 	 * @return void
 	 */
+	#[When('the administrator restores the trash-bin item with file-id :fileId of space :space using the CLI')]
 	public function theAdministratorRestoresTrashBinItemOfSpaceUsingTheCli(string $fileId, string $space): void {
 		$adminUsername = $this->featureContext->getAdminUsername();
 		$spaceId = $this->spacesContext->getSpaceIdByName($adminUsername, $space);
@@ -424,13 +427,13 @@ class CliContext implements Context {
 	}
 
 	/**
-	 * @When the administrator restores the trash-bin item with file-id :fileId of the personal space of user :user using the CLI
 	 *
 	 * @param string $fileId
 	 * @param string $user
 	 *
 	 * @return void
 	 */
+	#[When('the administrator restores the trash-bin item with file-id :fileId of the personal space of user :user using the CLI')]
 	public function theAdministratorRestoresTrashBinItemOfPersonalSpaceUsingTheCli(string $fileId, string $user): void {
 		$spaceId = $this->spacesContext->getSpaceIdByName($user, 'Personal');
 		$command = "storage-users trash-bin restore $spaceId $fileId";
@@ -441,10 +444,10 @@ class CliContext implements Context {
 	}
 
 	/**
-	 * @When the administrator cleans up orphaned shares using the CLI
 	 *
 	 * @return void
 	 */
+	#[When('the administrator cleans up orphaned shares using the CLI')]
 	public function theAdministratorCleansUpOrphanedSharesUsingTheCli(): void {
 		$serviceAccountId = getenv('OC_SERVICE_ACCOUNT_ID') ?: 'service-account-id';
 		$serviceAccountSecret = getenv('OC_SERVICE_ACCOUNT_SECRET') ?: 'service-account-secret';
@@ -457,10 +460,10 @@ class CliContext implements Context {
 	}
 
 	/**
-	 * @When the administrator lists the unified roles using the CLI
 	 *
 	 * @return void
 	 */
+	#[When('the administrator lists the unified roles using the CLI')]
 	public function theAdministratorListsTheUnifiedRolesUsingTheCli(): void {
 		$command = "graph list-unified-roles";
 		$body = [
@@ -470,10 +473,10 @@ class CliContext implements Context {
 	}
 
 	/**
-	 * @Then the command should be successful
 	 *
 	 * @return void
 	 */
+	#[Then('the command should be successful')]
 	public function theCommandShouldBeSuccessful(): void {
 		$response = $this->featureContext->getResponse();
 		$this->featureContext->theHTTPStatusCodeShouldBe(200, '', $response);
@@ -490,13 +493,13 @@ class CliContext implements Context {
 	}
 
 	/**
-	 * @Then /^the command output (should|should not) contain "([^"]*)"$/
 	 *
 	 * @param string $shouldOrNot
 	 * @param string $output
 	 *
 	 * @return void
 	 */
+	#[Then('/^the command output (should|should not) contain "([^"]*)"$/')]
 	public function theCommandOutputShouldContain(string $shouldOrNot, string $output): void {
 		$response = $this->featureContext->getResponse();
 		$jsonResponse = $this->featureContext->getJsonDecodedResponse($response);
@@ -510,13 +513,13 @@ class CliContext implements Context {
 	}
 
 	/**
-	 * @When the administrator lists all the upload sessions
-	 * @When the administrator lists all the upload sessions with flag :flag
 	 *
 	 * @param string|null $flag
 	 *
 	 * @return void
 	 */
+	#[When('the administrator lists all the upload sessions')]
+	#[When('the administrator lists all the upload sessions with flag :flag')]
 	public function theAdministratorListsAllTheUploadSessions(?string $flag = null): void {
 		if ($flag) {
 			$flag = "--$flag";
@@ -529,12 +532,12 @@ class CliContext implements Context {
 	}
 
 	/**
-	 * @When the administrator cleans upload sessions with the following flags:
 	 *
 	 * @param TableNode $table
 	 *
 	 * @return void
 	 */
+	#[When('the administrator cleans upload sessions with the following flags:')]
 	public function theAdministratorCleansUploadSessionsWithTheFollowingFlags(TableNode $table): void {
 		$flag = "";
 		foreach ($table->getRows() as $row) {
@@ -549,10 +552,10 @@ class CliContext implements Context {
 	}
 
 	/**
-	 * @When the administrator restarts the upload sessions that are in postprocessing
 	 *
 	 * @return void
 	 */
+	#[When('the administrator restarts the upload sessions that are in postprocessing')]
 	public function theAdministratorRestartsTheUploadSessionsThatAreInPostprocessing(): void {
 		$command = "storage-users uploads sessions --processing --restart --json";
 		$body = [
@@ -562,13 +565,13 @@ class CliContext implements Context {
 	}
 
 	/**
-	 * @When the administrator restarts the upload sessions of file :file
 	 *
 	 * @param string $file
 	 *
 	 * @return void
 	 * @throws JsonException
 	 */
+	#[When('the administrator restarts the upload sessions of file :file')]
 	public function theAdministratorRestartsUploadSessionsOfFile(string $file): void {
 		$response = CliHelper::runCommand(["command" => "storage-users uploads sessions --json"]);
 		$this->featureContext->theHTTPStatusCodeShouldBe(200, '', $response);
@@ -588,7 +591,6 @@ class CliContext implements Context {
 	}
 
 	/**
-	 * @Then /^the CLI response (should|should not) contain these entries:$/
 	 *
 	 * @param string $shouldOrNot
 	 * @param TableNode $table
@@ -596,6 +598,7 @@ class CliContext implements Context {
 	 * @return void
 	 * @throws JsonException
 	 */
+	#[Then('/^the CLI response (should|should not) contain these entries:$/')]
 	public function theCLIResponseShouldContainTheseEntries(string $shouldOrNot, TableNode $table): void {
 		$expectedFiles = $table->getColumn(0);
 		$responseArray = $this->getJSONDecodedCliMessage($this->featureContext->getResponse());
@@ -655,13 +658,13 @@ class CliContext implements Context {
 	}
 
 	/**
-	 * @When the administrator creates the folder :folder for user :user on the POSIX filesystem
 	 *
 	 * @param string $folder
 	 * @param string $user
 	 *
 	 * @return void
 	 */
+	#[When('the administrator creates the folder :folder for user :user on the POSIX filesystem')]
 	public function theAdministratorCreatesFolder(string $folder, string $user): void {
 		$userUuid = $this->featureContext->getAttributeOfCreatedUser($user, 'id');
 		$storagePath = $this->getUsersStoragePath();
@@ -677,12 +680,12 @@ class CliContext implements Context {
 	}
 
 	/**
-	 * @When the administrator lists the content of the POSIX storage folder of user :user
 	 *
 	 * @param string $user
 	 *
 	 * @return void
 	 */
+	#[When('the administrator lists the content of the POSIX storage folder of user :user')]
 	public function theAdministratorCheckUsersFolder(string $user): void {
 		$userUuid = $this->featureContext->getAttributeOfCreatedUser($user, 'id');
 		$storagePath = $this->getUsersStoragePath();
@@ -694,7 +697,6 @@ class CliContext implements Context {
 	}
 
 	/**
-	 * @When the administrator creates the file :file with content :content for user :user on the POSIX filesystem
 	 *
 	 * @param string $file
 	 * @param string $content
@@ -702,6 +704,7 @@ class CliContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[When('the administrator creates the file :file with content :content for user :user on the POSIX filesystem')]
 	public function theAdministratorCreatesFile(string $file, string $content, string $user): void {
 		$userUuid = $this->featureContext->getAttributeOfCreatedUser($user, 'id');
 		$storagePath = $this->getUsersStoragePath();
@@ -717,7 +720,6 @@ class CliContext implements Context {
 	}
 
 	/**
-	 * @When the administrator has created the file :file with content :content for user :user on the POSIX filesystem
 	 *
 	 * @param string $file
 	 * @param string $content
@@ -725,13 +727,13 @@ class CliContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[When('the administrator has created the file :file with content :content for user :user on the POSIX filesystem')]
 	public function theAdministratorHasCreatedFile(string $file, string $content, string $user): void {
 		$this->theAdministratorCreatesFile($file, $content, $user);
 		$this->theCommandShouldBeSuccessful();
 	}
 
 	/**
-	 * @When the administrator creates the file :file with size :size for user :user on the POSIX filesystem
 	 *
 	 * @param string $file
 	 * @param string $size Example: "1gb", "5gb"
@@ -739,6 +741,7 @@ class CliContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[When('the administrator creates the file :file with size :size for user :user on the POSIX filesystem')]
 	public function theAdministratorCreatesLargeFileWithSize(string $file, string $size, string $user): void {
 		$userUuid = $this->featureContext->getAttributeOfCreatedUser($user, 'id');
 		$storagePath = $this->getUsersStoragePath();
@@ -762,7 +765,6 @@ class CliContext implements Context {
 	}
 
 	/**
-	 * @When the administrator creates :count files sequentially in the directory :dir for user :user on the POSIX filesystem
 	 *
 	 * @param int $count
 	 * @param string $dir
@@ -770,6 +772,7 @@ class CliContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[When('the administrator creates :count files sequentially in the directory :dir for user :user on the POSIX filesystem')]
 	public function theAdministratorCreatesFilesSequentially(int $count, string $dir, string $user): void {
 		$userUuid = $this->featureContext->getAttributeOfCreatedUser($user, 'id');
 		$storagePath = $this->getUsersStoragePath() . "/$userUuid/$dir";
@@ -787,7 +790,6 @@ class CliContext implements Context {
 	}
 
 	/**
-	 * @When the administrator creates :count files in parallel in the directory :dir for user :user on the POSIX filesystem
 	 *
 	 * @param int $count
 	 * @param string $dir
@@ -795,6 +797,7 @@ class CliContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[When('the administrator creates :count files in parallel in the directory :dir for user :user on the POSIX filesystem')]
 	public function theAdministratorCreatesFilesInParallel(int $count, string $dir, string $user): void {
 		$userUuid = $this->featureContext->getAttributeOfCreatedUser($user, 'id');
 		$storagePath = $this->getUsersStoragePath() . "/$userUuid/$dir";
@@ -813,7 +816,6 @@ class CliContext implements Context {
 	}
 
 	/**
-	 * @When the administrator puts the content :content into the file :file in the POSIX storage folder of user :user
 	 *
 	 * @param string $content
 	 * @param string $file
@@ -821,6 +823,7 @@ class CliContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[When('the administrator puts the content :content into the file :file in the POSIX storage folder of user :user')]
 	public function theAdministratorChangesFileContent(string $content, string $file, string $user): void {
 		// this downloads the file using WebDAV and by that checks if it's still in
 		// postprocessing. So its effectively a check for finished postprocessing
@@ -838,13 +841,13 @@ class CliContext implements Context {
 	}
 
 	/**
-	 * @When the administrator reads the content of the file :file in the POSIX storage folder of user :user
 	 *
 	 * @param string $user
 	 * @param string $file
 	 *
 	 * @return void
 	 */
+	#[When('the administrator reads the content of the file :file in the POSIX storage folder of user :user')]
 	public function theAdministratorReadsTheFileContent(string $user, string $file): void {
 		// this downloads the file using WebDAV and by that checks if it's still in
 		// postprocessing. So its effectively a check for finished postprocessing
@@ -860,7 +863,6 @@ class CliContext implements Context {
 	}
 
 	/**
-	 * @When the administrator copies the file :file to the folder :folder for user :user on the POSIX filesystem
 	 *
 	 * @param string $user
 	 * @param string $file
@@ -868,6 +870,7 @@ class CliContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[When('the administrator copies the file :file to the folder :folder for user :user on the POSIX filesystem')]
 	public function theAdministratorCopiesFileToFolder(string $user, string $file, string $folder): void {
 		// this downloads the file using WebDAV and by that checks if it's still in
 		// postprocessing. So its effectively a check for finished postprocessing
@@ -888,7 +891,6 @@ class CliContext implements Context {
 	}
 
 	/**
-	 * @When the administrator renames the file :file to :newName for user :user on the POSIX filesystem
 	 *
 	 * @param string $user
 	 * @param string $file
@@ -896,6 +898,7 @@ class CliContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[When('the administrator renames the file :file to :newName for user :user on the POSIX filesystem')]
 	public function theAdministratorRenamesFile(string $user, string $file, string $newName): void {
 		// this downloads the file using WebDAV and by that checks if it's still in
 		// postprocessing. So its effectively a check for finished postprocessing
@@ -916,7 +919,6 @@ class CliContext implements Context {
 	}
 
 	/**
-	 * @When the administrator moves the file :file to the folder :folder for user :user on the POSIX filesystem
 	 *
 	 * @param string $user
 	 * @param string $file
@@ -924,6 +926,7 @@ class CliContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[When('the administrator moves the file :file to the folder :folder for user :user on the POSIX filesystem')]
 	public function theAdministratorMovesFileToFolder(string $user, string $file, string $folder): void {
 		// this downloads the file using WebDAV and by that checks if it's still in
 		// postprocessing. So its effectively a check for finished postprocessing
@@ -944,13 +947,13 @@ class CliContext implements Context {
 	}
 
 	/**
-	 * @When the administrator deletes the file :file for user :user on the POSIX filesystem
 	 *
 	 * @param string $file
 	 * @param string $user
 	 *
 	 * @return void
 	 */
+	#[When('the administrator deletes the file :file for user :user on the POSIX filesystem')]
 	public function theAdministratorDeletesFile(string $file, string $user): void {
 		$userUuid = $this->featureContext->getAttributeOfCreatedUser($user, 'id');
 		$storagePath = $this->getUsersStoragePath();
@@ -964,13 +967,13 @@ class CliContext implements Context {
 	}
 
 	/**
-	 * @When the administrator deletes the folder :folder for user :user on the POSIX filesystem
 	 *
 	 * @param string $folder
 	 * @param string $user
 	 *
 	 * @return void
 	 */
+	#[When('the administrator deletes the folder :folder for user :user on the POSIX filesystem')]
 	public function theAdministratorDeletesFolder(string $folder, string $user): void {
 		$userUuid = $this->featureContext->getAttributeOfCreatedUser($user, 'id');
 		$storagePath = $this->getUsersStoragePath();
@@ -984,7 +987,6 @@ class CliContext implements Context {
 	}
 
 	/**
-	 * @When the administrator copies the file :file to the space :space for user :user on the POSIX filesystem
 	 *
 	 * @param string $user
 	 * @param string $file
@@ -992,6 +994,7 @@ class CliContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[When('the administrator copies the file :file to the space :space for user :user on the POSIX filesystem')]
 	public function theAdministratorCopiesFileToSpace(string $user, string $file, string $space): void {
 		// this downloads the file using WebDAV and by that checks if it's still in
 		// postprocessing. So its effectively a check for finished postprocessing
@@ -1015,27 +1018,6 @@ class CliContext implements Context {
 	}
 
 	/**
-	 * @When the administrator deletes the project space :space on the POSIX filesystem
-	 *
-	 * @param string $space
-	 *
-	 * @return void
-	 */
-	public function theAdministratorDeletesSpace(string $space): void {
-		$projectsStoragePath = $this->getProjectsStoragePath();
-		$spaceId = $this->spacesContext->getSpaceIdByName($this->featureContext->getAdminUsername(), $space);
-		$spaceId = explode('$', $spaceId)[1];
-
-		$body = [
-		  "command" => "rm -r $projectsStoragePath/$spaceId",
-		  "raw" => true
-		];
-		$this->featureContext->setResponse(CliHelper::runCommand($body));
-		sleep(1);
-	}
-
-	/**
-	 * @When the administrator checks the attribute :attribute of file :file for user :user on the POSIX filesystem
 	 *
 	 * @param string $attribute
 	 * @param string $file
@@ -1043,6 +1025,7 @@ class CliContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[When('the administrator checks the attribute :attribute of file :file for user :user on the POSIX filesystem')]
 	public function theAdminChecksTheAttributeOfFileForUser(string $attribute, string $file, string $user): void {
 		// this downloads the file using WebDAV and by that checks if it's still in
 		// postprocessing. So its effectively a check for finished postprocessing

--- a/tests/acceptance/bootstrap/CollaborationContext.php
+++ b/tests/acceptance/bootstrap/CollaborationContext.php
@@ -27,6 +27,9 @@ use TestHelpers\HttpRequestHelper;
 use TestHelpers\WebDavHelper;
 use TestHelpers\CollaborationHelper;
 use TestHelpers\BehatHelper;
+use Behat\Step\Given;
+use Behat\Step\Then;
+use Behat\Step\When;
 
 /**
  * steps needed to re-configure OpenCloud server
@@ -71,8 +74,6 @@ class CollaborationContext implements Context {
 	}
 
 	/**
-	 * @When user :user checks the information of file :file of space :space using office :app
-	 * @When user :user checks the information of file :file of space :space using office :app with view mode :view
 	 *
 	 * @param string $user
 	 * @param string $file
@@ -84,6 +85,8 @@ class CollaborationContext implements Context {
 	 *
 	 * @throws GuzzleException
 	 */
+	#[When('user :user checks the information of file :file of space :space using office :app')]
+	#[When('user :user checks the information of file :file of space :space using office :app with view mode :view')]
 	public function userChecksTheInformationOfFileOfSpaceUsingOffice(
 		string $user,
 		string $file,
@@ -120,8 +123,6 @@ class CollaborationContext implements Context {
 	}
 
 	/**
-	 * @When user :user creates a file :file inside folder :folder in space :space using wopi endpoint
-	 * @When user :user tries to create a file :file inside folder :folder in space :space using wopi endpoint
 	 *
 	 * @param string $user
 	 * @param string $file
@@ -131,6 +132,8 @@ class CollaborationContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('user :user creates a file :file inside folder :folder in space :space using wopi endpoint')]
+	#[When('user :user tries to create a file :file inside folder :folder in space :space using wopi endpoint')]
 	public function userCreatesFileInsideFolderInSpaceUsingWopiEndpoint(
 		string $user,
 		string $file,
@@ -193,8 +196,6 @@ class CollaborationContext implements Context {
 	}
 
 	/**
-	 * @When the public creates a file :file inside the last shared public link folder with password :password using wopi endpoint
-	 * @When the public tries to create a file :file inside the last shared public link folder with password :password using wopi endpoint
 	 *
 	 * @param string $file
 	 * @param string $password
@@ -202,6 +203,8 @@ class CollaborationContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('the public creates a file :file inside the last shared public link folder with password :password using wopi endpoint')]
+	#[When('the public tries to create a file :file inside the last shared public link folder with password :password using wopi endpoint')]
 	public function thePublicCreatesAFileInsideTheLastSharedPublicLinkFolderWithPasswordUsingWopiEndpoint(
 		string $file,
 		string $password
@@ -210,8 +213,6 @@ class CollaborationContext implements Context {
 	}
 
 	/**
-	 * @When the public creates a file :file inside folder :folder in the last shared public link space with password :password using wopi endpoint
-	 * @When the public tries to create a file :file inside folder :folder in the last shared public link space with password :password using wopi endpoint
 	 *
 	 * @param string $file
 	 * @param string $folder
@@ -220,6 +221,8 @@ class CollaborationContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('the public creates a file :file inside folder :folder in the last shared public link space with password :password using wopi endpoint')]
+	#[When('the public tries to create a file :file inside folder :folder in the last shared public link space with password :password using wopi endpoint')]
 	public function thePublicCreatesAFileInsideFolderInTheLastSharedPublicLinkSpaceWithPasswordUsingWopiEndpoint(
 		string $file,
 		string $folder,
@@ -229,7 +232,6 @@ class CollaborationContext implements Context {
 	}
 
 	/**
-	 * @When user :user tries to check the information of file :file of space :space using office :app with invalid file-id
 	 *
 	 * @param string $user
 	 * @param string $file
@@ -241,6 +243,7 @@ class CollaborationContext implements Context {
 	 * @throws GuzzleException
 	 * @throws JsonException
 	 */
+	#[When('user :user tries to check the information of file :file of space :space using office :app with invalid file-id')]
 	public function userTriesToCheckTheInformationOfFileOfSpaceUsingOfficeWithInvalidFileId(
 		string $user,
 		string $file,
@@ -276,7 +279,6 @@ class CollaborationContext implements Context {
 	}
 
 	/**
-	 * @When user :user tries to create a file :file inside deleted folder using wopi endpoint
 	 *
 	 * @param string $user
 	 * @param string $file
@@ -284,6 +286,7 @@ class CollaborationContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('user :user tries to create a file :file inside deleted folder using wopi endpoint')]
 	public function userTriesToCreateAFileInsideDeletedFolderUsingWopiEndpoint(string $user, string $file): void {
 		$parentContainerId = $this->featureContext->getStoredFileID();
 		$this->featureContext->setResponse(
@@ -299,7 +302,6 @@ class CollaborationContext implements Context {
 	}
 
 	/**
-	 * @Given user :user has sent the following app-open request:
 	 *
 	 * @param string $user
 	 * @param TableNode $properties
@@ -307,6 +309,7 @@ class CollaborationContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[Given('user :user has sent the following app-open request:')]
 	public function userHasSentTheFollowingAppOpenRequest(string $user, TableNode $properties): void {
 		$rows = $properties->getRowsHash();
 		$appResponse = CollaborationHelper::sendPOSTRequestToAppOpen(
@@ -322,14 +325,14 @@ class CollaborationContext implements Context {
 	}
 
 	/**
-	 * @When user :user tries to get the information of the last opened file using wopi endpoint
-	 * @When user :user gets the information of the last opened file using wopi endpoint
 	 *
 	 * @param string $user
 	 *
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('user :user tries to get the information of the last opened file using wopi endpoint')]
+	#[When('user :user gets the information of the last opened file using wopi endpoint')]
 	public function userGetsTheInformationOfTheLastOpenedFileUsingWopiEndpoint(string $user): void {
 		$response = json_decode($this->getLastAppOpenData());
 		$accessToken = $response->form_parameters->access_token;
@@ -348,7 +351,6 @@ class CollaborationContext implements Context {
 	}
 
 	/**
-	 * @Then /^the response (should|should not) contain the following MIME types:$/
 	 *
 	 * @param string    $shouldOrNot
 	 * @param TableNode $table
@@ -356,6 +358,7 @@ class CollaborationContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('/^the response (should|should not) contain the following MIME types:$/')]
 	public function theFollowingMimeTypesShouldExistForUser(string $shouldOrNot, TableNode $table): void {
 		$rows = $table->getRows();
 		$responseArray = $this->featureContext->getJsonDecodedResponse(
@@ -380,13 +383,13 @@ class CollaborationContext implements Context {
 	}
 
 	/**
-	 * @Then the app list response should contain the following template information for office :app:
 	 *
 	 * @param string $app
 	 * @param TableNode $table
 	 *
 	 * @return void
 	 */
+	#[Then('the app list response should contain the following template information for office :app:')]
 	public function theAppListResponseShouldContainTheFollowingTemplateInformationForOffice(
 		string $app,
 		TableNode $table
@@ -442,7 +445,6 @@ class CollaborationContext implements Context {
 	}
 
 	/**
-	 * @When user :user has created a file :file using wopi endpoint
 	 *
 	 * @param string $user
 	 * @param string $file
@@ -450,6 +452,7 @@ class CollaborationContext implements Context {
 	 * @return string
 	 * @throws GuzzleException
 	 */
+	#[When('user :user has created a file :file using wopi endpoint')]
 	public function userHasCreatedAFileInSpaceUsingWopiEndpoint(string $user, string $file): string {
 		$parentContainerId = $this->featureContext->getFileIdForPath($user, "/");
 		$response = CollaborationHelper::createFile(

--- a/tests/acceptance/bootstrap/FavoritesContext.php
+++ b/tests/acceptance/bootstrap/FavoritesContext.php
@@ -21,6 +21,7 @@
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use TestHelpers\BehatHelper;
+use Behat\Step\Then;
 
 require_once 'bootstrap.php';
 
@@ -31,7 +32,6 @@ class FavoritesContext implements Context {
 	private WebDavPropertiesContext $webDavPropertiesContext;
 
 	/**
-	 * @Then /^as user "([^"]*)" (?:file|folder|entry) "([^"]*)" should be favorited$/
 	 *
 	 * @param string $user
 	 * @param string $path
@@ -40,6 +40,7 @@ class FavoritesContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[Then('/^as user "([^"]*)" (?:file|folder|entry) "([^"]*)" should be favorited$/')]
 	public function asUserFileOrFolderShouldBeFavorited(
 		string $user,
 		string $path,
@@ -58,13 +59,13 @@ class FavoritesContext implements Context {
 	}
 
 	/**
-	 * @Then /^as user "([^"]*)" (?:file|folder|entry) "([^"]*)" should not be favorited$/
 	 *
 	 * @param string $user
 	 * @param string $path
 	 *
 	 * @return void
 	 */
+	#[Then('/^as user "([^"]*)" (?:file|folder|entry) "([^"]*)" should not be favorited$/')]
 	public function asUserFileShouldNotBeFavorited(string $user, string $path): void {
 		$this->asUserFileOrFolderShouldBeFavorited($user, $path, 0);
 	}

--- a/tests/acceptance/bootstrap/FeatureContext.php
+++ b/tests/acceptance/bootstrap/FeatureContext.php
@@ -54,6 +54,9 @@ use Swaggest\JsonSchema\Exception\NumericException;
 use Swaggest\JsonSchema\Exception\ObjectException;
 use Swaggest\JsonSchema\Exception\StringException;
 use Swaggest\JsonSchema\Exception\TypeException;
+use Behat\Step\Given;
+use Behat\Step\Then;
+use Behat\Step\When;
 
 require_once 'bootstrap.php';
 
@@ -949,21 +952,21 @@ class FeatureContext extends BehatVariablesContext {
 	}
 
 	/**
-	 * @Given using SharingNG
 	 *
 	 * @return void
 	 */
+	#[Given('using SharingNG')]
 	public function usingSharingNG(): void {
 		$this->useSharingNG = true;
 	}
 
 	/**
-	 * @Given /^using OCS API version "([^"]*)"$/
 	 *
 	 * @param string $version
 	 *
 	 * @return void
 	 */
+	#[Given('using OCS API version :version')]
 	public function usingOcsApiVersion(string $version): void {
 		$this->ocsApiVersion = (int)$version;
 	}
@@ -1019,12 +1022,12 @@ class FeatureContext extends BehatVariablesContext {
 	}
 
 	/**
-	 * @Given /^using server "(LOCAL|REMOTE)"$/
 	 *
 	 * @param string|null $server
 	 *
 	 * @return string Previous used server
 	 */
+	#[Given('/^using server "(LOCAL|REMOTE)"$/')]
 	public function usingServer(?string $server): string {
 		$previousServer = $this->currentServer;
 		if ($server === 'LOCAL') {
@@ -1323,8 +1326,6 @@ class FeatureContext extends BehatVariablesContext {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" sends HTTP method "([^"]*)" to URL "([^"]*)"$/
-	 * @When /^user "([^"]*)" tries to send HTTP method "([^"]*)" to URL "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $verb
@@ -1332,6 +1333,8 @@ class FeatureContext extends BehatVariablesContext {
 	 *
 	 * @return void
 	 */
+	#[When('user :user sends HTTP method :verb to URL :url')]
+	#[When('user :user tries to send HTTP method :verb to URL :url')]
 	public function userSendsHTTPMethodToUrl(string $user, string $verb, string $url): void {
 		$user = $this->getActualUsername($user);
 		$endpoint = $this->substituteInLineCodes($url, $user);
@@ -1339,7 +1342,6 @@ class FeatureContext extends BehatVariablesContext {
 	}
 
 	/**
-	 * @When the public sends HTTP method :method to URL :url with password :password
 	 *
 	 * @param string $method
 	 * @param string $url
@@ -1347,6 +1349,7 @@ class FeatureContext extends BehatVariablesContext {
 	 *
 	 * @return void
 	 */
+	#[When('the public sends HTTP method :method to URL :url with password :password')]
 	public function thePublicSendsHttpMethodToUrlWithPassword(string $method, string $url, string $password): void {
 		$password = $this->getActualPassword($password);
 		$token = $this->shareNgGetLastCreatedLinkShareToken();
@@ -1367,7 +1370,6 @@ class FeatureContext extends BehatVariablesContext {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" sends HTTP method "([^"]*)" to URL "([^"]*)" with headers$/
 	 *
 	 * @param string $user
 	 * @param string $verb
@@ -1378,6 +1380,7 @@ class FeatureContext extends BehatVariablesContext {
 	 * @throws GuzzleException
 	 * @throws JsonException
 	 */
+	#[When('user :user sends HTTP method :verb to URL :url with headers')]
 	public function userSendsHTTPMethodToUrlWithHeaders(
 		string $user,
 		string $verb,
@@ -1419,7 +1422,6 @@ class FeatureContext extends BehatVariablesContext {
 	}
 
 	/**
-	 * @When user :user sends HTTP method :method to URL :davPath with content :content
 	 *
 	 * @param string $user
 	 * @param string $method
@@ -1428,6 +1430,7 @@ class FeatureContext extends BehatVariablesContext {
 	 *
 	 * @return void
 	 */
+	#[When('user :user sends HTTP method :method to URL :davPath with content :content')]
 	public function userSendsHttpMethodToUrlWithContent(
 		string $user,
 		string $method,
@@ -1435,25 +1438,6 @@ class FeatureContext extends BehatVariablesContext {
 		string $content
 	): void {
 		$this->setResponse($this->sendingToWithDirectUrl($user, $method, $davPath, $content));
-	}
-
-	/**
-	 * @When /^user "([^"]*)" sends HTTP method "([^"]*)" to URL "([^"]*)" with password "([^"]*)"$/
-	 *
-	 * @param string $user
-	 * @param string $verb
-	 * @param string $url
-	 * @param string $password
-	 *
-	 * @return void
-	 */
-	public function userSendsHTTPMethodToUrlWithPassword(
-		string $user,
-		string $verb,
-		string $url,
-		string $password
-	): void {
-		$this->setResponse($this->sendingToWithDirectUrl($user, $verb, $url, null, $password));
 	}
 
 	/**
@@ -1618,7 +1602,6 @@ class FeatureContext extends BehatVariablesContext {
 	}
 
 	/**
-	 * @Then the ocs JSON data of the response should match
 	 *
 	 * @param PyStringNode $schemaString
 	 *
@@ -1626,6 +1609,7 @@ class FeatureContext extends BehatVariablesContext {
 	 *
 	 * @throws Exception
 	 */
+	#[Then('the ocs JSON data of the response should match')]
 	public function theOcsDataOfTheResponseShouldMatch(
 		PyStringNode $schemaString
 	): void {
@@ -1637,13 +1621,13 @@ class FeatureContext extends BehatVariablesContext {
 	}
 
 	/**
-	 * @Then the JSON data of the response should match
 	 *
 	 * @param PyStringNode $schemaString
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('the JSON data of the response should match')]
 	public function theJsonDataOfTheResponseShouldMatch(PyStringNode $schemaString): void {
 		$responseBody = $this->getJsonDecodedResponseBodyContent();
 		$this->assertJsonDocumentMatchesSchema(
@@ -1653,24 +1637,24 @@ class FeatureContext extends BehatVariablesContext {
 	}
 
 	/**
-	 * @Then /^the HTTP status code should be "([^"]*)"$/
 	 *
 	 * @param int|string $statusCode
 	 *
 	 * @return void
 	 */
+	#[Then('the HTTP status code should be :statusCode')]
 	public function thenTheHTTPStatusCodeShouldBe($statusCode): void {
 		$this->theHTTPStatusCodeShouldBe($statusCode);
 	}
 
 	/**
-	 * @Then /^the HTTP status code should be "([^"]*)" or "([^"]*)"$/
 	 *
 	 * @param int|string $statusCode1
 	 * @param int|string $statusCode2
 	 *
 	 * @return void
 	 */
+	#[Then('the HTTP status code should be :statusCode1 or :statusCode2')]
 	public function theHTTPStatusCodeShouldBeOr($statusCode1, $statusCode2): void {
 		$this->theHTTPStatusCodeShouldBe(
 			[$statusCode1, $statusCode2]
@@ -1678,7 +1662,6 @@ class FeatureContext extends BehatVariablesContext {
 	}
 
 	/**
-	 * @Then /^the HTTP status code should be between "(\d+)" and "(\d+)"$/
 	 *
 	 * @param int|string $minStatusCode
 	 * @param int|string $maxStatusCode
@@ -1686,6 +1669,7 @@ class FeatureContext extends BehatVariablesContext {
 	 *
 	 * @return void
 	 */
+	#[Then('the HTTP status code should be between :minStatusCode and :maxStatusCode')]
 	public function theHTTPStatusCodeShouldBeBetween(
 		$minStatusCode,
 		$maxStatusCode,
@@ -2016,10 +2000,10 @@ class FeatureContext extends BehatVariablesContext {
 	}
 
 	/**
-	 * @When the administrator requests status.php
 	 *
 	 * @return void
 	 */
+	#[When('the administrator requests status.php')]
 	public function theAdministratorRequestsStatusPhp(): void {
 		$this->response = $this->getStatusPhp();
 	}

--- a/tests/acceptance/bootstrap/FilesVersionsContext.php
+++ b/tests/acceptance/bootstrap/FilesVersionsContext.php
@@ -26,6 +26,9 @@ use Psr\Http\Message\ResponseInterface;
 use TestHelpers\HttpRequestHelper;
 use TestHelpers\WebDavHelper;
 use TestHelpers\BehatHelper;
+use Behat\Step\Given;
+use Behat\Step\Then;
+use Behat\Step\When;
 
 require_once 'bootstrap.php';
 
@@ -55,7 +58,6 @@ class FilesVersionsContext implements Context {
 	}
 
 	/**
-	 * @When user :user tries to get versions of file :file from :fileOwner
 	 *
 	 * @param string $user
 	 * @param string $file
@@ -64,12 +66,12 @@ class FilesVersionsContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('user :user tries to get versions of file :file from :fileOwner')]
 	public function userTriesToGetFileVersions(string $user, string $file, string $fileOwner): void {
 		$this->featureContext->setResponse($this->getFileVersions($user, $file, $fileOwner));
 	}
 
 	/**
-	 * @When user :user gets the number of versions of file :file
 	 *
 	 * @param string $user
 	 * @param string $file
@@ -77,12 +79,12 @@ class FilesVersionsContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('user :user gets the number of versions of file :file')]
 	public function userGetsFileVersions(string $user, string $file): void {
 		$this->featureContext->setResponse($this->getFileVersions($user, $file));
 	}
 
 	/**
-	 * @When the public tries to get the number of versions of file :file with password :password using file-id :endpoint
 	 *
 	 * @param string $file
 	 * @param string $password
@@ -90,6 +92,7 @@ class FilesVersionsContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[When('the public tries to get the number of versions of file :file with password :password using file-id :endpoint')]
 	public function thePublicTriesToGetTheNumberOfVersionsOfFileWithPasswordUsingFileId(
 		string $file,
 		string $password,
@@ -148,14 +151,14 @@ class FilesVersionsContext implements Context {
 	}
 
 	/**
-	 * @When user :user gets the number of versions of file :resource using file-id :fileId
-	 * @When user :user tries to get the number of versions of file :resource using file-id :fileId
 	 *
 	 * @param string $user
 	 * @param string $fileId
 	 *
 	 * @return void
 	 */
+	#[When('user :user gets the number of versions of file :resource using file-id :fileId')]
+	#[When('user :user tries to get the number of versions of file :resource using file-id :fileId')]
 	public function userGetsTheNumberOfVersionsOfFileOfTheSpace(string $user, string $fileId): void {
 		$this->featureContext->setResponse(
 			$this->featureContext->makeDavRequest(
@@ -240,7 +243,6 @@ class FilesVersionsContext implements Context {
 	}
 
 	/**
-	 * @Given user :user has restored version index :versionIndex of file :path
 	 *
 	 * @param string $user
 	 * @param int $versionIndex
@@ -249,13 +251,13 @@ class FilesVersionsContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Given('user :user has restored version index :versionIndex of file :path')]
 	public function userHasRestoredVersionIndexOfFile(string $user, int $versionIndex, string $path): void {
 		$response = $this->restoreVersionIndexOfFile($user, $versionIndex, $path);
 		$this->featureContext->theHTTPStatusCodeShouldBe(204, "", $response);
 	}
 
 	/**
-	 * @When user :user restores version index :versionIndex of file :path using the WebDAV API
 	 *
 	 * @param string $user
 	 * @param int $versionIndex
@@ -264,6 +266,7 @@ class FilesVersionsContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('user :user restores version index :versionIndex of file :path using the WebDAV API')]
 	public function userRestoresVersionIndexOfFile(string $user, int $versionIndex, string $path): void {
 		$response = $this->restoreVersionIndexOfFile($user, $versionIndex, $path);
 		$this->featureContext->setResponse($response, $user);
@@ -297,7 +300,6 @@ class FilesVersionsContext implements Context {
 	}
 
 	/**
-	 * @Then the version folder of file :path for user :user should contain :count element(s)
 	 *
 	 * @param string $path
 	 * @param string $user
@@ -306,6 +308,7 @@ class FilesVersionsContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('the version folder of file :path for user :user should contain :count element(s)')]
 	public function theVersionFolderOfFileShouldContainElements(
 		string $path,
 		string $user,
@@ -322,7 +325,6 @@ class FilesVersionsContext implements Context {
 	}
 
 	/**
-	 * @Then the content length of file :path with version index :index for user :user in versions folder should be :length
 	 *
 	 * @param string $path
 	 * @param int $index
@@ -332,6 +334,7 @@ class FilesVersionsContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('the content length of file :path with version index :index for user :user in versions folder should be :length')]
 	public function theContentLengthOfFileForUserInVersionsFolderIs(
 		string $path,
 		int $index,
@@ -406,7 +409,6 @@ class FilesVersionsContext implements Context {
 	}
 
 	/**
-	 * @When user :user downloads the version of file :path with the index :index
 	 *
 	 * @param string $user
 	 * @param string $path
@@ -415,12 +417,12 @@ class FilesVersionsContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('user :user downloads the version of file :path with the index :index')]
 	public function userDownloadsVersion(string $user, string $path, string $index): void {
 		$this->featureContext->setResponse($this->downloadVersion($user, $path, $index), $user);
 	}
 
 	/**
-	 * @Then /^the content of version index "([^"]*)" of file "([^"]*)" for user "([^"]*)" should be "([^"]*)"$/
 	 *
 	 * @param string $index
 	 * @param string $path
@@ -430,6 +432,7 @@ class FilesVersionsContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('the content of version index :index of file :path for user :user should be :content')]
 	public function theContentOfVersionIndexOfFileForUserShouldBe(
 		string $index,
 		string $path,
@@ -442,7 +445,6 @@ class FilesVersionsContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" retrieves the meta information of (file|fileId) "([^"]*)" using the meta API$/
 	 *
 	 * @param string $user
 	 * @param string $fileOrFileId
@@ -450,6 +452,7 @@ class FilesVersionsContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[When('/^user "([^"]*)" retrieves the meta information of (file|fileId) "([^"]*)" using the meta API$/')]
 	public function userGetMetaInfo(string $user, string $fileOrFileId, string $path): void {
 		$user = $this->featureContext->getActualUsername($user);
 		$baseUrl = $this->featureContext->getBaseUrl();
@@ -525,8 +528,6 @@ class FilesVersionsContext implements Context {
 	}
 
 	/**
-	 * @When user :user gets the number of versions of file :file from space :space
-	 * @When user :user tries to get the number of versions of file :file from space :space
 	 *
 	 * @param string $user
 	 * @param string $file
@@ -534,6 +535,7 @@ class FilesVersionsContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[When('user :user tries to get the number of versions of file :file from space :space')]
 	public function userGetsTheNumberOfVersionsOfFileFromSpace(string $user, string $file, string $space): void {
 		$fileId = $this->spacesContext->getFileId($user, $space, $file);
 		$this->featureContext->setResponse(

--- a/tests/acceptance/bootstrap/GraphContext.php
+++ b/tests/acceptance/bootstrap/GraphContext.php
@@ -18,6 +18,9 @@ use TestHelpers\WebDavHelper;
 use TestHelpers\HttpRequestHelper;
 use TestHelpers\BehatHelper;
 use TestHelpers\TokenHelper;
+use Behat\Step\Given;
+use Behat\Step\Then;
+use Behat\Step\When;
 
 require_once 'bootstrap.php';
 
@@ -52,8 +55,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When /^the user "([^"]*)" changes the email of user "([^"]*)" to "([^"]*)" using the Graph API$/
-	 * @When /^the user "([^"]*)" tries to change the email of user "([^"]*)" to "([^"]*)" using the Graph API$/
 	 *
 	 * @param string $byUser
 	 * @param string $user
@@ -63,14 +64,14 @@ class GraphContext implements Context {
 	 * @throws GuzzleException
 	 * @throws Exception
 	 */
+	#[When('the user :byUser changes the email of user :user to :email using the Graph API')]
+	#[When('the user :byUser tries to change the email of user :user to :email using the Graph API')]
 	public function theUserChangesTheEmailOfUserToUsingTheGraphApi(string $byUser, string $user, string $email): void {
 		$response = $this->editUserUsingTheGraphApi($byUser, $user, null, null, $email);
 		$this->featureContext->setResponse($response);
 	}
 
 	/**
-	 * @When /^the user "([^"]*)" changes the display name of user "([^"]*)" to "([^"]*)" using the Graph API$/
-	 * @When /^the user "([^"]*)" tries to change the display name of user "([^"]*)" to "([^"]*)" using the Graph API$/
 	 *
 	 * @param string $byUser
 	 * @param string $user
@@ -80,6 +81,8 @@ class GraphContext implements Context {
 	 * @throws GuzzleException
 	 * @throws Exception
 	 */
+	#[When('the user :byUser changes the display name of user :user to :displayName using the Graph API')]
+	#[When('the user :byUser tries to change the display name of user :user to :displayName using the Graph API')]
 	public function theUserChangesTheDisplayNameOfUserToUsingTheGraphApi(
 		string $byUser,
 		string $user,
@@ -90,8 +93,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When /^the user "([^"]*)" changes the user name of user "([^"]*)" to "([^"]*)" using the Graph API$/
-	 * @When /^the user "([^"]*)" tries to change the user name of user "([^"]*)" to "([^"]*)" using the Graph API$/
 	 *
 	 * @param string $byUser
 	 * @param string $user
@@ -101,6 +102,8 @@ class GraphContext implements Context {
 	 * @throws GuzzleException
 	 * @throws Exception
 	 */
+	#[When('the user :byUser changes the user name of user :user to :userName using the Graph API')]
+	#[When('the user :byUser tries to change the user name of user :user to :userName using the Graph API')]
 	public function theUserChangesTheUserNameOfUserToUsingTheGraphApi(
 		string $byUser,
 		string $user,
@@ -111,8 +114,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When /^the user "([^"]*)" disables user "([^"]*)" using the Graph API$/
-	 * @When /^the user "([^"]*)" tries to disable user "([^"]*)" using the Graph API$/
 	 *
 	 * @param string $byUser
 	 * @param string $user
@@ -121,13 +122,14 @@ class GraphContext implements Context {
 	 * @throws GuzzleException
 	 * @throws Exception
 	 */
+	#[When('the user :byUser disables user :user using the Graph API')]
+	#[When('the user :byUser tries to disable user :user using the Graph API')]
 	public function theUserDisablesUserToUsingTheGraphApi(string $byUser, string $user): void {
 		$response = $this->editUserUsingTheGraphApi($byUser, $user, null, null, null, null, false);
 		$this->featureContext->setResponse($response);
 	}
 
 	/**
-	 * @Given /^the user "([^"]*)" has disabled user "([^"]*)"$/
 	 *
 	 * @param string $byUser
 	 * @param string $user
@@ -136,14 +138,13 @@ class GraphContext implements Context {
 	 * @throws GuzzleException
 	 * @throws Exception
 	 */
+	#[Given('the user :byUser has disabled user :user')]
 	public function theUserHasDisabledUser(string $byUser, string $user): void {
 		$response = $this->editUserUsingTheGraphApi($byUser, $user, null, null, null, null, false);
 		$this->featureContext->theHTTPStatusCodeShouldBe(200, '', $response);
 	}
 
 	/**
-	 * @When /^the user "([^"]*)" enables user "([^"]*)" using the Graph API$/
-	 * @When /^the user "([^"]*)" tries to enable user "([^"]*)" using the Graph API$/
 	 *
 	 * @param string $byUser
 	 * @param string $user
@@ -152,13 +153,14 @@ class GraphContext implements Context {
 	 * @throws GuzzleException
 	 * @throws Exception
 	 */
+	#[When('the user :byUser enables user :user using the Graph API')]
+	#[When('the user :byUser tries to enable user :user using the Graph API')]
 	public function theUserEnablesUserToUsingTheGraphApi(string $byUser, string $user): void {
 		$response = $this->editUserUsingTheGraphApi($byUser, $user);
 		$this->featureContext->setResponse($response);
 	}
 
 	/**
-	 * @Then /^the user information of "([^"]*)" should match this JSON schema$/
 	 *
 	 * @param string $user
 	 * @param PyStringNode $schemaString
@@ -168,6 +170,7 @@ class GraphContext implements Context {
 	 * @throws GuzzleException
 	 * @throws JsonException
 	 */
+	#[Then('the user information of :user should match this JSON schema')]
 	public function theUserInformationShouldMatchTheJSON(string $user, PyStringNode $schemaString): void {
 		$response = $this->adminHasRetrievedUserUsingTheGraphApi($user);
 		$responseBody = $this->featureContext->getJsonDecodedResponseBodyContent($response);
@@ -342,7 +345,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When /^the user "([^"]*)" deletes a user "([^"]*)" using the Graph API$/
 	 *
 	 * @param string $byUser
 	 * @param string $user
@@ -351,13 +353,13 @@ class GraphContext implements Context {
 	 * @throws Exception
 	 * @throws GuzzleException
 	 */
+	#[When('the user :byUser deletes a user :user using the Graph API')]
 	public function theUserDeletesAUserUsingTheGraphAPI(string $byUser, string $user): void {
 		$userId = $this->featureContext->getAttributeOfCreatedUser($user, 'id');
 		$this->featureContext->setResponse($this->deleteUserByUserIdUsingTheGraphApi($userId, $byUser));
 	}
 
 	/**
-	 * @When /^the user "([^"]*)" tries to delete a nonexistent user using the Graph API$/
 	 *
 	 * @param string $byUser
 	 *
@@ -365,13 +367,13 @@ class GraphContext implements Context {
 	 * @throws GuzzleException
 	 * @throws Exception
 	 */
+	#[When('the user :byUser tries to delete a nonexistent user using the Graph API')]
 	public function theUserTriesToDeleteNonExistingUser(string $byUser): void {
 		$userId = WebDavHelper::generateUUIDv4();
 		$this->featureContext->setResponse($this->deleteUserByUserIdUsingTheGraphApi($userId, $byUser));
 	}
 
 	/**
-	 * @Given /^the user "([^"]*)" has deleted a user "([^"]*)"$/
 	 *
 	 * @param string $byUser
 	 * @param string $user
@@ -380,6 +382,7 @@ class GraphContext implements Context {
 	 * @throws Exception
 	 * @throws GuzzleException
 	 */
+	#[Given('the user :byUser has deleted a user :user')]
 	public function theUserHasDeletedAUser(string $byUser, string $user): void {
 		$response = $this->adminDeletesUserUsingTheGraphApi($user, $byUser);
 		$this->featureContext->theHttpStatusCodeShouldBe(204, "", $response);
@@ -479,7 +482,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When /^the user "([^"]*)" resets the password of user "([^"]*)" to "([^"]*)" using the Graph API$/
 	 *
 	 * @param string $byUser
 	 * @param string $user
@@ -488,6 +490,7 @@ class GraphContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('the user :byUser resets the password of user :user to :password using the Graph API')]
 	public function theUserResetsThePasswordOfUserToUsingTheGraphApi(string $byUser, string $user, string $password) {
 		$response = $this->adminChangesPasswordOfUserToUsingTheGraphApi($user, $password, $byUser);
 		$this->featureContext->setResponse($response);
@@ -666,7 +669,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When /^the user "([^"]*)" creates a new user with the following attributes using the Graph API:$/
 	 *
 	 * @param string $user
 	 * @param TableNode $table
@@ -674,6 +676,7 @@ class GraphContext implements Context {
 	 * @return void
 	 * @throws Exception|GuzzleException
 	 */
+	#[When('the user :user creates a new user with the following attributes using the Graph API:')]
 	public function theUserCreatesNewUser(string $user, TableNode $table): void {
 		$rows = $table->getRowsHash();
 		$response = GraphHelper::createUser(
@@ -734,7 +737,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @Given /^the administrator has added a user "([^"]*)" to the group "([^"]*)" using the Graph API$/
 	 *
 	 * @param string $user
 	 * @param string $group
@@ -743,6 +745,7 @@ class GraphContext implements Context {
 	 * @throws Exception
 	 * @throws GuzzleException
 	 */
+	#[Given('the administrator has added a user :user to the group :group using the Graph API')]
 	public function adminHasAddedUserToGroupUsingTheGraphApi(
 		string $user,
 		string $group
@@ -752,12 +755,12 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When the administrator adds the following users to the following groups using the Graph API
 	 *
 	 * @param TableNode $table
 	 *
 	 * @return void
 	 */
+	#[When('the administrator adds the following users to the following groups using the Graph API')]
 	public function theAdministratorAddsTheFollowingUsersToTheFollowingGroupsUsingTheGraphAPI(TableNode $table): void {
 		$this->featureContext->verifyTableNodeColumns($table, ['username', 'groupname']);
 		$userGroupList = $table->getColumnsHash();
@@ -769,14 +772,14 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When the administrator tries to add nonexistent user to group :group using the Graph API
-	 * @When user :byUser tries to add nonexistent user to group :group using the Graph API
 	 *
 	 * @param string $group
 	 * @param string|null $byUser
 	 *
 	 * @return void
 	 */
+	#[When('the administrator tries to add nonexistent user to group :group using the Graph API')]
+	#[When('user :byUser tries to add nonexistent user to group :group using the Graph API')]
 	public function theAdministratorTriesToAddNonExistentUserToGroupUsingTheGraphAPI(
 		string $group,
 		?string $byUser = null
@@ -785,8 +788,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When the administrator tries to add user :user to a nonexistent group using the Graph API
-	 * @When user :byUser tries to add user :user to a nonexistent group using the Graph API
 	 *
 	 * @param string $user
 	 * @param string|null $byUser
@@ -795,6 +796,8 @@ class GraphContext implements Context {
 	 *
 	 * @throws GuzzleException | Exception
 	 */
+	#[When('the administrator tries to add user :user to a nonexistent group using the Graph API')]
+	#[When('user :byUser tries to add user :user to a nonexistent group using the Graph API')]
 	public function theAdministratorTriesToAddUserToNonExistentGroupUsingTheGraphAPI(
 		string $user,
 		?string $byUser = null
@@ -803,19 +806,18 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When user :user tries to add himself/herself to group :group using the Graph API
 	 *
 	 * @param string $user
 	 * @param string $group
 	 *
 	 * @return void
 	 */
+	#[When('user :user tries to add himself/herself to group :group using the Graph API')]
 	public function theUserTriesToAddHimselfToGroupUsingTheGraphAPI(string $user, string $group): void {
 		$this->featureContext->setResponse($this->addUserToGroup($group, $user, $user));
 	}
 
 	/**
-	 * @When user :byUser tries to add user :user to group :group using the Graph API
 	 *
 	 * @param string $byUser
 	 * @param string $user
@@ -823,6 +825,7 @@ class GraphContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[When('user :byUser tries to add user :user to group :group using the Graph API')]
 	public function theUserTriesToAddAnotherUserToGroupUsingTheGraphAPI(
 		string $byUser,
 		string $user,
@@ -852,9 +855,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When /^the administrator creates a group "([^"]*)" using the Graph API$/
-	 * @When user :user creates a group :group using the Graph API
-	 * @When user :user tries to create a group :group using the Graph API
 	 *
 	 * @param string $group
 	 * @param ?string $user
@@ -863,6 +863,9 @@ class GraphContext implements Context {
 	 * @throws Exception
 	 * @throws GuzzleException
 	 */
+	#[When('the administrator creates a group :group using the Graph API')]
+	#[When('user :user creates a group :group using the Graph API')]
+	#[When('user :user tries to create a group :group using the Graph API')]
 	public function userCreatesGroupUsingTheGraphApi(string $group, ?string $user = null): void {
 		$response = $this->createGroup($group, $user);
 		$this->featureContext->setResponse($response);
@@ -875,8 +878,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @Given /^the administrator has created a group "([^"]*)" using the Graph API$/
-	 * @Given user :user has created a group :group using the Graph API
 	 *
 	 * @param string $group
 	 * @param ?string $user
@@ -885,6 +886,8 @@ class GraphContext implements Context {
 	 * @throws Exception
 	 * @throws GuzzleException
 	 */
+	#[Given('the administrator has created a group :group using the Graph API')]
+	#[Given('user :user has created a group :group using the Graph API')]
 	public function userHasCreatedGroupUsingTheGraphApi(string $group, ?string $user = null): void {
 		$response = $this->createGroup($group, $user);
 
@@ -957,7 +960,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When /^the user "([^"]*)" changes its own password "([^"]*)" to "([^"]*)" using the Graph API$/
 	 *
 	 * @param string $user
 	 * @param string $currentPassword
@@ -967,6 +969,7 @@ class GraphContext implements Context {
 	 * @throws GuzzleException
 	 * @throws Exception
 	 */
+	#[When('the user :user changes its own password :currentPassword to :newPassword using the Graph API')]
 	public function userChangesOwnPassword(string $user, string $currentPassword, string $newPassword): void {
 		$response = GraphHelper::changeOwnPassword(
 			$this->featureContext->getBaseUrl(),
@@ -980,31 +983,29 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When user :user gets all the groups using the Graph API
 	 *
 	 * @param string $user
 	 *
 	 * @return void
 	 */
+	#[When('user :user gets all the groups using the Graph API')]
 	public function userGetsAllTheGroupsUsingTheGraphApi(string $user): void {
 		$this->featureContext->setResponse($this->listGroups($user));
 	}
 
 	/**
-	 * @When user :user gets all the members of group :group using the Graph API
 	 *
 	 * @param string $user
 	 * @param string $group
 	 *
 	 * @return void
 	 */
+	#[When('user :user gets all the members of group :group using the Graph API')]
 	public function userGetsAllTheMembersOfGroupUsingTheGraphApi(string $user, string $group): void {
 		$this->featureContext->setResponse($this->listGroupMembers($group, $user));
 	}
 
 	/**
-	 * @When user :user retrieves all groups along with their members using the Graph API
-	 * @When user :user gets all the members information of group :group using the Graph API
 	 *
 	 * @param string $user
 	 * @param string $group
@@ -1012,20 +1013,22 @@ class GraphContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('user :user retrieves all groups along with their members using the Graph API')]
+	#[When('user :user gets all the members information of group :group using the Graph API')]
 	public function userRetrievesAllMemberInformationOfSingleOrAllGroups(string $user, string $group = ''): void {
 		$this->featureContext->setResponse($this->listSingleOrAllGroupsAlongWithAllMemberInformation($user, $group));
 	}
 
 	/**
-	 * @When user :user deletes group :group using the Graph API
-	 * @When the administrator deletes group :group using the Graph API
-	 * @When user :user tries to delete group :group using the Graph API
 	 *
 	 * @param string $group
 	 * @param string|null $user
 	 *
 	 * @return void
 	 */
+	#[When('user :user deletes group :group using the Graph API')]
+	#[When('the administrator deletes group :group using the Graph API')]
+	#[When('user :user tries to delete group :group using the Graph API')]
 	public function userDeletesGroupUsingTheGraphApi(string $group, ?string $user = null): void {
 		$groupId = $this->featureContext->getAttributeOfCreatedGroup($group, "id") ?: $group;
 		$response = $this->deleteGroupWithId($groupId, $user);
@@ -1036,13 +1039,13 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @Then the following users should be listed in the following groups
 	 *
 	 * @param TableNode $table
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('the following users should be listed in the following groups')]
 	public function theFollowingUsersShouldBeListedInFollowingGroups(TableNode $table): void {
 		$this->featureContext->verifyTableNodeColumns($table, ['username', 'groupname']);
 		$usersGroups = $table->getColumnsHash();
@@ -1090,8 +1093,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When user :user renames group :oldGroup to :newGroup using the Graph API
-	 * @When user :user tries to rename group :oldGroup to :newGroup using the Graph API
 	 *
 	 * @param string $user
 	 * @param string $oldGroup
@@ -1100,13 +1101,14 @@ class GraphContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('user :user renames group :oldGroup to :newGroup using the Graph API')]
+	#[When('user :user tries to rename group :oldGroup to :newGroup using the Graph API')]
 	public function userRenamesGroupUsingTheGraphApi(string $user, string $oldGroup, string $newGroup): void {
 		$oldGroupId = $this->featureContext->getAttributeOfCreatedGroup($oldGroup, "id");
 		$this->featureContext->setResponse($this->renameGroup($oldGroupId, $newGroup, $user));
 	}
 
 	/**
-	 * @When user :user tries to rename a nonexistent group to :newGroup using the Graph API
 	 *
 	 * @param string $user
 	 * @param string $newGroup
@@ -1115,18 +1117,19 @@ class GraphContext implements Context {
 	 * @throws GuzzleException
 	 * @throws Exception
 	 */
+	#[When('user :user tries to rename a nonexistent group to :newGroup using the Graph API')]
 	public function userTriesToRenameNonExistentGroupToNewGroupName(string $user, string $newGroup): void {
 		$oldGroupId = WebDavHelper::generateUUIDv4();
 		$this->featureContext->setResponse($this->renameGroup($oldGroupId, $newGroup, $user));
 	}
 
 	/**
-	 * @When the administrator removes the following users from the following groups using the Graph API
 	 *
 	 * @param TableNode $table
 	 *
 	 * @return void
 	 */
+	#[When('the administrator removes the following users from the following groups using the Graph API')]
 	public function theAdministratorRemovesTheFollowingUsersFromTheFollowingGroupsUsingTheGraphApi(
 		TableNode $table
 	): void {
@@ -1142,7 +1145,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When user :byUser tries to remove user :user from group :group using the Graph API
 	 *
 	 * @param string $user
 	 * @param string $group
@@ -1151,6 +1153,7 @@ class GraphContext implements Context {
 	 * @return void
 	 * @throws Exception | GuzzleException
 	 */
+	#[When('user :byUser tries to remove user :user from group :group using the Graph API')]
 	public function theUserTriesToRemoveAnotherUserFromGroupUsingTheGraphAPI(
 		string $user,
 		string $group,
@@ -1160,8 +1163,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When the administrator tries to remove user :user from a nonexistent group using the Graph API
-	 * @When user :byUser tries to remove user :user from a nonexistent group using the Graph API
 	 *
 	 * @param string $user
 	 * @param string|null $byUser
@@ -1169,6 +1170,8 @@ class GraphContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('the administrator tries to remove user :user from a nonexistent group using the Graph API')]
+	#[When('user :byUser tries to remove user :user from a nonexistent group using the Graph API')]
 	public function theUserTriesToRemoveAnotherUserFromNonExistentGroupUsingTheGraphAPI(
 		string $user,
 		?string $byUser = null
@@ -1196,13 +1199,13 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When /^the user "([^"]*)" retrieves (her|his) information using the Graph API$/
 	 *
 	 * @param string $user
 	 *
 	 * @return void
 	 * @throws JsonException
 	 */
+	#[When('/^the user "([^"]*)" retrieves (her|his) information using the Graph API$/')]
 	public function userRetrievesHisOrHerInformationOfUserUsingGraphApi(
 		string $user
 	): void {
@@ -1211,8 +1214,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When user :byUser tries to get information of user :user using Graph API
-	 * @When user :byUser gets information of user :user using Graph API
 	 *
 	 * @param string $byUser
 	 * @param string $user
@@ -1220,6 +1221,8 @@ class GraphContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('user :byUser tries to get information of user :user using Graph API')]
+	#[When('user :byUser gets information of user :user using Graph API')]
 	public function userTriesToGetInformationOfUser(string $byUser, string $user): void {
 		$credentials = $this->getAdminOrUserCredentials($byUser);
 		$response = GraphHelper::getUser(
@@ -1233,8 +1236,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When user :byUser tries to search for user :searchTerm using Graph API
-	 * @When user :byUser searches for user :searchTerm using Graph API
 	 *
 	 * @param string $byUser
 	 * @param string $searchTerm
@@ -1242,6 +1243,8 @@ class GraphContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('user :byUser tries to search for user :searchTerm using Graph API')]
+	#[When('user :byUser searches for user :searchTerm using Graph API')]
 	public function userSearchesForUserUsingGraphApi(string $byUser, string $searchTerm): void {
 		$credentials = $this->getAdminOrUserCredentials($byUser);
 		$response = GraphHelper::searchUser(
@@ -1255,7 +1258,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When user :byUser searches for federated user :searchTerm using Graph API
 	 *
 	 * @param string $byUser
 	 * @param string $searchTerm
@@ -1263,6 +1265,7 @@ class GraphContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('user :byUser searches for federated user :searchTerm using Graph API')]
 	public function userSearchesForFederatedUserUsingGraphApi(string $byUser, string $searchTerm): void {
 		$credentials = $this->getAdminOrUserCredentials($byUser);
 		$response = GraphHelper::searchFederatedUser(
@@ -1276,14 +1279,14 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When user :user tries to get all users using the Graph API
-	 * @When user :user gets all users using the Graph API
 	 *
 	 * @param string $user
 	 *
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('user :user tries to get all users using the Graph API')]
+	#[When('user :user gets all users using the Graph API')]
 	public function userGetsAllUserUsingTheGraphApi(string $user) {
 		$credentials = $this->getAdminOrUserCredentials($user);
 		$response = GraphHelper::getUsers(
@@ -1342,26 +1345,26 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When /^the user "([^"]*)" gets user "([^"]*)" along with (his|her) drive information using Graph API$/
 	 *
 	 * @param string $byUser
 	 * @param string $user
 	 *
 	 * @return void
 	 */
+	#[When('/^the user "([^"]*)" gets user "([^"]*)" along with (his|her) drive information using Graph API$/')]
 	public function userTriesToGetInformationOfUserAlongWithHisDriveData(string $byUser, string $user) {
 		$response = $this->retrieveUserInformationAlongWithDriveUsingGraphApi($byUser, $user);
 		$this->featureContext->setResponse($response);
 	}
 
 	/**
-	 * @When /^the user "([^"]*)" gets user "([^"]*)" along with (his|her) group information using Graph API$/
 	 *
 	 * @param string $byUser
 	 * @param string $user
 	 *
 	 * @return void
 	 */
+	#[When('/^the user "([^"]*)" gets user "([^"]*)" along with (his|her) group information using Graph API$/')]
 	public function userTriesToGetInformationOfUserAlongWithHisGroup(string $byUser, string $user) {
 		$response = $this->retrieveUserInformationAlongWithGroupUsingGraphApi($byUser, $user);
 		$this->featureContext->setResponse($response);
@@ -1369,12 +1372,12 @@ class GraphContext implements Context {
 
 	/**
 	 *
-	 * @When /^the user "([^"]*)" gets (his|her) drive information using Graph API$/
 	 *
 	 * @param string $user
 	 *
 	 * @return void
 	 */
+	#[When('/^the user "([^"]*)" gets (his|her) drive information using Graph API$/')]
 	public function userTriesToGetOwnDriveInformation(string $user) {
 		$response = $this->retrieveUserInformationAlongWithDriveUsingGraphApi($user);
 		$this->featureContext->setResponse($response);
@@ -1409,7 +1412,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When /^the administrator "([^"]*)" adds the following users to a group "([^"]*)" at once using the Graph API$/
 	 *
 	 * @param string $user
 	 * @param string $group
@@ -1419,6 +1421,7 @@ class GraphContext implements Context {
 	 * @throws Exception
 	 * @throws GuzzleException
 	 */
+	#[When('the administrator :user adds the following users to a group :group at once using the Graph API')]
 	public function theAdministratorAddsTheFollowingUsersToAGroupInASingleRequestUsingTheGraphApi(
 		string $user,
 		string $group,
@@ -1435,7 +1438,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" tries to add the following users to a group "([^"]*)" at once with an invalid host using the Graph API$/
 	 *
 	 * @param string $user
 	 * @param string $group
@@ -1445,6 +1447,7 @@ class GraphContext implements Context {
 	 * @throws Exception
 	 * @throws GuzzleException
 	 */
+	#[When('user :user tries to add the following users to a group :group at once with an invalid host using the Graph API')]
 	public function userTriesToAddTheFollowingUsersToAGroupAtOnceWithInvalidHostUsingTheGraphApi(
 		string $user,
 		string $group,
@@ -1478,7 +1481,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" tries to add user "([^"]*)" to group "([^"]*)" with an invalid host using the Graph API$/
 	 *
 	 * @param string $adminUser
 	 * @param string $user
@@ -1488,6 +1490,7 @@ class GraphContext implements Context {
 	 * @throws Exception
 	 * @throws GuzzleException
 	 */
+	#[When('user :adminUser tries to add user :user to group :group with an invalid host using the Graph API')]
 	public function userTriesToAddUserToGroupWithInvalidHostUsingTheGraphApi(
 		string $adminUser,
 		string $user,
@@ -1514,7 +1517,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When /^the administrator "([^"]*)" tries to add the following users to a nonexistent group at once using the Graph API$/
 	 *
 	 * @param string $user
 	 * @param TableNode $table
@@ -1523,6 +1525,7 @@ class GraphContext implements Context {
 	 * @throws GuzzleException
 	 * @throws Exception
 	 */
+	#[When('the administrator :user tries to add the following users to a nonexistent group at once using the Graph API')]
 	public function theAdministratorTriesToAddsTheFollowingUsersToANonExistingGroupAtOnceUsingTheGraphApi(
 		string $user,
 		TableNode $table
@@ -1538,7 +1541,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When /^the administrator "([^"]*)" tries to add the following nonexistent users to a group "([^"]*)" at once using the Graph API$/
 	 *
 	 * @param string $user
 	 * @param string $group
@@ -1548,6 +1550,7 @@ class GraphContext implements Context {
 	 * @throws GuzzleException
 	 * @throws Exception
 	 */
+	#[When('the administrator :user tries to add the following nonexistent users to a group :group at once using the Graph API')]
 	public function theAdministratorTriesToAddTheFollowingNonExistingUsersToAGroupAtOnceUsingTheGraphApi(
 		string $user,
 		string $group,
@@ -1564,8 +1567,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When /^the administrator "([^"]*)" tries to add the following users to a group "([^"]*)" at once using the Graph API$/
-	 * @When /^the administrator "([^"]*)" tries to add the following existent and nonexistent users to a group "([^"]*)" at once using the Graph API$/
 	 *
 	 * @param string $user
 	 * @param string $group
@@ -1575,6 +1576,7 @@ class GraphContext implements Context {
 	 * @throws GuzzleException
 	 * @throws Exception
 	 */
+	#[When('the administrator :user tries to add the following existent and nonexistent users to a group :group at once using the Graph API')]
 	public function theAdministratorTriesToAddTheFollowingUsersToAGroupAtOnceUsingTheGraphApi(
 		string $user,
 		string $group,
@@ -1592,13 +1594,13 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When user :user gets all applications using the Graph API
 	 *
 	 * @param string $user
 	 *
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('user :user gets all applications using the Graph API')]
 	public function userGetsAllApplicationsUsingTheGraphApi(string $user) {
 		$response = GraphHelper::getApplications(
 			$this->featureContext->getBaseUrl(),
@@ -1610,12 +1612,12 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @Then the user API response should contain the following application information:
 	 *
 	 * @param TableNode $table
 	 *
 	 * @return void
 	 */
+	#[Then('the user API response should contain the following application information:')]
 	public function theResponseShouldContainTheFollowingApplicationInformation(TableNode $table): void {
 		Assert::assertIsArray(
 			$responseArray = (
@@ -1636,12 +1638,12 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @Then the user API response should contain the following app roles:
 	 *
 	 * @param TableNode $table
 	 *
 	 * @return void
 	 */
+	#[Then('the user API response should contain the following app roles:')]
 	public function theResponseShouldContainTheFollowingAppRolesInformation(TableNode $table): void {
 		Assert::assertIsArray(
 			$responseArray = (
@@ -1661,7 +1663,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When the user :user gets all users of the group :group using the Graph API
 	 *
 	 * @param string $user
 	 * @param string $group
@@ -1669,6 +1670,7 @@ class GraphContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('the user :user gets all users of the group :group using the Graph API')]
 	public function userGetsAllUsersOfTheGroupUsingTheGraphApi(string $user, string $group) {
 		$groupId = $this->featureContext->getGroupIdByGroupName($group);
 		$response = GraphHelper::getUsersWithFilterMemberOf(
@@ -1682,7 +1684,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When the user :user gets all users of two groups :groups using the Graph API
 	 *
 	 * @param string $user
 	 * @param string $groups
@@ -1690,6 +1691,7 @@ class GraphContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('the user :user gets all users of two groups :groups using the Graph API')]
 	public function userGetsAllUsersOfTwoGroupsUsingTheGraphApi(string $user, string $groups) {
 		$groupsIdArray = [];
 		foreach (explode(',', $groups) as $group) {
@@ -1706,7 +1708,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When the user :user gets all users that are members in the group :firstGroup or the group :secondGroup using the Graph API
 	 *
 	 * @param string $user
 	 * @param string $firstGroup
@@ -1715,6 +1716,7 @@ class GraphContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('the user :user gets all users that are members in the group :firstGroup or the group :secondGroup using the Graph API')]
 	public function userGetsAllUsersOfFirstGroupOderSecondGroupUsingTheGraphApi(
 		string $user,
 		string $firstGroup,
@@ -1758,7 +1760,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When the user :user gets all users with role :role using the Graph API
 	 *
 	 * @param string $user
 	 * @param string $role
@@ -1766,6 +1767,7 @@ class GraphContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('the user :user gets all users with role :role using the Graph API')]
 	public function userGetsAllUsersWithRoleUsingTheGraphApi(string $user, string $role) {
 		$response = GraphHelper::getUsersWithFilterRoleAssignment(
 			$this->featureContext->getBaseUrl(),
@@ -1778,7 +1780,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When the user :user gets all users with role :role and member of the group :group using the Graph API
 	 *
 	 * @param string $user
 	 * @param string $role
@@ -1787,6 +1788,7 @@ class GraphContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('the user :user gets all users with role :role and member of the group :group using the Graph API')]
 	public function userGetsAllUsersWithRoleAndMemberOfGroupUsingTheGraphApi(
 		string $user,
 		string $role,
@@ -1804,7 +1806,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @Given /^the administrator has assigned the role "([^"]*)" to user "([^"]*)" using the Graph API$/
 	 *
 	 * @param string $role
 	 * @param string $user
@@ -1814,6 +1815,7 @@ class GraphContext implements Context {
 	 * @throws GuzzleException
 	 * @throws Exception
 	 */
+	#[Given('the administrator has assigned the role :role to user :user using the Graph API')]
 	public function theAdministratorHasGivenTheRoleUsingTheGraphApi(string $role, string $user): void {
 		$userId = $this->featureContext->getAttributeOfCreatedUser($user, 'id') ?: $user;
 
@@ -1839,13 +1841,13 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When /^the administrator retrieves the assigned role of user "([^"]*)" using the Graph API$/
 	 *
 	 * @param string $user
 	 *
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('the administrator retrieves the assigned role of user :user using the Graph API')]
 	public function userRetrievesAssignedRoleUsingTheGraphApi(string $user): void {
 		$admin = $this->featureContext->getAdminUserName();
 		$userId = $this->featureContext->getAttributeOfCreatedUser($user, 'id') ?: $user;
@@ -1861,7 +1863,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" tries to get the assigned role of user "([^"]*)" using the Graph API$/
 	 *
 	 * @param string $user
 	 * @param string $ofUser
@@ -1869,6 +1870,7 @@ class GraphContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('user :user tries to get the assigned role of user :ofUser using the Graph API')]
 	public function userTriesToGetAssignedRoleOfUserUsingTheGraphApi(string $user, string $ofUser): void {
 		$credentials = $this->getAdminOrUserCredentials($user);
 		$userId = $this->featureContext->getAttributeOfCreatedUser($ofUser, 'id') ?: $user;
@@ -1907,7 +1909,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @Then /^the Graph API response should have the role "([^"]*)"$/
 	 *
 	 * @param string $role
 	 *
@@ -1915,6 +1916,7 @@ class GraphContext implements Context {
 	 * @throws Exception
 	 * @throws GuzzleException
 	 */
+	#[Then('the Graph API response should have the role :role')]
 	public function theGraphApiResponseShouldHaveTheRole(string $role): void {
 		$response = $this->featureContext->getJsonDecodedResponse($this->featureContext->getResponse())['value'][0];
 		if (empty($this->appEntity)) {
@@ -1930,12 +1932,12 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @Then /^the Graph API response should have no role$/
 	 *
 	 * @return void
 	 * @throws Exception
 	 * @throws GuzzleException
 	 */
+	#[Then('the Graph API response should have no role')]
 	public function theGraphApiResponseShouldHaveNoRole(): void {
 		Assert::assertEmpty(
 			$this->featureContext->getJsonDecodedResponse($this->featureContext->getResponse())['value'],
@@ -1944,13 +1946,13 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When user :user gets details of the group :groupName using the Graph API
 	 *
 	 * @param string $user
 	 * @param string $groupName
 	 *
 	 * @return void
 	 */
+	#[When('user :user gets details of the group :groupName using the Graph API')]
 	public function userGetsDetailsOfTheGroupUsingTheGraphApi(string $user, string $groupName): void {
 		$credentials = $this->getAdminOrUserCredentials($user);
 
@@ -1966,14 +1968,14 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When user :user tries to search for group :searchTerm using Graph API
-	 * @When user :user searches for group :searchTerm using Graph API
 	 *
 	 * @param string $user
 	 * @param string $searchTerm
 	 *
 	 * @return void
 	 */
+	#[When('user :user tries to search for group :searchTerm using Graph API')]
+	#[When('user :user searches for group :searchTerm using Graph API')]
 	public function userSearchesForGroupUsingGraphApi(string $user, string $searchTerm): void {
 		$credentials = $this->getAdminOrUserCredentials($user);
 		$this->featureContext->setResponse(
@@ -1988,8 +1990,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @Then /^the JSON data of the response should (not )?contain the user "([^"]*)" in the item 'value'(?:, the user-details should match)?$/
-	 * @Then /^the JSON data of the response should (not )?contain the group "([^"]*)" in the item 'value'(?:, the group-details should match)?$/
 	 *
 	 * @param string $shouldOrNot (not| )
 	 * @param string $userOrGroup
@@ -1998,6 +1998,8 @@ class GraphContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('/^the JSON data of the response should (not )?contain the user "([^"]*)" in the item \'value\'(?:, the user-details should match)?$/')]
+	#[Then('/^the JSON data of the response should (not )?contain the group "([^"]*)" in the item \'value\'(?:, the group-details should match)?$/')]
 	public function theJsonDataResponseShouldOrNotContainUserOrGroupAndMatch(
 		string $shouldOrNot,
 		string $userOrGroup,
@@ -2027,7 +2029,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @Given /^the administrator "([^"]*)" has added the following users to a group "([^"]*)" at once using the Graph API$/
 	 *
 	 * @param string $user
 	 * @param string $group
@@ -2037,6 +2038,7 @@ class GraphContext implements Context {
 	 * @throws GuzzleException
 	 * @throws Exception
 	 */
+	#[Given('the administrator :user has added the following users to a group :group at once using the Graph API')]
 	public function theAdministratorHasAddedTheFollowingUsersToAGroupAtOnceUsingTheGraphApi(
 		string $user,
 		string $group,
@@ -2053,7 +2055,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When /^the administrator "([^"]*)" tries to add a group "([^"]*)" to another group "([^"]*)" with PATCH request using the Graph API$/
 	 *
 	 * @param string $user
 	 * @param string $groupToAdd
@@ -2063,6 +2064,7 @@ class GraphContext implements Context {
 	 * @throws GuzzleException
 	 * @throws Exception
 	 */
+	#[When('the administrator :user tries to add a group :groupToAdd to another group :group with PATCH request using the Graph API')]
 	public function theAdministratorTriesToAddGroupToAGroupAtOnceUsingTheGraphApi(
 		string $user,
 		string $groupToAdd,
@@ -2091,7 +2093,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When /^the administrator "([^"]*)" tries to add a group "([^"]*)" to another group "([^"]*)" with POST request using the Graph API$/
 	 *
 	 * @param string $user
 	 * @param string $groupToAdd
@@ -2101,6 +2102,7 @@ class GraphContext implements Context {
 	 * @throws GuzzleException
 	 * @throws Exception
 	 */
+	#[When('the administrator :user tries to add a group :groupToAdd to another group :group with POST request using the Graph API')]
 	public function theAdministratorTriesToAddAGroupToAGroupThroughPostRequestUsingTheGraphApi(
 		string $user,
 		string $groupToAdd,
@@ -2127,7 +2129,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" tries to add user "([^"]*)" to group "([^"]*)" with invalid JSON "([^"]*)" using the Graph API$/
 	 *
 	 * @param string $adminUser
 	 * @param string $user
@@ -2138,6 +2139,7 @@ class GraphContext implements Context {
 	 * @throws Exception
 	 * @throws GuzzleException
 	 */
+	#[When('user :adminUser tries to add user :user to group :group with invalid JSON :invalidJSON using the Graph API')]
 	public function userTriesToAddUserToGroupWithInvalidJsonUsingTheGraphApi(
 		string $adminUser,
 		string $user,
@@ -2169,7 +2171,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" tries to add the following users to a group "([^"]*)" at once with invalid JSON "([^"]*)" using the Graph API$/
 	 *
 	 * @param string $user
 	 * @param string $group
@@ -2180,6 +2181,7 @@ class GraphContext implements Context {
 	 * @throws Exception
 	 * @throws GuzzleException
 	 */
+	#[When('user :user tries to add the following users to a group :group at once with invalid JSON :invalidJSON using the Graph API')]
 	public function userTriesToAddTheFollowingUsersToAGroupAtOnceWithInvalidJsonUsingTheGraphApi(
 		string $user,
 		string $group,
@@ -2213,7 +2215,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When /^the administrator "([^"]*)" tries to add the following invalid user ids to a group "([^"]*)" at once using the Graph API$/
 	 *
 	 * @param string $user
 	 * @param string $group
@@ -2223,6 +2224,7 @@ class GraphContext implements Context {
 	 * @throws GuzzleException
 	 * @throws Exception
 	 */
+	#[When('the administrator :user tries to add the following invalid user ids to a group :group at once using the Graph API')]
 	public function theAdministratorTriesToAddTheFollowingUserIdWithInvalidCharacterToAGroup(
 		string $user,
 		string $group,
@@ -2247,7 +2249,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When /^the administrator "([^"]*)" tries to add an invalid user id "([^"]*)" to a group "([^"]*)" using the Graph API$/
 	 *
 	 * @param string $user
 	 * @param string $userId
@@ -2257,6 +2258,7 @@ class GraphContext implements Context {
 	 * @throws GuzzleException
 	 * @throws Exception
 	 */
+	#[When('the administrator :user tries to add an invalid user id :userId to a group :group using the Graph API')]
 	public function theAdministratorTriesToAddUserIdWithInvalidCharactersToAGroup(
 		string $user,
 		string $userId,
@@ -2277,7 +2279,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @Then the user :user should be listed once in the group :group
 	 *
 	 * @param string $user
 	 * @param string $group
@@ -2285,6 +2286,7 @@ class GraphContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[Then('the user :user should be listed once in the group :group')]
 	public function theUsersShouldBeListedOnceToAGroup(string $user, string $group): void {
 		$count = 0;
 		$members = $this->listGroupMembers($group);
@@ -2304,14 +2306,14 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" gets the personal drive information of user "([^"]*)" using Graph API$/
-	 * @When /^user "([^"]*)" gets own personal drive information using Graph API$/
 	 *
 	 * @param string $byUser
 	 * @param string|null $user
 	 *
 	 * @return  void
 	 */
+	#[When('user :byUser gets the personal drive information of user :user using Graph API')]
+	#[When('user :byUser gets own personal drive information using Graph API')]
 	public function userGetsThePersonalDriveInformationOfUserUsingGraphApi(string $byUser, ?string $user = null): void {
 		$user = $user ?? $byUser;
 		$credentials = $this->getAdminOrUserCredentials($byUser);
@@ -2328,7 +2330,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" exports (?:her|his) GDPR report to "([^"]*)" using the Graph API$/
 	 *
 	 * @param string $user
 	 * @param string $path
@@ -2336,6 +2337,7 @@ class GraphContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('/^user "([^"]*)" exports (?:her|his) GDPR report to "([^"]*)" using the Graph API$/')]
 	public function userGeneratesGDPRReportOfOwnDataToPath(string $user, string $path): void {
 		$credentials = $this->getAdminOrUserCredentials($user);
 		$userId = $this->featureContext->getAttributeOfCreatedUser($user, 'id');
@@ -2353,8 +2355,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @Then the downloaded JSON content should contain event type :eventType in item 'events' and should match
-	 * @Then the downloaded JSON content should contain event type :eventType for :spaceType space and should match
 	 *
 	 * @param string $eventType
 	 * @param string|null $spaceType
@@ -2364,6 +2364,8 @@ class GraphContext implements Context {
 	 * @throws Exception
 	 *
 	 */
+	#[Then('the downloaded JSON content should contain event type :eventType in item \'events\' and should match')]
+	#[Then('the downloaded JSON content should contain event type :eventType for :spaceType space and should match')]
 	public function downloadedJsonContentShouldContainEventTypeInItemAndShouldMatch(
 		string $eventType,
 		?string $spaceType=null,
@@ -2396,7 +2398,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @Then the downloaded JSON content should contain key 'user' and match
 	 *
 	 * @param PyStringNode $schemaString
 	 *
@@ -2404,6 +2405,7 @@ class GraphContext implements Context {
 	 * @throws GuzzleException
 	 *
 	 */
+	#[Then('the downloaded JSON content should contain key \'user\' and match')]
 	public function downloadedJsonContentShouldContainKeyUserAndMatch(PyStringNode $schemaString): void {
 		$actualResponseToAssert = $this->featureContext->getJsonDecodedResponseBodyContent();
 		if (!isset($actualResponseToAssert->user)) {
@@ -2418,7 +2420,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When user :user tries to export GDPR report of user :ofUser to :path using Graph API
 	 *
 	 * @param string $user
 	 * @param string $ofUser
@@ -2427,6 +2428,7 @@ class GraphContext implements Context {
 	 * @return void
 	 *
 	 */
+	#[When('user :user tries to export GDPR report of user :ofUser to :path using Graph API')]
 	public function userTriesToExportGdprReportOfAnotherUserUsingGraphApi(
 		string $user,
 		string $ofUser,
@@ -2465,7 +2467,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" (?:unassigns|tries to unassign) the role of user "([^"]*)" using the Graph API$/
 	 *
 	 * @param string $user
 	 * @param string $ofUser
@@ -2475,6 +2476,7 @@ class GraphContext implements Context {
 	 * @throws GuzzleException
 	 * @throws Exception
 	 */
+	#[When('/^user "([^"]*)" (?:unassigns|tries to unassign) the role of user "([^"]*)" using the Graph API$/')]
 	public function theUserUnassignsTheRoleOfUserUsingTheGraphApi(string $user, string $ofUser): void {
 		$credentials = $this->getAdminOrUserCredentials($user);
 		$userId = $this->featureContext->getAttributeOfCreatedUser($ofUser, 'id');
@@ -2503,7 +2505,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @Then user :user should have the role :role assigned
 	 *
 	 * @param string $user
 	 * @param string $role
@@ -2512,6 +2513,7 @@ class GraphContext implements Context {
 	 * @throws GuzzleException
 	 * @throws Exception
 	 */
+	#[Then('user :user should have the role :role assigned')]
 	public function userShouldHaveTheRoleAssigned(string $user, string $role): void {
 		$jsonDecodedResponse = $this->featureContext->getJsonDecodedResponse($this->getAssignedRole($user))['value'][0];
 		if (empty($this->appEntity)) {
@@ -2527,7 +2529,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @Then user :user should not have any role assigned
 	 *
 	 * @param string $user
 	 *
@@ -2535,6 +2536,7 @@ class GraphContext implements Context {
 	 * @throws GuzzleException
 	 * @throws Exception
 	 */
+	#[Then('user :user should not have any role assigned')]
 	public function userShouldNotHaveAnyRoleAssigned(string $user): void {
 		$jsonDecodedResponse = $this->featureContext->getJsonDecodedResponse($this->getAssignedRole($user))['value'];
 		Assert::assertEmpty(
@@ -2545,8 +2547,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When user :user changes the role of user :ofUser to role :role using the Graph API
-	 * @When user :user tries to change the role of user :ofUser to role :role using the Graph API
 	 *
 	 * @param string $user
 	 * @param string $ofUser
@@ -2557,6 +2557,8 @@ class GraphContext implements Context {
 	 * @throws GuzzleException
 	 * @throws Exception
 	 */
+	#[When('user :user changes the role of user :ofUser to role :role using the Graph API')]
+	#[When('user :user tries to change the role of user :ofUser to role :role using the Graph API')]
 	public function userChangesTheRoleOfUserToRoleUsingTheGraphApi(string $user, string $ofUser, string $role): void {
 		$userId = $this->featureContext->getAttributeOfCreatedUser($ofUser, 'id') ?: $ofUser;
 		$credentials = $this->getAdminOrUserCredentials($user);
@@ -2578,7 +2580,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @Given user :user has switched the system language to :language using the Graph API
 	 *
 	 * @param string $user
 	 * @param string $language
@@ -2586,6 +2587,7 @@ class GraphContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[Given('user :user has switched the system language to :language using the Graph API')]
 	public function userHasSwitchedTheSystemLanguageUsingGraphApi(string $user, string $language): void {
 		$credentials = $this->getAdminOrUserCredentials($user);
 		$response =  GraphHelper::switchSystemLanguage(
@@ -2603,7 +2605,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When user :user switches the system language to :language using the Graph API
 	 *
 	 * @param string $user
 	 * @param string $language
@@ -2611,6 +2612,7 @@ class GraphContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('user :user switches the system language to :language using the Graph API')]
 	public function userSwitchesTheSystemLanguageUsingGraphApi(string $user, string $language): void {
 		$credentials = $this->getAdminOrUserCredentials($user);
 		$this->featureContext->setResponse(
@@ -2625,7 +2627,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" lists the shares shared with (?:him|her)(| after clearing user cache)(| without retry) using the Graph API$/
 	 *
 	 * @param string $user
 	 * @param string $cacheStepString
@@ -2634,6 +2635,7 @@ class GraphContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('/^user "([^"]*)" lists the shares shared with (?:him|her)(| after clearing user cache)(| without retry) using the Graph API$/')]
 	public function userListsTheResourcesSharedWithThemUsingGraphApi(
 		string $user,
 		string $cacheStepString,
@@ -2711,33 +2713,32 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When user :user lists the shares shared by him/her using the Graph API
 	 *
 	 * @param string $user
 	 *
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('user :user lists the shares shared by him/her using the Graph API')]
 	public function userListsTheResourcesSharedByAUserUsingGraphApi(string $user): void {
 		$response = $this->listSharesSharedByMe($user);
 		$this->featureContext->setResponse($response);
 	}
 
 	/**
-	 * @When user :user lists the shares shared by him/her after clearing user/group cache using the Graph API
 	 *
 	 * @param string $user
 	 *
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('user :user lists the shares shared by him/her after clearing user/group cache using the Graph API')]
 	public function userListsTheResourcesSharedByAUserAfterClearingUserOrGroupSpaceUsingGraphApi(string $user): void {
 		$response = $this->listSharesSharedByMe($user, true);
 		$this->featureContext->setResponse($response);
 	}
 
 	/**
-	 * @Then /^the JSON data of the response should (not )?contain resource "([^"]*)" with the following data:?$/
 	 *
 	 * @param string $shouldOrNot (not| )
 	 * @param string $fileName
@@ -2746,6 +2747,7 @@ class GraphContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('/^the JSON data of the response should (not )?contain resource "([^"]*)" with the following data:?$/')]
 	public function theJsonDataResponseShouldOrNotContainSharedByMeDetails(
 		string $shouldOrNot,
 		string $fileName,
@@ -2775,11 +2777,11 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @Then the JSON data of the search response should not contain user(s) email
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('the JSON data of the search response should not contain user(s) email')]
 	public function theJsonDataResponseShouldNotContainUserEmail(): void {
 		$responseBody = $this->featureContext->getJsonDecodedResponseBodyContent()->value;
 		$mailValueExist = false;
@@ -2798,7 +2800,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @Then user :byUser using password :password should be able to create a new user :user with default attributes
 	 *
 	 * @param string $byUser
 	 * @param string $password
@@ -2808,6 +2809,7 @@ class GraphContext implements Context {
 	 * @throws GuzzleException
 	 * @throws JsonException
 	 */
+	#[Then('user :byUser using password :password should be able to create a new user :user with default attributes')]
 	public function userUsingPasswordShouldBeAbleToCreateANewUserWithDefaultAttributes(
 		string $byUser,
 		string $password,
@@ -2841,7 +2843,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @Given user :byUser has changed the username to :userName
 	 *
 	 * @param string $byUser
 	 * @param string $userName
@@ -2850,6 +2851,7 @@ class GraphContext implements Context {
 	 * @throws GuzzleException
 	 * @throws JsonException
 	 */
+	#[Given('user :byUser has changed the username to :userName')]
 	public function theUserHasChangedItsOwnUsernameTo(string $byUser, string $userName): void {
 		$userId = $this->featureContext->getAttributeOfCreatedUser($byUser, 'id');
 		$response = GraphHelper::editUser(
@@ -2867,13 +2869,13 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When user :user gets a list of permissions role definitions using the Graph API
 	 *
 	 * @param string $user
 	 *
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('user :user gets a list of permissions role definitions using the Graph API')]
 	public function getListOfPermissionRoleDefinitionsUsingTheGraphAPI(string $user): void {
 		$credentials = $this->getAdminOrUserCredentials($user);
 		$this->featureContext->setResponse(
@@ -2887,7 +2889,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When user :user gets the :permissionRole role definition using the Graph API
 	 *
 	 * @param string $user
 	 * @param string $permissionRole
@@ -2896,6 +2897,7 @@ class GraphContext implements Context {
 	 * @throws GuzzleException
 	 * @throws Exception
 	 */
+	#[When('user :user gets the :permissionRole role definition using the Graph API')]
 	public function getPermissionRoleDefinitionUsingGraphAPI(string $user, string $permissionRole): void {
 		$credentials = $this->getAdminOrUserCredentials($user);
 		$this->featureContext->setResponse(
@@ -2910,7 +2912,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" lists the activities of (?:folder|file) "([^"]*)" from space "([^"]*)" using the Graph API$/
 	 *
 	 * @param string $user
 	 * @param string $resource
@@ -2919,6 +2920,7 @@ class GraphContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('/^user "([^"]*)" lists the activities of (?:folder|file) "([^"]*)" from space "([^"]*)" using the Graph API$/')]
 	public function userListsTheActivitiesForResourceOfSpaceUsingTheGraphAPI(
 		string $user,
 		string $resource,
@@ -2936,13 +2938,13 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When user :user tries to list the activities of folder :folder with share mount-point id using the Graph API
 	 *
 	 * @param string $user
 	 * @param string $folder
 	 *
 	 * @return void
 	 */
+	#[When('user :user tries to list the activities of folder :folder with share mount-point id using the Graph API')]
 	public function userTriesToListTheActivitiesOfFolderWithShareMountIdPointIdUsingTheGraphApi(
 		string $user,
 		string $folder
@@ -2965,7 +2967,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When user :user tries to list the activities of file :file from space :spaceName owned by user :owner using the Graph API
 	 *
 	 * @param string $user
 	 * @param string $file
@@ -2974,6 +2975,7 @@ class GraphContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[When('user :user tries to list the activities of file :file from space :spaceName owned by user :owner using the Graph API')]
 	public function userTriesToListActivitiesOfFileFromSpaceOwnedByUserUsingTheGraphApi(
 		string $user,
 		string $file,
@@ -2992,13 +2994,13 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When user :user lists the activities of space :spaceName using the Graph API
 	 *
 	 * @param string $user
 	 * @param string $spaceName
 	 *
 	 * @return void
 	 */
+	#[When('user :user lists the activities of space :spaceName using the Graph API')]
 	public function userListsTheActivitiesOfProjectSpaceUsingTheGraphApi(string $user, string $spaceName): void {
 		$spaceId = ($this->featureContext->spacesContext->getSpaceByName($user, $spaceName))["id"];
 		$response = GraphHelper::getActivities(
@@ -3012,12 +3014,12 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When user :user lists the activities of personal space using the Graph API
 	 *
 	 * @param string $user
 	 *
 	 * @return void
 	 */
+	#[When('user :user lists the activities of personal space using the Graph API')]
 	public function userListsTheActivitiesOfPersonalSpaceUsingTheGraphApi(string $user): void {
 		$space = $this->featureContext->spacesContext->getPersonalSpace($user);
 		$response = GraphHelper::getActivities(
@@ -3031,7 +3033,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When the public tries to check the activities of space :spaceName owned by user :user with password :password using the Graph API
 	 *
 	 * @param string $spaceName
 	 * @param string $user
@@ -3039,6 +3040,7 @@ class GraphContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[When('the public tries to check the activities of space :spaceName owned by user :user with password :password using the Graph API')]
 	public function thePublicTriesToCheckTheActivitiesOfSpaceOwnedByUserWithPasswordUsingGraphApi(
 		string $spaceName,
 		string $user,
@@ -3055,7 +3057,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When /^the public tries to check the activities of (?:folder|file) "([^"]*)" from space "([^"]*)" owned by user "([^"]*)" with password "([^"]*)" using the Graph API$/
 	 *
 	 * @param string $resource
 	 * @param string $space
@@ -3064,6 +3065,7 @@ class GraphContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[When('/^the public tries to check the activities of (?:folder|file) "([^"]*)" from space "([^"]*)" owned by user "([^"]*)" with password "([^"]*)" using the Graph API$/')]
 	public function thePublicTriesToCheckTheActivitiesOfResourceFromSpaceOwnedByUserWithPasswordUsingGraphApi(
 		string $resource,
 		string $space,
@@ -3081,7 +3083,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" lists the activities of (?:folder|file) "([^"]*)" from space "([^"]*)" with (depth|limit|sort) "([^"]*)" using the Graph API$/
 	 *
 	 * @param string $user
 	 * @param string $resource
@@ -3091,6 +3092,7 @@ class GraphContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[When('/^user "([^"]*)" lists the activities of (?:folder|file) "([^"]*)" from space "([^"]*)" with (depth|limit|sort) "([^"]*)" using the Graph API$/')]
 	public function userListsTheActivitiesForFolderOfSpaceWithDepthOrLimitUsingTheGraphApi(
 		string $user,
 		string $resource,
@@ -3111,13 +3113,13 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @Then the activities should be in the following order:
 	 *
 	 * @param TableNode $table
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('the activities should be in the following order:')]
 	public function theActivitiesShouldBeInTheFollowingOrder(TableNode $table): void {
 		$responseBody = $this->featureContext->getJsonDecodedResponseBodyContent();
 		$activities = $responseBody->value;
@@ -3132,7 +3134,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" lists the activities of (?:folder|file) "([^"]*)" from space "([^"]*)" with (depth|limit) "([^"]*)" and sort "(asc|desc)" using the Graph API$/
 	 *
 	 * @param string $user
 	 * @param string $resource
@@ -3144,6 +3145,7 @@ class GraphContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('/^user "([^"]*)" lists the activities of (?:folder|file) "([^"]*)" from space "([^"]*)" with (depth|limit) "([^"]*)" and sort "(asc|desc)" using the Graph API$/')]
 	public function userListsTheActivitiesOfResourceFromSpaceWithDepthOrLimitAndSortUsingTheGraphApi(
 		string $user,
 		string $resource,
@@ -3165,13 +3167,13 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When the administrator gets federated users using the Graph API
-	 * @When user :user tries to get federated users using the Graph API
 	 *
 	 * @param ?string $user
 	 *
 	 * @return void
 	 */
+	#[When('the administrator gets federated users using the Graph API')]
+	#[When('user :user tries to get federated users using the Graph API')]
 	public function theUserGetsFederatedUsersUsingTheGraphApi(?string $user = null): void {
 		$credentials = $this->getAdminOrUserCredentials($user);
 
@@ -3186,13 +3188,12 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When the administrator gets federated and local users using the Graph API
-	 * @When user :user tries to get federated and local users using the Graph API
 	 *
 	 * @param ?string $user
 	 *
 	 * @return void
 	 */
+	#[When('the administrator gets federated and local users using the Graph API')]
 	public function theUserGetsAllUsersUsingTheGraphApi(?string $user = null): void {
 		$credentials = $this->getAdminOrUserCredentials($user);
 
@@ -3244,7 +3245,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When user :user marks :item :itemName as favorite from space :spaceName using the Graph API
 	 *
 	 * @param string $user
 	 * @param string $item (file|folder)
@@ -3253,6 +3253,7 @@ class GraphContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[When('user :user marks :item :itemName as favorite from space :spaceName using the Graph API')]
 	public function userMarksItemFromSpaceAsFavoriteUsingTheGraphApi(
 		string $user,
 		string $item,
@@ -3266,7 +3267,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When user :user unmarks :item :itemName as favorite from space :spaceName using the Graph API
 	 *
 	 * @param string $user
 	 * @param string $item (file|folder)
@@ -3275,6 +3275,7 @@ class GraphContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[When('user :user unmarks :item :itemName as favorite from space :spaceName using the Graph API')]
 	public function userUnmarksItemFromSpaceAsFavoriteUsingTheGraphApi(
 		string $user,
 		string $item,
@@ -3288,7 +3289,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @Given user :user has marked :item :itemName as favorite from space :spaceName
 	 *
 	 * @param string $user
 	 * @param string $item (folder|file)
@@ -3297,6 +3297,7 @@ class GraphContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[Given('user :user has marked :item :itemName as favorite from space :spaceName')]
 	public function userHasMarkedItemFromSpaceAsFavoriteUsingTheGraphApi(
 		string $user,
 		string $item,
@@ -3312,7 +3313,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @Given user :user has unmarked :item :itemName as favorite from space :spaceName
 	 *
 	 * @param string $user
 	 * @param string $item (folder|file)
@@ -3321,6 +3321,7 @@ class GraphContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[Given('user :user has unmarked :item :itemName as favorite from space :spaceName')]
 	public function userHasUnmarkedItemFromSpaceAsFavoriteUsingTheGraphApi(
 		string $user,
 		string $item,
@@ -3369,8 +3370,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" gets the drive item with colon path "([^"]*)" of space "([^"]*)" using the Graph API version "(v1\.0|v1beta1)"$/
-	 *
 	 * Hits /graph/{version}/drives/{driveID}/root:/{path}, exercising the
 	 * colon-syntax path lookup middleware (root-anchored, no suffix).
 	 *
@@ -3381,6 +3380,7 @@ class GraphContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[When('/^user "([^"]*)" gets the drive item with colon path "([^"]*)" of space "([^"]*)" using the Graph API version "(v1\\.0|v1beta1)"$/')]
 	public function userGetsDriveItemWithColonPathOfSpace(
 		string $user,
 		string $path,
@@ -3394,8 +3394,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" gets the drive item with colon path "([^"]*)" of space "([^"]*)" with trailing colon using the Graph API version "(v1\.0|v1beta1)"$/
-	 *
 	 * Hits /graph/{version}/drives/{driveID}/root:/{path}: with the optional
 	 * trailing ":" — verifies the middleware accepts both forms.
 	 *
@@ -3406,6 +3404,7 @@ class GraphContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[When('/^user "([^"]*)" gets the drive item with colon path "([^"]*)" of space "([^"]*)" with trailing colon using the Graph API version "(v1\\.0|v1beta1)"$/')]
 	public function userGetsDriveItemWithColonPathOfSpaceWithTrailingColon(
 		string $user,
 		string $path,
@@ -3419,8 +3418,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" gets the drive item with colon path "([^"]*)" relative to folder "([^"]*)" of space "([^"]*)" using the Graph API version "(v1\.0|v1beta1)"$/
-	 *
 	 * Hits /graph/{version}/drives/{driveID}/items/{itemID}:/{relPath}, the
 	 * item-anchored colon-syntax form.
 	 *
@@ -3432,6 +3429,7 @@ class GraphContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[When('/^user "([^"]*)" gets the drive item with colon path "([^"]*)" relative to folder "([^"]*)" of space "([^"]*)" using the Graph API version "(v1\\.0|v1beta1)"$/')]
 	public function userGetsDriveItemWithColonPathRelativeToFolderOfSpace(
 		string $user,
 		string $relPath,
@@ -3447,8 +3445,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" lists permissions of the drive item with colon path "([^"]*)" of space "([^"]*)" using the Graph API version "(v1\.0|v1beta1)"$/
-	 *
 	 * Hits /graph/{version}/drives/{driveID}/root:/{path}:/permissions, the
 	 * "colon path with suffix" form (root-anchored colon path + canonical
 	 * sub-route).
@@ -3460,6 +3456,7 @@ class GraphContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[When('/^user "([^"]*)" lists permissions of the drive item with colon path "([^"]*)" of space "([^"]*)" using the Graph API version "(v1\\.0|v1beta1)"$/')]
 	public function userListsPermissionsOfDriveItemWithColonPathOfSpace(
 		string $user,
 		string $path,
@@ -3473,8 +3470,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" gets the drive item with colon path "([^"]*)" of the personal space of "([^"]*)" using the Graph API version "(v1\.0|v1beta1)"$/
-	 *
 	 * Same as userGetsDriveItemWithColonPathOfSpace, but the request is
 	 * issued by :user against the personal space drive ID of :owner. Used
 	 * for security tests where one user attempts to reach another user's
@@ -3488,6 +3483,7 @@ class GraphContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[When('/^user "([^"]*)" gets the drive item with colon path "([^"]*)" of the personal space of "([^"]*)" using the Graph API version "(v1\\.0|v1beta1)"$/')]
 	public function userGetsDriveItemWithColonPathOfPersonalSpaceOf(
 		string $user,
 		string $path,

--- a/tests/acceptance/bootstrap/NotificationContext.php
+++ b/tests/acceptance/bootstrap/NotificationContext.php
@@ -16,6 +16,9 @@ use TestHelpers\OcsApiHelper;
 use TestHelpers\GraphHelper;
 use TestHelpers\SettingsHelper;
 use TestHelpers\BehatHelper;
+use Behat\Step\Given;
+use Behat\Step\Then;
+use Behat\Step\When;
 
 require_once 'bootstrap.php';
 
@@ -128,12 +131,12 @@ class NotificationContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" lists all notifications$/
 	 *
 	 * @param string $user
 	 *
 	 * @return void
 	 */
+	#[When('user :user lists all notifications')]
 	public function userListAllNotifications(string $user): void {
 		$response = $this->listAllNotifications($user);
 		$this->featureContext->setResponse($response);
@@ -160,7 +163,6 @@ class NotificationContext implements Context {
 	}
 
 	/**
-	 * @When user :user deletes all notifications
 	 *
 	 * @param string $user
 	 *
@@ -168,13 +170,13 @@ class NotificationContext implements Context {
 	 * @throws GuzzleException
 	 * @throws JsonException
 	 */
+	#[When('user :user deletes all notifications')]
 	public function userDeletesAllNotifications(string $user): void {
 		$response = $this->deleteAllNotifications($user);
 		$this->featureContext->setResponse($response);
 	}
 
 	/**
-	 * @Given user :user has deleted all notifications
 	 *
 	 * @param string $user
 	 *
@@ -182,13 +184,13 @@ class NotificationContext implements Context {
 	 * @throws GuzzleException
 	 * @throws JsonException
 	 */
+	#[Given('user :user has deleted all notifications')]
 	public function userHasDeletedAllNotifications(string $user): void {
 		$response = $this->deleteAllNotifications($user);
 		$this->featureContext->theHTTPStatusCodeShouldBe(200, "", $response);
 	}
 
 	/**
-	 * @When user :user deletes a notification related to resource :resource with subject :subject
 	 *
 	 * @param string $user
 	 * @param string $resource
@@ -198,6 +200,7 @@ class NotificationContext implements Context {
 	 * @throws GuzzleException
 	 * @throws JsonException
 	 */
+	#[When('user :user deletes a notification related to resource :resource with subject :subject')]
 	public function userDeletesNotificationOfResourceAndSubject(string $user, string $resource, string $subject): void {
 		$response = $this->listAllNotifications($user);
 		$this->filterNotificationsBySubjectAndResource($subject, $resource, $response);
@@ -229,11 +232,11 @@ class NotificationContext implements Context {
 	}
 
 	/**
-	 * @Then the notifications should be empty
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('the notifications should be empty')]
 	public function theNotificationsShouldBeEmpty(): void {
 		$statusCode = $this->featureContext->getResponse()->getStatusCode();
 		if ($statusCode !== 200) {
@@ -248,13 +251,13 @@ class NotificationContext implements Context {
 	}
 
 	/**
-	 * @Then user :user should not have any notification
 	 *
 	 * @param $user
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('user :user should not have any notification')]
 	public function userShouldNotHaveAnyNotification($user): void {
 		$response = $this->listAllNotifications($user);
 		$notifications = $this->featureContext->getJsonDecodedResponseBodyContent($response)->ocs->data;
@@ -262,13 +265,13 @@ class NotificationContext implements Context {
 	}
 
 	/**
-	 * @Then /^there should be "([^"]*)" notifications$/
 	 *
 	 * @param int $numberOfNotification
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('there should be :numberOfNotification notifications')]
 	public function userShouldHaveNotifications(int $numberOfNotification): void {
 		if (!isset($this->featureContext->getJsonDecodedResponseBodyContent()->ocs->data)) {
 			throw new Exception("Notification is empty");
@@ -283,7 +286,6 @@ class NotificationContext implements Context {
 	}
 
 	/**
-	 * @Then /^the JSON response should contain a notification message with the subject "([^"]*)" and the message-details should match$/
 	 *
 	 * @param string $subject
 	 * @param PyStringNode $schemaString
@@ -291,6 +293,7 @@ class NotificationContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('the JSON response should contain a notification message with the subject :subject and the message-details should match')]
 	public function theJsonDataFromLastResponseShouldMatch(
 		string $subject,
 		PyStringNode $schemaString
@@ -377,7 +380,6 @@ class NotificationContext implements Context {
 	}
 
 	/**
-	 * @Then /^user "([^"]*)" should get a notification with subject "([^"]*)" and message:$/
 	 *
 	 * @param string $user
 	 * @param string $subject
@@ -386,6 +388,7 @@ class NotificationContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('user :user should get a notification with subject :subject and message:')]
 	public function userShouldGetANotificationWithMessage(string $user, string $subject, TableNode $table): void {
 		$count = 0;
 		// Sometimes the test might try to get the notifications before the server has created the notification.
@@ -419,7 +422,6 @@ class NotificationContext implements Context {
 	}
 
 	/**
-	 * @Then user :user should get a notification for resource :resource with subject :subject and message:
 	 *
 	 * @param string $user
 	 * @param string $resource
@@ -429,6 +431,7 @@ class NotificationContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('user :user should get a notification for resource :resource with subject :subject and message:')]
 	public function userShouldGetNotificationForResourceWithMessage(
 		string $user,
 		string $resource,
@@ -462,7 +465,6 @@ class NotificationContext implements Context {
 	}
 
 	/**
-	 * @Then user :user should not get a notification related to resource :resource with subject :subject
 	 *
 	 * @param string $user
 	 * @param string $resource
@@ -470,6 +472,7 @@ class NotificationContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[Then('user :user should not get a notification related to resource :resource with subject :subject')]
 	public function userShouldNotHaveANotificationRelatedToResourceWithSubject(
 		string $user,
 		string $resource,
@@ -486,7 +489,6 @@ class NotificationContext implements Context {
 	}
 
 	/**
-	 * @Then user :user should have received the following email from user :sender about the share of project space :spaceName
 	 *
 	 * @param string $user
 	 * @param string $sender
@@ -496,6 +498,7 @@ class NotificationContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('user :user should have received the following email from user :sender about the share of project space :spaceName')]
 	public function userShouldHaveReceivedTheFollowingEmailFromUserAboutTheShareOfProjectSpace(
 		string $user,
 		string $sender,
@@ -529,7 +532,6 @@ class NotificationContext implements Context {
 	}
 
 	/**
-	 * @Then user :user should have received the following email from user :sender
 	 *
 	 * @param string $user
 	 * @param string $sender
@@ -538,6 +540,7 @@ class NotificationContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('user :user should have received the following email from user :sender')]
 	public function userShouldHaveReceivedTheFollowingEmailFromUser(
 		string $user,
 		string $sender,
@@ -552,7 +555,6 @@ class NotificationContext implements Context {
 	}
 
 	/**
-	 * @Then user :user should have received the following email from user :sender ignoring whitespaces
 	 *
 	 * @param string $user
 	 * @param string $sender
@@ -561,6 +563,7 @@ class NotificationContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('user :user should have received the following email from user :sender ignoring whitespaces')]
 	public function userShouldHaveReceivedTheFollowingEmailFromUserIgnoringWhitespaces(
 		string $user,
 		string $sender,
@@ -692,8 +695,6 @@ class NotificationContext implements Context {
 	}
 
 	/**
-	 * @When the administrator creates a deprovisioning notification
-	 * @When user :user tries to create a deprovisioning notification
 	 *
 	 * @param string|null $user
 	 *
@@ -702,6 +703,8 @@ class NotificationContext implements Context {
 	 * @throws GuzzleException
 	 * @throws JsonException
 	 */
+	#[When('the administrator creates a deprovisioning notification')]
+	#[When('user :user tries to create a deprovisioning notification')]
 	public function theAdministratorCreatesADeprovisioningNotification(?string $user = null) {
 		$response = $this->userCreatesDeprovisioningNotification($user);
 		$this->featureContext->setResponse($response);
@@ -709,7 +712,6 @@ class NotificationContext implements Context {
 	}
 
 	/**
-	 * @When the administrator creates a deprovisioning notification for date :deprovision_date of format :deprovision_date_format
 	 *
 	 * @param $deprovision_date
 	 * @param $deprovision_date_format
@@ -719,6 +721,7 @@ class NotificationContext implements Context {
 	 * @throws GuzzleException
 	 * @throws JsonException
 	 */
+	#[When('the administrator creates a deprovisioning notification for date :deprovision_date of format :deprovision_date_format')]
 	public function theAdministratorCreatesADeprovisioningNotificationUsingDateFormat(
 		$deprovision_date,
 		$deprovision_date_format
@@ -729,23 +732,23 @@ class NotificationContext implements Context {
 	}
 
 	/**
-	 * @Given the administrator has created a deprovisioning notification
 	 *
 	 * @return void
 	 */
+	#[Given('the administrator has created a deprovisioning notification')]
 	public function userHasCreatedDeprovisioningNotification(): void {
 		$response = $this->userCreatesDeprovisioningNotification();
 		$this->featureContext->theHTTPStatusCodeShouldBe(200, "", $response);
 	}
 
 	/**
-	 * @When the administrator deletes the deprovisioning notification
-	 * @When user :user tries to delete the deprovisioning notification
 	 *
 	 * @param string|null $user
 	 *
 	 * @return void
 	 */
+	#[When('the administrator deletes the deprovisioning notification')]
+	#[When('user :user tries to delete the deprovisioning notification')]
 	public function userDeletesDeprovisioningNotification(?string $user = null): void {
 		$payload["ids"] = ["deprovision"];
 

--- a/tests/acceptance/bootstrap/OCSContext.php
+++ b/tests/acceptance/bootstrap/OCSContext.php
@@ -20,7 +20,6 @@
 
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
-use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\TableNode;
 use Psr\Http\Message\ResponseInterface;
 use PHPUnit\Framework\Assert;
@@ -28,6 +27,8 @@ use TestHelpers\HttpRequestHelper;
 use TestHelpers\OcsApiHelper;
 use TestHelpers\TranslationHelper;
 use TestHelpers\BehatHelper;
+use Behat\Step\Then;
+use Behat\Step\When;
 
 require_once 'bootstrap.php';
 
@@ -38,21 +39,6 @@ class OCSContext implements Context {
 	private FeatureContext $featureContext;
 
 	/**
-	 * @When /^the user sends HTTP method "([^"]*)" to OCS API endpoint "([^"]*)"$/
-	 *
-	 * @param string $verb
-	 * @param string $url
-	 *
-	 * @return void
-	 */
-	public function theUserSendsToOcsApiEndpoint(string $verb, string $url): void {
-		$response = $this->theUserSendsToOcsApiEndpointWithBody($verb, $url);
-		$this->featureContext->setResponse($response);
-	}
-
-	/**
-	 * @When /^user "([^"]*)" sends HTTP method "([^"]*)" to OCS API endpoint "([^"]*)"$/
-	 * @When /^user "([^"]*)" sends HTTP method "([^"]*)" to OCS API endpoint "([^"]*)" using password "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $verb
@@ -61,6 +47,7 @@ class OCSContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[When('user :user sends HTTP method :verb to OCS API endpoint :url')]
 	public function userSendsToOcsApiEndpoint(string $user, string $verb, string $url, ?string $password = null): void {
 		$response = $this->sendRequestToOcsEndpoint(
 			$user,
@@ -143,27 +130,6 @@ class OCSContext implements Context {
 	}
 
 	/**
-	 * @param string $verb
-	 * @param string $url
-	 * @param TableNode|null $body
-	 *
-	 * @return ResponseInterface
-	 */
-	public function theUserSendsToOcsApiEndpointWithBody(
-		string $verb,
-		string $url,
-		?TableNode $body = null
-	): ResponseInterface {
-		return $this->sendRequestToOcsEndpoint(
-			$this->featureContext->getCurrentUser(),
-			$verb,
-			$url,
-			$body
-		);
-	}
-
-	/**
-	 * @When /^user "([^"]*)" sends HTTP method "([^"]*)" to OCS API endpoint "([^"]*)" with headers$/
 	 *
 	 * @param string $user
 	 * @param string $verb
@@ -173,6 +139,7 @@ class OCSContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('user :user sends HTTP method :verb to OCS API endpoint :url with headers')]
 	public function userSendsToOcsApiEndpointWithHeaders(
 		string $user,
 		string $verb,
@@ -194,7 +161,6 @@ class OCSContext implements Context {
 	}
 
 	/**
-	 * @Then /^the OCS status code should be "([^"]*)"$/
 	 *
 	 * @param string $statusCode
 	 * @param string $message
@@ -203,6 +169,7 @@ class OCSContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('the OCS status code should be :statusCode')]
 	public function theOCSStatusCodeShouldBe(
 		string $statusCode,
 		string $message = "",
@@ -238,40 +205,14 @@ class OCSContext implements Context {
 	}
 
 	/**
-	 * @Then /^the OCS status code should be "([^"]*)" or "([^"]*)"$/
-	 *
-	 * @param string $statusCode1
-	 * @param string $statusCode2
-	 *
-	 * @return void
-	 * @throws Exception
-	 */
-	public function theOcsStatusCodeShouldBeOr(string $statusCode1, string $statusCode2): void {
-		$statusCodes = [$statusCode1,$statusCode1];
-		$response = $this->featureContext->getResponse();
-		$responseStatusCode = $this->getOCSResponseStatusCode(
-			$response
-		);
-		Assert::assertContainsEquals(
-			$responseStatusCode,
-			$statusCodes,
-			"OCS status code is not any of the expected values "
-			. \implode(",", $statusCodes) . " got " . $responseStatusCode
-		);
-		$this->featureContext->emptyLastOCSStatusCodesArray();
-	}
-
-	/**
 	 * Check the text in an OCS status message
-	 *
-	 * @Then /^the OCS status message should be "([^"]*)"$/
-	 * @Then /^the OCS status message should be "([^"]*)" in language "([^"]*)"$/
 	 *
 	 * @param string $statusMessage
 	 * @param string|null $language
 	 *
 	 * @return void
 	 */
+	#[Then('the OCS status message should be :statusMessage')]
 	public function theOCSStatusMessageShouldBe(string $statusMessage, ?string $language = null): void {
 		$language = TranslationHelper::getLanguage($language);
 		$statusMessage = $this->getActualStatusMessage($statusMessage, $language);
@@ -282,38 +223,6 @@ class OCSContext implements Context {
 				$this->featureContext->getResponse()
 			),
 			'Unexpected OCS status message :"' . $this->getOCSResponseStatusMessage(
-				$this->featureContext->getResponse()
-			) . '" in response'
-		);
-	}
-
-	/**
-	 * Check the text in an OCS status message.
-	 * Use this step form if the expected text contains double quotes,
-	 * single quotes and other content that theOCSStatusMessageShouldBe()
-	 * cannot handle.
-	 *
-	 * After the step, write the expected text in PyString form like:
-	 *
-	 * """
-	 * File "abc.txt" can't be shared due to reason "xyz"
-	 * """
-	 *
-	 * @Then /^the OCS status message should be:$/
-	 *
-	 * @param PyStringNode $statusMessage
-	 *
-	 * @return void
-	 */
-	public function theOCSStatusMessageShouldBePyString(
-		PyStringNode $statusMessage
-	): void {
-		Assert::assertEquals(
-			$statusMessage->getRaw(),
-			$this->getOCSResponseStatusMessage(
-				$this->featureContext->getResponse()
-			),
-			'Unexpected OCS status message: "' . $this->getOCSResponseStatusMessage(
 				$this->featureContext->getResponse()
 			) . '" in response'
 		);

--- a/tests/acceptance/bootstrap/OcConfigContext.php
+++ b/tests/acceptance/bootstrap/OcConfigContext.php
@@ -24,6 +24,7 @@ use GuzzleHttp\Exception\GuzzleException;
 use TestHelpers\OcConfigHelper;
 use TestHelpers\GraphHelper;
 use PHPUnit\Framework\Assert;
+use Behat\Step\Given;
 
 /**
  * steps needed to re-configure OpenCloud server
@@ -48,13 +49,13 @@ class OcConfigContext implements Context {
 	}
 
 	/**
-	 * @Given async upload has been enabled with post-processing delayed to :delayTime seconds
 	 *
 	 * @param string $delayTime
 	 *
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[Given('async upload has been enabled with post-processing delayed to :delayTime seconds')]
 	public function asyncUploadHasBeenEnabledWithDelayedPostProcessing(string $delayTime): void {
 		$envs = [
 			"OC_ASYNC_UPLOADS" => true,
@@ -72,7 +73,6 @@ class OcConfigContext implements Context {
 	}
 
 	/**
-	 * @Given the config :configVariable has been set to :configValue
 	 *
 	 * @param string $configVariable
 	 * @param string $configValue
@@ -80,6 +80,7 @@ class OcConfigContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[Given('the config :configVariable has been set to :configValue')]
 	public function theConfigHasBeenSetTo(string $configVariable, string $configValue): void {
 		$envs = [
 			$configVariable => $configValue,
@@ -97,12 +98,12 @@ class OcConfigContext implements Context {
 	}
 
 	/**
-	 * @Given the administrator has enabled the permissions role :role
 	 *
 	 * @param string $role
 	 *
 	 * @return void
 	 */
+	#[Given('the administrator has enabled the permissions role :role')]
 	public function theAdministratorHasEnabledTheRole(string $role): void {
 		$roleId = GraphHelper::getPermissionsRoleIdByName($role);
 		$defaultRoles = array_values(GraphHelper::DEFAULT_PERMISSIONS_ROLES);
@@ -123,12 +124,12 @@ class OcConfigContext implements Context {
 	}
 
 	/**
-	 * @Given the administrator has disabled the permissions role :role
 	 *
 	 * @param string $role
 	 *
 	 * @return void
 	 */
+	#[Given('the administrator has disabled the permissions role :role')]
 	public function theAdministratorHasDisabledThePermissionsRole(string $role): void {
 		$roleId = GraphHelper::getPermissionsRoleIdByName($role);
 		$availableRoles = $this->getEnabledPermissionsRoles();
@@ -149,7 +150,6 @@ class OcConfigContext implements Context {
 	}
 
 	/**
-	 * @Given the config :configVariable has been set to path :path
 	 *
 	 * @param string $configVariable
 	 * @param string $path
@@ -157,6 +157,7 @@ class OcConfigContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[Given('the config :configVariable has been set to path :path')]
 	public function theConfigHasBeenSetPathTo(string $configVariable, string $path): void {
 		if (\getenv('TEST_ROOT_PATH')) {
 			$path = \getenv('TEST_ROOT_PATH') . "/" . $path;
@@ -177,13 +178,13 @@ class OcConfigContext implements Context {
 	}
 
 	/**
-	 * @Given the following configs have been set:
 	 *
 	 * @param TableNode $table
 	 *
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[Given('the following configs have been set:')]
 	public function theConfigHasBeenSetToValue(TableNode $table): void {
 		$envs = [];
 		foreach ($table->getHash() as $row) {

--- a/tests/acceptance/bootstrap/OcmContext.php
+++ b/tests/acceptance/bootstrap/OcmContext.php
@@ -27,6 +27,8 @@ use TestHelpers\OcHelper;
 use TestHelpers\OcmHelper;
 use TestHelpers\WebDavHelper;
 use TestHelpers\BehatHelper;
+use Behat\Step\Given;
+use Behat\Step\When;
 
 /**
  * Acceptance test steps related to testing federation share(ocm) features
@@ -88,8 +90,6 @@ class OcmContext implements Context {
 	}
 
 	/**
-	 * @When :user creates the federation share invitation
-	 * @When :user creates the federation share invitation with email :email and description :description
 	 *
 	 * @param string $user
 	 * @param string $email
@@ -98,13 +98,13 @@ class OcmContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When(':user creates the federation share invitation')]
+	#[When(':user creates the federation share invitation with email :email and description :description')]
 	public function userCreatesTheFederationShareInvitation(string $user, $email = null, $description = null): void {
 		$this->featureContext->setResponse($this->createInvitation($user, $email, $description));
 	}
 
 	/**
-	 * @Given :user has created the federation share invitation
-	 * @Given :user has created the federation share invitation with email :email and description :description
 	 *
 	 * @param string $user
 	 * @param string $email
@@ -113,6 +113,8 @@ class OcmContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[Given(':user has created the federation share invitation')]
+	#[Given(':user has created the federation share invitation with email :email and description :description')]
 	public function userHasCreatedTheFederationShareInvitation(string $user, $email = null, $description = null): void {
 		$response = $this->createInvitation($user, $email, $description);
 		$this->featureContext->theHTTPStatusCodeShouldBe(200, '', $response);
@@ -141,38 +143,38 @@ class OcmContext implements Context {
 	}
 
 	/**
-	 * @When :user accepts the last federation share invitation
-	 * @When :user tries to accept the last federation share invitation
 	 *
 	 * @param string $user
 	 *
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When(':user accepts the last federation share invitation')]
+	#[When(':user tries to accept the last federation share invitation')]
 	public function userAcceptsTheLastFederationShareInvitation(string $user): void {
 		$this->featureContext->setResponse($this->acceptInvitation($user));
 	}
 
 	/**
-	 * @When :user tries to accept the invitation with invalid token
 	 *
 	 * @param string $user
 	 *
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When(':user tries to accept the invitation with invalid token')]
 	public function userTriesToAcceptInvitationWithInvalidToken(string $user): void {
 		$this->featureContext->setResponse($this->acceptInvitation($user, WebDavHelper::generateUUIDv4()));
 	}
 
 	/**
-	 * @Given :user has accepted invitation
 	 *
 	 * @param string $user
 	 *
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[Given(':user has accepted invitation')]
 	public function userHasAcceptedTheLastFederationShareInvitation(string $user): void {
 		$response = $this->acceptInvitation($user);
 		$this->featureContext->theHTTPStatusCodeShouldBe(200, '', $response);
@@ -194,13 +196,13 @@ class OcmContext implements Context {
 	}
 
 	/**
-	 * @When :user searches for accepted users
 	 *
 	 * @param string $user
 	 *
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When(':user searches for accepted users')]
 	public function userFindsAcceptedUsers(string $user): void {
 		$this->featureContext->setResponse($this->findAcceptedUsers($user));
 	}
@@ -239,31 +241,30 @@ class OcmContext implements Context {
 	}
 
 	/**
-	 * @When :user lists the created invitations
 	 *
 	 * @param string $user
 	 *
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When(':user lists the created invitations')]
 	public function userListsCreatedInvitations(string $user): void {
 		$this->featureContext->setResponse($this->listInvitations($user));
 	}
 
 	/**
-	 * @When the user waits :number seconds for the invitation token to expire
 	 *
 	 * @param int $number
 	 *
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('the user waits :number seconds for the invitation token to expire')]
 	public function theUserWaitsForTokenToExpire(int $number): void {
 		\sleep($number);
 	}
 
 	/**
-	 * @When user :user deletes federated connection with user :ocmUser using the Graph API
 	 *
 	 * @param string $user
 	 * @param string $ocmUser
@@ -271,12 +272,12 @@ class OcmContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('user :user deletes federated connection with user :ocmUser using the Graph API')]
 	public function userDeletesFederatedConnectionWithUserUsingTheGraphApi(string $user, string $ocmUser): void {
 		$this->featureContext->setResponse($this->deleteConnection($user, $ocmUser));
 	}
 
 	/**
-	 * @When user :user has deleted federated connection with user :ocmUser
 	 *
 	 * @param string $user
 	 * @param string $ocmUser
@@ -284,6 +285,7 @@ class OcmContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('user :user has deleted federated connection with user :ocmUser')]
 	public function userHasDeletedFederatedConnectionWithUser(string $user, string $ocmUser): void {
 		$response = $this->deleteConnection($user, $ocmUser);
 		$this->featureContext->theHTTPStatusCodeShouldBe(

--- a/tests/acceptance/bootstrap/Provisioning.php
+++ b/tests/acceptance/bootstrap/Provisioning.php
@@ -20,7 +20,6 @@
  */
 
 use Behat\Gherkin\Node\TableNode;
-use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\GuzzleException;
 use Psr\Http\Message\ResponseInterface;
 use PHPUnit\Framework\Assert;
@@ -32,6 +31,9 @@ use TestHelpers\GraphHelper;
 use Laminas\Ldap\Exception\LdapException;
 use Laminas\Ldap\Ldap;
 use TestHelpers\TokenHelper;
+use Behat\Step\Given;
+use Behat\Step\Then;
+use Behat\Step\When;
 
 /**
  * Functions for provisioning of users and groups
@@ -188,13 +190,13 @@ trait Provisioning {
 	}
 
 	/**
-	 * @Given user :user has been created with default attributes
 	 *
 	 * @param string $user
 	 *
 	 * @return void
 	 * @throws Exception|GuzzleException
 	 */
+	#[Given('user :user has been created with default attributes')]
 	public function userHasBeenCreatedWithDefaultAttributes(
 		string $user
 	): void {
@@ -202,13 +204,13 @@ trait Provisioning {
 	}
 
 	/**
-	 * @Given these users have been created without being initialized:
 	 *
 	 * @param TableNode $table
 	 *
 	 * @return void
 	 * @throws Exception|GuzzleException
 	 */
+	#[Given('these users have been created without being initialized:')]
 	public function userHasBeenCreatedWithDefaultAttributesAndNotInitialized(
 		TableNode $table
 	): void {
@@ -216,7 +218,6 @@ trait Provisioning {
 	}
 
 	/**
-	 * @Given these users have been created with default attributes:
 	 * expects a table of users with the heading
 	 * "|username|"
 	 *
@@ -225,12 +226,12 @@ trait Provisioning {
 	 * @return void
 	 * @throws Exception|GuzzleException
 	 */
+	#[Given('these users have been created with default attributes:')]
 	public function theseUsersHaveBeenCreatedWithDefaultAttributesAndWithoutSkeletonFiles(TableNode $table): void {
 		$this->usersHaveBeenCreated($table);
 	}
 
 	/**
-	 * @Given the user :byUser has created a new user with the following attributes:
 	 *
 	 * @param string $byUser
 	 * @param TableNode $table
@@ -238,6 +239,7 @@ trait Provisioning {
 	 * @return void
 	 * @throws Exception|GuzzleException
 	 */
+	#[Given('the user :byUser has created a new user with the following attributes:')]
 	public function theAdministratorHasCreatedANewUserWithFollowingSettings(string $byUser, TableNode $table): void {
 		$rows = $table->getRowsHash();
 		$this->userHasBeenCreated(
@@ -725,13 +727,13 @@ trait Provisioning {
 	}
 
 	/**
-	 * @When /^the administrator deletes user "([^"]*)" using the provisioning API$/
 	 *
 	 * @param string $user
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('the administrator deletes user :user using the provisioning API')]
 	public function theAdminDeletesUserUsingTheProvisioningApi(string $user): void {
 		$user = $this->getActualUsername($user);
 		$this->setResponse($this->deleteUser($user));
@@ -739,13 +741,13 @@ trait Provisioning {
 	}
 
 	/**
-	 * @Then /^user "([^"]*)" should exist$/
 	 *
 	 * @param string $user
 	 *
 	 * @return void
 	 * @throws JsonException
 	 */
+	#[Then('user :user should exist')]
 	public function userShouldExist(string $user): void {
 		Assert::assertTrue(
 			$this->userExists($user),
@@ -754,13 +756,13 @@ trait Provisioning {
 	}
 
 	/**
-	 * @Then /^user "([^"]*)" should not exist$/
 	 *
 	 * @param string $user
 	 *
 	 * @return void
 	 * @throws JsonException
 	 */
+	#[Then('user :user should not exist')]
 	public function userShouldNotExist(string $user): void {
 		$user = $this->getActualUsername($user);
 		Assert::assertFalse(
@@ -771,7 +773,6 @@ trait Provisioning {
 	}
 
 	/**
-	 * @Then /^group "([^"]*)" should exist$/
 	 *
 	 * @param string $group
 	 *
@@ -779,6 +780,7 @@ trait Provisioning {
 	 * @throws Exception
 	 * @throws GuzzleException
 	 */
+	#[Then('group :group should exist')]
 	public function groupShouldExist(string $group): void {
 		Assert::assertTrue(
 			$this->groupExists($group),
@@ -787,7 +789,6 @@ trait Provisioning {
 	}
 
 	/**
-	 * @Then /^group "([^"]*)" should not exist$/
 	 *
 	 * @param string $group
 	 *
@@ -795,6 +796,7 @@ trait Provisioning {
 	 * @throws Exception
 	 * @throws GuzzleException
 	 */
+	#[Then('group :group should not exist')]
 	public function groupShouldNotExist(string $group): void {
 		Assert::assertFalse(
 			$this->groupExists($group),
@@ -803,7 +805,6 @@ trait Provisioning {
 	}
 
 	/**
-	 * @Then /^these groups should (not|)\s?exist:$/
 	 * expects a table of groups with the heading "groupname"
 	 *
 	 * @param string $shouldOrNot (not|)
@@ -812,6 +813,7 @@ trait Provisioning {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('/^these groups should (not|)\\s?exist:$/')]
 	public function theseGroupsShouldNotExist(string $shouldOrNot, TableNode $table): void {
 		$should = ($shouldOrNot !== "not");
 		$this->verifyTableNodeColumns($table, ['groupname']);
@@ -832,13 +834,13 @@ trait Provisioning {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" has been deleted$/
 	 *
 	 * @param string $user
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Given('user :user has been deleted')]
 	public function userHasBeenDeleted(string $user): void {
 		$user = $this->getActualUsername($user);
 		if ($this->isTestingWithLdap() && \in_array($user, $this->ldapCreatedUsers)) {
@@ -882,20 +884,6 @@ trait Provisioning {
 			$this->getStepLineRef(),
 			$actualUser,
 			$actualPassword
-		);
-	}
-
-	/**
-	 * @When user :user gets the list of all users using the provisioning API
-	 *
-	 * @param string $user
-	 *
-	 * @return void
-	 * @throws Exception
-	 */
-	public function userGetsTheListOfAllUsersUsingTheProvisioningApi(string $user): void {
-		$this->featureContext->setResponse(
-			$this->userGetsTheListOfAllUsers($user)
 		);
 	}
 
@@ -1121,7 +1109,6 @@ trait Provisioning {
 	}
 
 	/**
-	 * @When the administrator removes user :user from group :group using the provisioning API
 	 *
 	 * @param string $user
 	 * @param string $group
@@ -1129,6 +1116,7 @@ trait Provisioning {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('the administrator removes user :user from group :group using the provisioning API')]
 	public function adminRemovesUserFromGroupUsingTheProvisioningApi(string $user, string $group): void {
 		$user = $this->getActualUsername($user);
 		if (OcHelper::isTestingOnReva()) {
@@ -1154,13 +1142,13 @@ trait Provisioning {
 	}
 
 	/**
-	 * @Then /^the extra groups returned by the API should be$/
 	 *
 	 * @param TableNode $groupsList
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('the extra groups returned by the API should be')]
 	public function theExtraGroupsShouldBe(TableNode $groupsList): void {
 		$this->verifyTableNodeColumnsCount($groupsList, 1);
 		$groups = $groupsList->getRows();
@@ -1248,7 +1236,6 @@ trait Provisioning {
 	}
 
 	/**
-	 * @Then /^user "([^"]*)" should belong to group "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $group
@@ -1256,6 +1243,7 @@ trait Provisioning {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('user :user should belong to group :group')]
 	public function userShouldBelongToGroup(string $user, string $group): void {
 		$user = $this->getActualUsername($user);
 		if (OcHelper::isTestingOnReva()) {
@@ -1286,13 +1274,13 @@ trait Provisioning {
 	}
 
 	/**
-	 * @Then the following users should not belong to the following groups
 	 *
 	 * @param TableNode $table
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('the following users should not belong to the following groups')]
 	public function theTheFollowingUserShouldNotBelongToTheFollowingGroup(TableNode $table): void {
 		$this->verifyTableNodeColumns($table, ["username", "groupname"]);
 		$rows = $table->getHash();
@@ -1321,27 +1309,6 @@ trait Provisioning {
 	}
 
 	/**
-	 * @Then group :group should not contain user :username
-	 *
-	 * @param string $group
-	 * @param string $username
-	 *
-	 * @return void
-	 */
-	public function groupShouldNotContainUser(string $group, string $username): void {
-		$username = $this->getActualUsername($username);
-		$fullUrl = $this->getBaseUrl() . "/ocs/v2.php/cloud/groups/$group";
-		$response = HttpRequestHelper::get(
-			$fullUrl,
-			$this->getStepLineRef(),
-			$this->getAdminUsername(),
-			$this->getAdminPassword()
-		);
-		Assert::assertNotContains($username, $this->getArrayOfUsersResponded($response));
-	}
-
-	/**
-	 * @When /^the administrator adds user "([^"]*)" to group "([^"]*)" using the provisioning API$/
 	 *
 	 * @param string $user
 	 * @param string $group
@@ -1349,13 +1316,13 @@ trait Provisioning {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('the administrator adds user :user to group :group using the provisioning API')]
 	public function adminAddsUserToGroupUsingTheProvisioningApi(string $user, string $group): void {
 		$response = $this->graphContext->addUserToGroup($group, $user);
 		$this->setResponse($response);
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" has been added to group "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $group
@@ -1363,6 +1330,7 @@ trait Provisioning {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Given('user :user has been added to group :group')]
 	public function userHasBeenAddedToGroup(string $user, string $group): void {
 		$user = $this->getActualUsername($user);
 		if ($this->isTestingWithLdap()) {
@@ -1383,13 +1351,13 @@ trait Provisioning {
 	}
 
 	/**
-	 * @Given the following users have been added to the following groups
 	 *
 	 * @param TableNode $table
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Given('the following users have been added to the following groups')]
 	public function theFollowingUserHaveBeenAddedToTheFollowingGroup(TableNode $table): void {
 		$this->verifyTableNodeColumns($table, ['username', 'groupname']);
 		foreach ($table as $row) {
@@ -1461,7 +1429,6 @@ trait Provisioning {
 	}
 
 	/**
-	 * @Given /^group "([^"]*)" has been created$/
 	 *
 	 * @param string $group
 	 *
@@ -1469,6 +1436,7 @@ trait Provisioning {
 	 * @throws Exception
 	 * @throws GuzzleException
 	 */
+	#[Given('group :group has been created')]
 	public function groupHasBeenCreated(string $group): void {
 		$this->createTheGroup($group);
 		Assert::assertTrue(
@@ -1478,7 +1446,6 @@ trait Provisioning {
 	}
 
 	/**
-	 * @Given these groups have been created:
 	 * expects a table of groups with the heading "groupname"
 	 *
 	 * @param TableNode $table
@@ -1486,6 +1453,7 @@ trait Provisioning {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Given('these groups have been created:')]
 	public function theseGroupsHaveBeenCreated(TableNode $table): void {
 		$this->verifyTableNodeColumns($table, ['groupname'], ['comment']);
 		foreach ($table as $row) {
@@ -1687,13 +1655,13 @@ trait Provisioning {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" has been disabled$/
 	 *
 	 * @param string|null $user
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Given('user :user has been disabled')]
 	public function adminHasDisabledUserUsingTheProvisioningApi(?string $user): void {
 		$user = $this->getActualUsername($user);
 		if (OcHelper::isTestingOnReva()) {
@@ -1742,7 +1710,6 @@ trait Provisioning {
 	}
 
 	/**
-	 * @Given /^group "([^"]*)" has been deleted$/
 	 *
 	 * @param string $group
 	 *
@@ -1750,6 +1717,7 @@ trait Provisioning {
 	 * @throws Exception
 	 * @throws GuzzleException
 	 */
+	#[Given('group :group has been deleted')]
 	public function groupHasBeenDeleted(string $group): void {
 		if ($this->isTestingWithLdap()) {
 			$this->deleteLdapGroup($group);
@@ -1795,7 +1763,6 @@ trait Provisioning {
 	}
 
 	/**
-	 * @Given user :user has been removed from group :group
 	 *
 	 * @param string $user
 	 * @param string $group
@@ -1803,6 +1770,7 @@ trait Provisioning {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Given('user :user has been removed from group :group')]
 	public function adminHasRemovedUserFromGroup(string $user, string $group): void {
 		$user = $this->getActualUsername($user);
 		if ($this->isTestingWithLdap()
@@ -1836,13 +1804,13 @@ trait Provisioning {
 	}
 
 	/**
-	 * @Then /^the users returned by the API should be$/
 	 *
 	 * @param TableNode $usersList
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('the users returned by the API should be')]
 	public function theUsersShouldBe(TableNode $usersList): void {
 		$this->verifyTableNodeColumnsCount($usersList, 1);
 		$users = $usersList->getRows();
@@ -1906,11 +1874,11 @@ trait Provisioning {
 	}
 
 	/**
-	 * @Then /^the API should not return any data$/
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('the API should not return any data')]
 	public function theApiShouldNotReturnAnyData(): void {
 		$responseData = HttpRequestHelper::getResponseXml($this->response, __METHOD__)->data[0];
 		Assert::assertEmpty(

--- a/tests/acceptance/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/bootstrap/PublicWebDavContext.php
@@ -27,6 +27,9 @@ use TestHelpers\HttpRequestHelper;
 use TestHelpers\WebDavHelper;
 use TestHelpers\BehatHelper;
 use TestHelpers\UploadHelper;
+use Behat\Step\Given;
+use Behat\Step\Then;
+use Behat\Step\When;
 
 require_once 'bootstrap.php';
 
@@ -60,37 +63,35 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @When /^the public downloads the last public link shared file using the public WebDAV API$/
-	 * @When /^the public tries to download the last public link shared file using the public WebDAV API$/
 	 *
 	 * @return void
 	 */
+	#[When('the public tries to download the last public link shared file using the public WebDAV API')]
 	public function downloadPublicFile(): void {
 		$response = $this->downloadPublicFileWithRange("");
 		$this->featureContext->setResponse($response);
 	}
 
 	/**
-	 * @When /^the public downloads the last public link shared file with password "([^"]*)" using the public WebDAV API$/
-	 * @When /^the public tries to download the last public link shared file with password "([^"]*)" using the public WebDAV API$/
 	 *
 	 * @param string $password
 	 *
 	 * @return void
 	 */
+	#[When('the public tries to download the last public link shared file with password :password using the public WebDAV API')]
 	public function downloadPublicFileWithPassword(string $password): void {
 		$response = $this->downloadPublicFileWithRange("", $password);
 		$this->featureContext->setResponse($response);
 	}
 
 	/**
-	 * @When /^user "([^"]*)" tries to download file "([^"]*)" from the last public link using own basic auth and public WebDAV API$/
 	 *
 	 * @param string $user
 	 * @param string $path
 	 *
 	 * @return void
 	 */
+	#[When('user :user tries to download file :path from the last public link using own basic auth and public WebDAV API')]
 	public function userTriesToDownloadFileFromPublicLinkUsingBasicAuthAndPublicWebdav(
 		string $user,
 		string $path
@@ -100,12 +101,12 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @When /^the public deletes (?:file|folder|entry) "([^"]*)" from the last public link share using the public WebDAV API$/
 	 *
 	 * @param string $fileName
 	 *
 	 * @return void
 	 */
+	#[When('/^the public deletes (?:file|folder|entry) "([^"]*)" from the last public link share using the public WebDAV API$/')]
 	public function thePublicDeletesFileFolderFromTheLastPublicLinkShareUsingThePublicWebdavApi(
 		string $fileName
 	): void {
@@ -147,13 +148,13 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @Given /^the public has deleted (?:file|folder|entry) "([^"]*)" from the last link share with password "([^"]*)" using the public WebDAV API$/
 	 *
 	 * @param string $file
 	 * @param string $password
 	 *
 	 * @return void
 	 */
+	#[Given('/^the public has deleted (?:file|folder|entry) "([^"]*)" from the last link share with password "([^"]*)" using the public WebDAV API$/')]
 	public function thePublicHasDeletedFileFromTheLastLinkShareWithPasswordUsingPublicWebdavApi(
 		string $file,
 		string $password
@@ -163,13 +164,13 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @When /^the public deletes (?:file|folder|entry) "([^"]*)" from the last link share with password "([^"]*)" using the public WebDAV API$/
 	 *
 	 * @param string $file
 	 * @param string $password
 	 *
 	 * @return void
 	 */
+	#[When('/^the public deletes (?:file|folder|entry) "([^"]*)" from the last link share with password "([^"]*)" using the public WebDAV API$/')]
 	public function thePublicDeletesFileFromTheLastLinkShareWithPasswordUsingPublicWebdavApi(
 		string $file,
 		string $password
@@ -219,7 +220,6 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @When /^the public renames (?:file|folder|entry) "([^"]*)" to "([^"]*)" from the last public link share using the password "([^"]*)" and the public WebDAV API$/
 	 *
 	 * @param string $fileName
 	 * @param string $toName
@@ -227,6 +227,7 @@ class PublicWebDavContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[When('/^the public renames (?:file|folder|entry) "([^"]*)" to "([^"]*)" from the last public link share using the password "([^"]*)" and the public WebDAV API$/')]
 	public function thePublicRenamesFileFromTheLastPublicShareUsingThePasswordPasswordAndOldPublicWebdavApi(
 		string $fileName,
 		string $toName,
@@ -239,14 +240,14 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @When /^the public downloads file "([^"]*)" from inside the last public link shared folder with password "([^"]*)" using the public WebDAV API$/
-	 * @When /^the public tries to download file "([^"]*)" from inside the last public link shared folder with password "([^"]*)" using the public WebDAV API$/
 	 *
 	 * @param string $path
 	 * @param string $password
 	 *
 	 * @return void
 	 */
+	#[When('the public downloads file :path from inside the last public link shared folder with password :password using the public WebDAV API')]
+	#[When('the public tries to download file :path from inside the last public link shared folder with password :password using the public WebDAV API')]
 	public function publicDownloadsFileFromInsideLastPublicSharedFolderWithPassword(
 		string $path,
 		string $password = ""
@@ -376,13 +377,13 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @When /^the public copies (?:file|folder) "([^"]*)" to "([^"]*)" using the public WebDAV API$/
 	 *
 	 * @param string $source
 	 * @param string $destination
 	 *
 	 * @return void
 	 */
+	#[When('/^the public copies (?:file|folder) "([^"]*)" to "([^"]*)" using the public WebDAV API$/')]
 	public function thePublicCopiesFileUsingTheWebDAVApi(string $source, string $destination): void {
 		$token = ($this->featureContext->isUsingSharingNG())
 		? $this->featureContext->shareNgGetLastCreatedLinkShareToken()
@@ -424,7 +425,6 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @Given /^the public has uploaded file "([^"]*)" with content "([^"]*)" and password "([^"]*)" to the last link share using the public WebDAV API$/
 	 *
 	 * @param string $filename
 	 * @param string $content
@@ -432,6 +432,7 @@ class PublicWebDavContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[Given('the public has uploaded file :filename with content :content and password :password to the last link share using the public WebDAV API')]
 	public function thePublicHasUploadedFileWithContentAndPasswordToLastLinkShareUsingPublicWebdavApi(
 		string $filename,
 		string $content = 'test',
@@ -446,7 +447,6 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @When /^the public uploads file "([^"]*)" with password "([^"]*)" and content "([^"]*)" using the public WebDAV API$/
 	 *
 	 * @param string $filename target file name
 	 * @param string $password
@@ -454,6 +454,7 @@ class PublicWebDavContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[When('the public uploads file :filename with password :password and content :body using the public WebDAV API')]
 	public function thePublicUploadsFileWithPasswordAndContentUsingPublicWebDAVApi(
 		string $filename,
 		string $password,
@@ -468,26 +469,26 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @When the public overwrites file :filename with content :body using the public WebDAV API
 	 *
 	 * @param string $filename target file name
 	 * @param string $body content to upload
 	 *
 	 * @return void
 	 */
+	#[When('the public overwrites file :filename with content :body using the public WebDAV API')]
 	public function thePublicOverwritesFileWithContentUsingWebDavApi(string $filename, string $body): void {
 		$response = $this->publicUploadContent($filename, '', $body);
 		$this->featureContext->setResponse($response);
 	}
 
 	/**
-	 * @When /^the public uploads file "([^"]*)" with content "([^"]*)" using the public WebDAV API$/
 	 *
 	 * @param string $filename target file name
 	 * @param string $body content to upload
 	 *
 	 * @return void
 	 */
+	#[When('the public uploads file :filename with content :body using the public WebDAV API')]
 	public function thePublicUploadsFileWithContentUsingThePublicWebDavApi(
 		string $filename,
 		string $body = 'test'
@@ -498,20 +499,6 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @Given the public has uploaded file :filename with content :body
-	 *
-	 * @param string $filename target file name
-	 * @param string $body content to upload
-	 *
-	 * @return void
-	 */
-	public function thePublicHasUploadedFileWithContent(string $filename, string $body): void {
-		$response = $this->publicUploadContent($filename, '', $body);
-		$this->featureContext->theHTTPStatusCodeShouldBe([201, 204], "", $response);
-	}
-
-	/**
-	 * @Then /^the public should be able to download the last publicly shared file using the public WebDAV API with password "([^"]*)" and the content should be "([^"]*)"$/
 	 *
 	 * @param string $password
 	 * @param string $expectedContent
@@ -519,6 +506,7 @@ class PublicWebDavContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('the public should be able to download the last publicly shared file using the public WebDAV API with password :password and the content should be :expectedContent')]
 	public function checkLastPublicSharedFileWithPasswordDownload(
 		string $password,
 		string $expectedContent
@@ -538,14 +526,13 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @Then /^the public should not be able to download file "([^"]*)" from inside the last public link shared folder using the public WebDAV API without a password$/
-	 * @Then /^the public download of file "([^"]*)" from inside the last public link shared folder using the public WebDAV API should fail with HTTP status code "([^"]*)"$/
 	 *
 	 * @param string $path
 	 * @param string $expectedHttpCode
 	 *
 	 * @return void
 	 */
+	#[Then('the public should not be able to download file :path from inside the last public link shared folder using the public WebDAV API without a password')]
 	public function shouldNotBeAbleToDownloadFileInsidePublicSharedFolder(
 		string $path,
 		string $expectedHttpCode = "401"
@@ -560,13 +547,13 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @Then /^the public should be able to download file "([^"]*)" from inside the last public link shared folder using the public WebDAV API with password "([^"]*)"$/
 	 *
 	 * @param string $path
 	 * @param string $password
 	 *
 	 * @return void
 	 */
+	#[Then('the public should be able to download file :path from inside the last public link shared folder using the public WebDAV API with password :password')]
 	public function shouldBeAbleToDownloadFileInsidePublicSharedFolderWithPassword(
 		string $path,
 		string $password
@@ -581,7 +568,6 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @Then /^the public should be able to download file "([^"]*)" from inside the last public link shared folder using the public WebDAV API with password "([^"]*)" and the content should be "([^"]*)"$/
 	 *
 	 * @param string $path
 	 * @param string $password
@@ -590,6 +576,7 @@ class PublicWebDavContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('the public should be able to download file :path from inside the last public link shared folder using the public WebDAV API with password :password and the content should be :content')]
 	public function shouldBeAbleToDownloadFileInsidePublicSharedFolderWithPasswordAndContentShouldBe(
 		string $path,
 		string $password,
@@ -606,7 +593,6 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @Then /^the public should be able to download file "([^"]*)" from the last link share with password "([^"]*)" and the content should be "([^"]*)"$/
 	 *
 	 * @param string $path
 	 * @param string $password
@@ -615,6 +601,7 @@ class PublicWebDavContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('the public should be able to download file :path from the last link share with password :password and the content should be :content')]
 	public function shouldBeAbleToDownloadFileInsidePublicSharedFolderWithPasswordForSharingNGAndContentShouldBe(
 		string $path,
 		string $password,
@@ -632,8 +619,6 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @Then /^the public should not be able to download file "([^"]*)" from inside the last public link shared folder using the public WebDAV API with password "([^"]*)"$/
-	 * @Then /^the public download of file "([^"]*)" from inside the last public link shared folder using the public WebDAV API with password "([^"]*)" should fail with HTTP status code "([^"]*)"$/
 	 *
 	 * @param string $path
 	 * @param string $password
@@ -641,6 +626,7 @@ class PublicWebDavContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[Then('the public should not be able to download file :path from inside the last public link shared folder using the public WebDAV API with password :password')]
 	public function shouldNotBeAbleToDownloadFileInsidePublicSharedFolderWithPassword(
 		string $path,
 		string $password,
@@ -656,7 +642,6 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @Then /^the public download of file "([^"]*)" from the last link share with password "([^"]*)" should fail with HTTP status code "([^"]*)" using shareNg$/
 	 *
 	 * @param string $path
 	 * @param string $password
@@ -664,6 +649,7 @@ class PublicWebDavContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[Then('the public download of file :path from the last link share with password :password should fail with HTTP status code :expectedHttpCode using shareNg')]
 	public function shouldNotBeAbleToDownloadFileWithPasswordForShareNg(
 		string $path,
 		string $password,
@@ -704,7 +690,6 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @Then /^the public upload to the last publicly shared file using the public WebDAV API with password "([^"]*)" should (?:fail|pass) with HTTP status code "([^"]*)"$/
 	 *
 	 * @param string $password
 	 * @param string $expectedHttpCode
@@ -712,6 +697,7 @@ class PublicWebDavContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('/^the public upload to the last publicly shared file using the public WebDAV API with password "([^"]*)" should (?:fail|pass) with HTTP status code "([^"]*)"$/')]
 	public function publiclyUploadingShouldToSharedFileShouldFail(
 		string $password,
 		string $expectedHttpCode
@@ -727,13 +713,13 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @Then /^the public upload to the last publicly shared folder using the public WebDAV API with password "([^"]*)" should fail with HTTP status code "([^"]*)"$/
 	 *
 	 * @param string $password
 	 * @param string|null $expectedHttpCode
 	 *
 	 * @return void
 	 */
+	#[Then('the public upload to the last publicly shared folder using the public WebDAV API with password :password should fail with HTTP status code :expectedHttpCode')]
 	public function publiclyUploadingWithPasswordShouldNotWork(
 		string $password,
 		string $expectedHttpCode = null
@@ -750,13 +736,13 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @Then /^the public should be able to upload file "([^"]*)" into the last public link shared folder using the public WebDAV API with password "([^"]*)"$/
 	 *
 	 * @param string $filename
 	 * @param string $password
 	 *
 	 * @return void
 	 */
+	#[Then('the public should be able to upload file :filename into the last public link shared folder using the public WebDAV API with password :password')]
 	public function publiclyUploadingIntoFolderWithPasswordShouldWork(
 		string $filename,
 		string $password
@@ -770,13 +756,13 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @Then /^uploading a file with password "([^"]*)" should work using the public WebDAV API$/
 	 *
 	 * @param string $password
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('uploading a file with password :password should work using the public WebDAV API')]
 	public function publiclyUploadingShouldWork(string $password): void {
 		$path = "whateverfilefortesting-publicWebDAVAPI.txt";
 		$content = "test";
@@ -802,7 +788,6 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @Then /^uploading content to a public link shared file with password "([^"]*)" should (not|)\s?work using the public WebDAV API$/
 	 *
 	 * @param string $password
 	 * @param string $shouldOrNot (not|)
@@ -810,6 +795,7 @@ class PublicWebDavContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('/^uploading content to a public link shared file with password "([^"]*)" should (not|)\\s?work using the public WebDAV API$/')]
 	public function publiclyUploadingToPublicLinkSharedFileShouldWork(
 		string $password,
 		string $shouldOrNot,
@@ -851,13 +837,13 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @When the public uploads file :source to :destination inside last link shared folder using the public WebDAV API
 	 *
 	 * @param string $source
 	 * @param string $destination
 	 *
 	 * @return void
 	 */
+	#[When('the public uploads file :source to :destination inside last link shared folder using the public WebDAV API')]
 	public function thePublicUploadsFileToInsideLastLinkSharedFolderUsingThePublicWebdavApi(
 		string $source,
 		string $destination,
@@ -875,7 +861,6 @@ class PublicWebDavContext implements Context {
 
 	/**
 	 *
-	 * @When the public uploads file :source to :destination inside last link shared folder with password :password using the public WebDAV API
 	 *
 	 * @param string $source
 	 * @param string $destination
@@ -883,6 +868,7 @@ class PublicWebDavContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[When('the public uploads file :source to :destination inside last link shared folder with password :password using the public WebDAV API')]
 	public function thePublicUploadsFileToInsideLastLinkSharedFolderWithPasswordUsingThePublicWebdavApi(
 		string $source,
 		string $destination,
@@ -900,7 +886,6 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @When the public uploads file :fileName to the last public link shared folder with password :password with mtime :mtime using the public WebDAV API
 	 *
 	 * @param string $fileName
 	 * @param string $password
@@ -909,6 +894,7 @@ class PublicWebDavContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('the public uploads file :fileName to the last public link shared folder with password :password with mtime :mtime using the public WebDAV API')]
 	public function thePublicUploadsFileToLastSharedFolderWithMtimeUsingTheWebdavApi(
 		string $fileName,
 		string $password,
@@ -964,57 +950,17 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @When the public creates folder :destination using the public WebDAV API
 	 *
 	 * @param String $destination
 	 *
 	 * @return void
 	 */
+	#[When('the public creates folder :destination using the public WebDAV API')]
 	public function publicCreatesFolder(string $destination): void {
 		$this->featureContext->setResponse($this->publicCreatesFolderUsingPassword($destination, ''));
 	}
 
 	/**
-	 * @Then /^the public should be able to create folder "([^"]*)" in the last public link shared folder using the new public WebDAV API with password "([^"]*)"$/
-	 *
-	 * @param string $foldername
-	 * @param string $password
-	 *
-	 * @return void
-	 */
-	public function publicShouldBeAbleToCreateFolderWithPassword(
-		string $foldername,
-		string $password
-	): void {
-		$response = $this->publicCreatesFolderUsingPassword($foldername, $password);
-		$this->featureContext->theHTTPStatusCodeShouldBe(201, "", $response);
-	}
-
-	/**
-	 * @Then /^the public creation of folder "([^"]*)" in the last public link shared folder using the new public WebDAV API with password "([^"]*)" should fail with HTTP status code "([^"]*)"$/
-	 *
-	 * @param string $foldername
-	 * @param string $password
-	 * @param string $expectedHttpCode
-	 *
-	 * @return void
-	 */
-	public function publicCreationOfFolderWithPasswordShouldFail(
-		string $foldername,
-		string $password,
-		string $expectedHttpCode
-	): void {
-		$response = $this->publicCreatesFolderUsingPassword($foldername, $password);
-		$this->featureContext->theHTTPStatusCodeShouldBe(
-			$expectedHttpCode,
-			"creation of $foldername in the last publicly shared folder should have failed with code " .
-			$expectedHttpCode,
-			$response
-		);
-	}
-
-	/**
-	 * @Then the mtime of file :fileName in the last shared public link using the WebDAV API should be :mtime
 	 *
 	 * @param string $fileName
 	 * @param string $mtime
@@ -1022,6 +968,7 @@ class PublicWebDavContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('the mtime of file :fileName in the last shared public link using the WebDAV API should be :mtime')]
 	public function theMtimeOfFileInTheLastSharedPublicLinkUsingTheWebdavApiShouldBe(
 		string $fileName,
 		string $mtime
@@ -1034,32 +981,6 @@ class PublicWebDavContext implements Context {
 		\array_pop($mtime);
 		$mtime = \implode(" ", $mtime);
 		Assert::assertStringContainsString(
-			$mtime,
-			WebDavHelper::getMtimeOfFileInPublicLinkShare(
-				$baseUrl,
-				$fileName,
-				$token,
-				$this->featureContext->getStepLineRef()
-			)
-		);
-	}
-
-	/**
-	 * @Then the mtime of file :fileName in the last shared public link using the WebDAV API should not be :mtime
-	 *
-	 * @param string $fileName
-	 * @param string $mtime
-	 *
-	 * @return void
-	 * @throws Exception
-	 */
-	public function theMtimeOfFileInTheLastSharedPublicLinkUsingTheWebdavApiShouldNotBe(
-		string $fileName,
-		string $mtime
-	): void {
-		$token = $this->featureContext->getLastCreatedPublicShareToken();
-		$baseUrl = $this->featureContext->getBaseUrl();
-		Assert::assertNotEquals(
 			$mtime,
 			WebDavHelper::getMtimeOfFileInPublicLinkShare(
 				$baseUrl,
@@ -1158,7 +1079,6 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @When /^the public sends "([^"]*)" request to the last public link share using the public WebDAV API(?: with password "([^"]*)")?$/
 	 *
 	 * @param string $method
 	 * @param string|null $password
@@ -1166,6 +1086,7 @@ class PublicWebDavContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('/^the public sends "([^"]*)" request to the last public link share using the public WebDAV API(?: with password "([^"]*)")?$/')]
 	public function publicSendsRequestToLastPublicShare(string $method, ?string $password = ''): void {
 		if ($method === "PROPFIND") {
 			$body = '<?xml version="1.0"?>

--- a/tests/acceptance/bootstrap/SearchContext.php
+++ b/tests/acceptance/bootstrap/SearchContext.php
@@ -27,6 +27,8 @@ use Psr\Http\Message\ResponseInterface;
 use TestHelpers\WebDavHelper;
 use TestHelpers\HttpRequestHelper;
 use TestHelpers\BehatHelper;
+use Behat\Step\Then;
+use Behat\Step\When;
 
 require_once 'bootstrap.php';
 
@@ -126,10 +128,6 @@ class SearchContext implements Context {
 	}
 
 	/**
-	 * @When user :user searches for :pattern using the WebDAV API
-	 * @When user :user searches for :pattern and limits the results to :limit items using the WebDAV API
-	 * @When user :user searches for :pattern using the WebDAV API requesting these properties:
-	 * @When user :user searches for :pattern and limits the results to :limit items using the WebDAV API requesting these properties:
 	 *
 	 * @param string $user
 	 * @param string $pattern
@@ -139,6 +137,9 @@ class SearchContext implements Context {
 	 * @return void
 	 * @throws Exception|GuzzleException
 	 */
+	#[When('user :user searches for :pattern using the WebDAV API')]
+	#[When('user :user searches for :pattern and limits the results to :limit items using the WebDAV API')]
+	#[When('user :user searches for :pattern using the WebDAV API requesting these properties:')]
 	public function userSearchesUsingWebDavAPI(
 		string     $user,
 		string     $pattern,
@@ -153,7 +154,6 @@ class SearchContext implements Context {
 	}
 
 	/**
-	 * @Then file/folder :path in the search result of user :user should contain these properties:
 	 *
 	 * @param string $path
 	 * @param string $user
@@ -162,6 +162,7 @@ class SearchContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('file/folder :path in the search result of user :user should contain these properties:')]
 	public function fileOrFolderInTheSearchResultShouldContainProperties(
 		string    $path,
 		string    $user,
@@ -216,7 +217,6 @@ class SearchContext implements Context {
 	}
 
 	/**
-	 * @Then /^the search result should contain these (?:files|entries) with highlight on keyword "([^"]*)"/
 	 *
 	 * @param TableNode $expectedFiles
 	 * @param string $expectedContent
@@ -225,6 +225,7 @@ class SearchContext implements Context {
 	 *
 	 * @throws Exception
 	 */
+	#[Then('/^the search result should contain these (?:files|entries) with highlight on keyword "([^"]*)"/')]
 	public function theSearchResultShouldContainEntriesWithHighlight(
 		TableNode $expectedFiles,
 		string    $expectedContent
@@ -253,8 +254,6 @@ class SearchContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" searches for "([^"]*)" inside (folder|space) "([^"]*)" using the WebDAV API$/
-	 * @When /^user "([^"]*)" searches for "([^"]*)" inside (folder) "([^"]*)" in space "([^"]*)" using the WebDAV API$/
 	 *
 	 * @param string $user
 	 * @param string $pattern
@@ -265,6 +264,8 @@ class SearchContext implements Context {
 	 * @return void
 	 * @throws Exception|GuzzleException
 	 */
+	#[When('/^user "([^"]*)" searches for "([^"]*)" inside (folder|space) "([^"]*)" using the WebDAV API$/')]
+	#[When('/^user "([^"]*)" searches for "([^"]*)" inside (folder) "([^"]*)" in space "([^"]*)" using the WebDAV API$/')]
 	public function userSearchesInsideFolderOrSpaceUsingWebDavAPI(
 		string  $user,
 		string  $pattern,

--- a/tests/acceptance/bootstrap/SettingsContext.php
+++ b/tests/acceptance/bootstrap/SettingsContext.php
@@ -16,6 +16,9 @@ use Psr\Http\Message\ResponseInterface;
 use TestHelpers\HttpRequestHelper;
 use TestHelpers\SettingsHelper;
 use TestHelpers\BehatHelper;
+use Behat\Step\Given;
+use Behat\Step\Then;
+use Behat\Step\When;
 
 require_once 'bootstrap.php';
 
@@ -60,7 +63,6 @@ class SettingsContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" tries to get all existing roles using the settings API$/
 	 *
 	 * @param string $user
 	 *
@@ -69,6 +71,7 @@ class SettingsContext implements Context {
 	 * @throws GuzzleException
 	 * @throws Exception
 	 */
+	#[When('user :user tries to get all existing roles using the settings API')]
 	public function getAllExistingRoles(string $user): void {
 		$response = $this->getRoles($user);
 		$this->featureContext->setResponse($response);
@@ -115,7 +118,6 @@ class SettingsContext implements Context {
 	}
 
 	/**
-	 * @Given /^the administrator has given "([^"]*)" the role "([^"]*)" using the settings api$/
 	 *
 	 * @param string $user
 	 * @param string $role
@@ -124,6 +126,7 @@ class SettingsContext implements Context {
 	 *
 	 * @throws Exception
 	 */
+	#[Given('the administrator has given :user the role :role using the settings api')]
 	public function theAdministratorHasGivenUserTheRole(string $user, string $role): void {
 		$admin = $this->featureContext->getAdminUserName();
 		$roleId = $this->getRoleIdByRoleName($admin, $role);
@@ -137,7 +140,6 @@ class SettingsContext implements Context {
 	}
 
 	/**
-	 * @When user :assigner assigns the role :role to user :assignee using the settings API
 	 *
 	 * @param string $assigner
 	 * @param string $role
@@ -147,6 +149,7 @@ class SettingsContext implements Context {
 	 *
 	 * @throws Exception
 	 */
+	#[When('user :assigner assigns the role :role to user :assignee using the settings API')]
 	public function userAssignsTheRoleToUserUsingTheSettingsApi(
 		string $assigner,
 		string $role,
@@ -218,42 +221,6 @@ class SettingsContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" changes his own role to "([^"]*)"$/
-	 *
-	 * @param string $user
-	 * @param string $role
-	 *
-	 * @return void
-	 * @throws GuzzleException
-	 */
-	public function userChangeOwnRole(string $user, string $role): void {
-		// we assume that the user knows uuid role.
-		$roleId = $this->getRoleIdByRoleName($this->featureContext->getAdminUserName(), $role);
-		$userId = $this->featureContext->getAttributeOfCreatedUser($user, 'id');
-		$response = $this->assignRoleToUser($user, $userId, $roleId);
-		$this->featureContext->setResponse($response);
-	}
-
-	/**
-	 * @When /^user "([^"]*)" changes the role "([^"]*)" for user "([^"]*)"$/
-	 *
-	 * @param string $user
-	 * @param string $role
-	 * @param string $assignedUser
-	 *
-	 * @return void
-	 * @throws GuzzleException
-	 */
-	public function userChangeRoleAnotherUser(string $user, string $role, string $assignedUser): void {
-		// we assume that the user knows uuid role.
-		$roleId = $this->getRoleIdByRoleName($this->featureContext->getAdminUserName(), $role);
-		$userId = $this->featureContext->getAttributeOfCreatedUser($assignedUser, 'id');
-		$response = $this->assignRoleToUser($user, $userId, $roleId);
-		$this->featureContext->setResponse($response);
-	}
-
-	/**
-	 * @When /^user "([^"]*)" tries to get list of assignment using the settings API$/
 	 *
 	 * @param string $user
 	 *
@@ -262,13 +229,13 @@ class SettingsContext implements Context {
 	 * @throws GuzzleException
 	 * @throws Exception
 	 */
+	#[When('user :user tries to get list of assignment using the settings API')]
 	public function userGetAssignmentsList(string $user): void {
 		$userId = $this->featureContext->getAttributeOfCreatedUser($user, 'id');
 		$this->featureContext->setResponse($this->getAssignmentsList($user, $userId));
 	}
 
 	/**
-	 * @Then /^user "([^"]*)" should have the role "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $role
@@ -278,6 +245,7 @@ class SettingsContext implements Context {
 	 * @throws GuzzleException
 	 * @throws Exception
 	 */
+	#[Then('user :user should have the role :role')]
 	public function userShouldHaveRole(string $user, string $role): void {
 		$userId = $this->featureContext->getAttributeOfCreatedUser($user, 'id');
 		$response = $this->getAssignmentsList($this->featureContext->getAdminUserName(), $userId);
@@ -295,7 +263,6 @@ class SettingsContext implements Context {
 	}
 
 	/**
-	 * @Then /^the setting API response should have the role "([^"]*)"$/
 	 *
 	 * @param string $role
 	 *
@@ -303,6 +270,7 @@ class SettingsContext implements Context {
 	 *
 	 * @throws Exception
 	 */
+	#[Then('the setting API response should have the role :role')]
 	public function theSettingApiResponseShouldHaveTheRole(string $role): void {
 		$assignmentRoleId = $this->featureContext->getJsonDecodedResponse(
 			$this->featureContext->getResponse()
@@ -370,7 +338,6 @@ class SettingsContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" lists values-list with headers using the Settings API$/
 	 *
 	 * @param string $user
 	 * @param TableNode $headersTable
@@ -380,6 +347,7 @@ class SettingsContext implements Context {
 	 * @throws GuzzleException
 	 * @throws Exception
 	 */
+	#[When('user :user lists values-list with headers using the Settings API')]
 	public function theUserListsAllValuesListWithHeadersUsingSettingsApi(string $user, TableNode $headersTable): void {
 		$this->featureContext->verifyTableNodeColumns(
 			$headersTable,
@@ -446,7 +414,6 @@ class SettingsContext implements Context {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" has switched the system language to "([^"]*)" using the settings API$/
 	 *
 	 * @param string $user
 	 * @param string $language
@@ -456,6 +423,7 @@ class SettingsContext implements Context {
 	 * @throws Exception
 	 * @throws GuzzleException
 	 */
+	#[Given('user :user has switched the system language to :language using the settings API')]
 	public function theUserHasSwitchedSystemLanguage(string $user, string $language): void {
 		$response = $this->sendRequestToSwitchSystemLanguage($user, $language);
 		$this->featureContext->theHTTPStatusCodeShouldBe(
@@ -466,7 +434,6 @@ class SettingsContext implements Context {
 	}
 
 	/**
-	 * @When user :user switches the system language to :language using the settings API
 	 *
 	 * @param string $user
 	 * @param string $language
@@ -476,6 +443,7 @@ class SettingsContext implements Context {
 	 * @throws Exception
 	 * @throws GuzzleException
 	 */
+	#[When('user :user switches the system language to :language using the settings API')]
 	public function userSwitchesTheSystemLanguageUsingTheSettingsApi(string $user, string $language): void {
 		$response = $this->sendRequestToSwitchSystemLanguage($user, $language);
 		$this->featureContext->setResponse($response);
@@ -515,8 +483,6 @@ class SettingsContext implements Context {
 	}
 
 	/**
-	 * @Given user :user has disabled auto-accepting
-	 * @Given user :user has disabled the auto-sync share
 	 *
 	 * @param string $user
 	 *
@@ -525,6 +491,8 @@ class SettingsContext implements Context {
 	 * @throws Exception
 	 * @throws GuzzleException
 	 */
+	#[Given('user :user has disabled auto-accepting')]
+	#[Given('user :user has disabled the auto-sync share')]
 	public function theUserHasDisabledAutoAccepting(string $user): void {
 		$response = $this->sendRequestToDisableAutoAccepting($user);
 		$this->featureContext->theHTTPStatusCodeShouldBe(
@@ -536,7 +504,6 @@ class SettingsContext implements Context {
 	}
 
 	/**
-	 * @When user :user disables the auto-sync share using the settings API
 	 *
 	 * @param string $user
 	 *
@@ -545,6 +512,7 @@ class SettingsContext implements Context {
 	 * @throws Exception
 	 * @throws GuzzleException
 	 */
+	#[When('user :user disables the auto-sync share using the settings API')]
 	public function userDisablesAutoAcceptingUsingSettingsApi(string $user): void {
 		$response = $this->sendRequestToDisableAutoAccepting($user);
 		$this->featureContext->setResponse($response);

--- a/tests/acceptance/bootstrap/ShareesContext.php
+++ b/tests/acceptance/bootstrap/ShareesContext.php
@@ -27,6 +27,8 @@ use Psr\Http\Message\ResponseInterface;
 use PHPUnit\Framework\Assert;
 use TestHelpers\BehatHelper;
 use TestHelpers\HttpRequestHelper;
+use Behat\Step\Then;
+use Behat\Step\When;
 
 require_once 'bootstrap.php';
 
@@ -38,13 +40,13 @@ class ShareesContext implements Context {
 	private OCSContext $ocsContext;
 
 	/**
-	 * @When /^user "([^"]*)" gets the sharees using the sharing API with parameters$/
 	 *
 	 * @param string $user
 	 * @param TableNode $body
 	 *
 	 * @return void
 	 */
+	#[When('user :user gets the sharees using the sharing API with parameters')]
 	public function userGetsTheShareesWithParameters(string $user, TableNode $body): void {
 		$this->featureContext->setResponse(
 			$this->getShareesWithParameters(
@@ -55,7 +57,6 @@ class ShareesContext implements Context {
 	}
 
 	/**
-	 * @Then /^the "([^"]*)" sharees returned should be$/
 	 *
 	 * @param string $shareeType
 	 * @param TableNode $shareesList
@@ -63,6 +64,7 @@ class ShareesContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('the :shareeType sharees returned should be')]
 	public function theShareesReturnedShouldBe(string $shareeType, TableNode $shareesList): void {
 		$this->featureContext->verifyTableNodeColumnsCount($shareesList, 4);
 		$sharees = $shareesList->getRows();
@@ -78,37 +80,12 @@ class ShareesContext implements Context {
 	}
 
 	/**
-	 * @Then /^the "([^"]*)" sharees returned should include$/
-	 *
-	 * @param string $shareeType
-	 * @param TableNode $shareesList
-	 *
-	 * @return void
-	 * @throws Exception
-	 */
-	public function theShareesReturnedShouldInclude(string $shareeType, TableNode $shareesList): void {
-		$this->featureContext->verifyTableNodeColumnsCount($shareesList, 3);
-		$sharees = $shareesList->getRows();
-		$respondedArray = $this->getArrayOfShareesResponded(
-			$this->featureContext->getResponse(),
-			$shareeType
-		);
-		foreach ($sharees as $sharee) {
-			Assert::assertContains(
-				$sharee,
-				$respondedArray,
-				"Returned sharees do not match the expected ones. See the differences below."
-			);
-		}
-	}
-
-	/**
-	 * @Then /^the "([^"]*)" sharees returned should be empty$/
 	 *
 	 * @param string $shareeType
 	 *
 	 * @return void
 	 */
+	#[Then('the :shareeType sharees returned should be empty')]
 	public function theShareesReturnedShouldBeEmpty(string $shareeType): void {
 		$respondedArray = $this->getArrayOfShareesResponded(
 			$this->featureContext->getResponse(),

--- a/tests/acceptance/bootstrap/Sharing.php
+++ b/tests/acceptance/bootstrap/Sharing.php
@@ -30,6 +30,9 @@ use TestHelpers\HttpRequestHelper;
 use TestHelpers\TranslationHelper;
 use TestHelpers\WebDavHelper;
 use GuzzleHttp\Exception\GuzzleException;
+use Behat\Step\Given;
+use Behat\Step\Then;
+use Behat\Step\When;
 
 /**
  * Sharing trait
@@ -213,7 +216,7 @@ trait Sharing {
 			throw new Error(
 				'Response did not contain share id '
 				. $this->getJsonDecodedResponse($lastResponse)['link']['webUrl']
-				. ' for the created public link'
+				. '  for the created public link'
 			);
 		}
 		$last_created_link_webURL =  $this->getJsonDecodedResponse($lastResponse)['link']['webUrl'];
@@ -389,7 +392,6 @@ trait Sharing {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" creates a share using the sharing API with settings$/
 	 *
 	 * @param string $user
 	 * @param TableNode|null $body {@link createShareWithSettings}
@@ -397,6 +399,7 @@ trait Sharing {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('user :user creates a share using the sharing API with settings')]
 	public function userCreatesAShareWithSettings(string $user, ?TableNode $body): void {
 		$user = $this->getActualUsername($user);
 		$response = $this->createShareWithSettings(
@@ -422,7 +425,6 @@ trait Sharing {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" creates a public link share using the sharing API with settings$/
 	 *
 	 * @param string $user
 	 * @param TableNode $body
@@ -430,6 +432,7 @@ trait Sharing {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('user :user creates a public link share using the sharing API with settings')]
 	public function userCreatesAPublicLinkShareWithSettings(string $user, TableNode $body): void {
 		$this->setResponse($this->createPublicLinkShare($user, $body));
 		$this->pushToLastStatusCodesArrays();
@@ -572,7 +575,6 @@ trait Sharing {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" updates the last share using the sharing API with$/
 	 *
 	 * @param string $user
 	 * @param TableNode|null $body
@@ -580,13 +582,13 @@ trait Sharing {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('user :user updates the last share using the sharing API with')]
 	public function userUpdatesTheLastShareWith(string $user, ?TableNode $body): void {
 		$this->setResponse($this->updateLastShareWithSettings($user, $body));
 		$this->pushToLastStatusCodesArrays();
 	}
 
 	/**
-	 * @When /^user "([^"]*)" updates the last public link share using the sharing API with$/
 	 *
 	 * @param string $user
 	 * @param TableNode|null $body
@@ -594,13 +596,13 @@ trait Sharing {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('user :user updates the last public link share using the sharing API with')]
 	public function userUpdatesTheLastPublicLinkShareWith(string $user, ?TableNode $body): void {
 		$this->response = $this->updateLastShareWithSettings($user, $body, null, true);
 		$this->pushToLastStatusCodesArrays();
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" has updated the last share with$/
 	 *
 	 * @param string $user
 	 * @param TableNode|null $body
@@ -608,6 +610,7 @@ trait Sharing {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Given('user :user has updated the last share with')]
 	public function userHasUpdatedTheLastShareWith(string $user, ?TableNode $body): void {
 		$response = $this->updateLastShareWithSettings($user, $body);
 		$this->theHTTPStatusCodeShouldBeBetween(200, 299, $response);
@@ -803,10 +806,10 @@ trait Sharing {
 	}
 
 	/**
-	 * @Then no files or folders should be included in the response
 	 *
 	 * @return void
 	 */
+	#[Then('no files or folders should be included in the response')]
 	public function checkNoFilesFoldersInResponse(): void {
 		$data = HttpRequestHelper::getResponseXml($this->response, __METHOD__)->data[0];
 		Assert::assertIsObject($data, __METHOD__ . " data not found in response XML");
@@ -814,12 +817,12 @@ trait Sharing {
 	}
 
 	/**
-	 * @Then exactly :count file/files or folder/folders should be included in the response
 	 *
 	 * @param string $count
 	 *
 	 * @return void
 	 */
+	#[Then('exactly :count file/files or folder/folders should be included in the response')]
 	public function checkCountFilesFoldersInResponse(string $count): void {
 		$count = (int) $count;
 		$data = HttpRequestHelper::getResponseXml($this->response, __METHOD__)->data[0];
@@ -828,13 +831,13 @@ trait Sharing {
 	}
 
 	/**
-	 * @Then /^(?:file|folder|entry) "([^"]*)" should be included in the response$/
 	 *
 	 * @param string $filename
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('/^(?:file|folder|entry) "([^"]*)" should be included in the response$/')]
 	public function checkSharedFileInResponse(string $filename): void {
 		$filename = "/" . \ltrim($filename, '/');
 		Assert::assertTrue(
@@ -844,13 +847,13 @@ trait Sharing {
 	}
 
 	/**
-	 * @Then /^(?:file|folder|entry) "([^"]*)" should not be included in the response$/
 	 *
 	 * @param string $filename
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('/^(?:file|folder|entry) "([^"]*)" should not be included in the response$/')]
 	public function checkSharedFileNotInResponse(string $filename): void {
 		$filename = "/" . \ltrim($filename, '/');
 		Assert::assertFalse(
@@ -860,13 +863,13 @@ trait Sharing {
 	}
 
 	/**
-	 * @Then /^(?:file|folder|entry) "([^"]*)" should be included as path in the response$/
 	 *
 	 * @param string $filename
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('/^(?:file|folder|entry) "([^"]*)" should be included as path in the response$/')]
 	public function checkSharedFileAsPathInResponse(string $filename): void {
 		$filename = "/" . \ltrim($filename, '/');
 		Assert::assertTrue(
@@ -876,13 +879,13 @@ trait Sharing {
 	}
 
 	/**
-	 * @Then /^(?:file|folder|entry) "([^"]*)" should not be included as path in the response$/
 	 *
 	 * @param string $filename
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('/^(?:file|folder|entry) "([^"]*)" should not be included as path in the response$/')]
 	public function checkSharedFileAsPathNotInResponse(string $filename): void {
 		$filename = "/" . \ltrim($filename, '/');
 		Assert::assertFalse(
@@ -892,7 +895,6 @@ trait Sharing {
 	}
 
 	/**
-	 * @Then /^(user|group) "([^"]*)" should be included in the response$/
 	 *
 	 * @param string $type
 	 * @param string $user
@@ -900,6 +902,7 @@ trait Sharing {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('/^(user|group) "([^"]*)" should be included in the response$/')]
 	public function checkSharedUserOrGroupInResponse(string $type, string $user): void {
 		if ($type === 'user') {
 			$user = $this->getActualUsername($user);
@@ -911,14 +914,14 @@ trait Sharing {
 	}
 
 	/**
-	 * @Then /^user "([^"]*)" should not be included in the response$/
-	 * @Then /^group "([^"]*)" should not be included in the response$/
 	 *
 	 * @param string $userOrGroup
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('user :userOrGroup should not be included in the response')]
+	#[Then('group :userOrGroup should not be included in the response')]
 	public function checkSharedUserOrGroupNotInResponse(string $userOrGroup): void {
 		Assert::assertFalse(
 			$this->isFieldInResponse('share_with', "$userOrGroup", false),
@@ -953,8 +956,6 @@ trait Sharing {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" shares (?:file|folder|entry) "([^"]*)" with user "([^"]*)"(?: with permissions (\d+))? using the sharing API$/
-	 * @When /^user "([^"]*)" shares (?:file|folder|entry) "([^"]*)" with user "([^"]*)" with permissions "([^"]*)" using the sharing API$/
 	 *
 	 * @param string $sharer
 	 * @param string $filepath
@@ -963,6 +964,8 @@ trait Sharing {
 	 *
 	 * @return void
 	 */
+	#[When('/^user "([^"]*)" shares (?:file|folder|entry) "([^"]*)" with user "([^"]*)"(?: with permissions (\\d+))? using the sharing API$/')]
+	#[When('/^user "([^"]*)" shares (?:file|folder|entry) "([^"]*)" with user "([^"]*)" with permissions "([^"]*)" using the sharing API$/')]
 	public function userSharesFileWithUserUsingTheSharingApi(
 		string $sharer,
 		string $filepath,
@@ -980,8 +983,6 @@ trait Sharing {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" shares the following (?:files|folders|entries) with user "([^"]*)"(?: with permissions (\d+))? using the sharing API$/
-	 * @When /^user "([^"]*)" shares the following (?:files|folders|entries) with user "([^"]*)" with permissions "([^"]*)" using the sharing API$/
 	 *
 	 * @param string $sharer
 	 * @param string $sharee
@@ -991,6 +992,7 @@ trait Sharing {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('/^user "([^"]*)" shares the following (?:files|folders|entries) with user "([^"]*)" using the sharing API$/')]
 	public function userSharesTheFollowingFilesWithUserUsingTheSharingApi(
 		string $sharer,
 		string $sharee,
@@ -1010,31 +1012,6 @@ trait Sharing {
 			$this->setResponse($response);
 			$this->pushToLastStatusCodesArrays();
 		}
-	}
-
-	/**
-	 * @When /^the user shares (?:file|folder|entry) "([^"]*)" with user "([^"]*)"(?: with permissions (\d+))? using the sharing API$/
-	 * @When /^the user shares (?:file|folder|entry) "([^"]*)" with user "([^"]*)" with permissions "([^"]*)" using the sharing API$/
-	 *
-	 * @param string $filepath
-	 * @param string $user2
-	 * @param string|int|string[]|int[] $permissions
-	 *
-	 * @return void
-	 */
-	public function theUserSharesFileWithUserUsingTheSharingApi(
-		string $filepath,
-		string $user2,
-		$permissions = null
-	) {
-		$response = $this->createAUserShare(
-			$this->getCurrentUser(),
-			$filepath["path"],
-			$this->getActualUsername($user2),
-			$permissions
-		);
-		$this->setResponse($response);
-		$this->pushToLastStatusCodesArrays();
 	}
 
 	/**
@@ -1064,8 +1041,6 @@ trait Sharing {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" shares (?:file|folder|entry) "([^"]*)" with group "([^"]*)" with permissions "([^"]*)" using the sharing API$/
-	 * @When /^user "([^"]*)" shares (?:file|folder|entry) "([^"]*)" with group "([^"]*)"(?: with permissions (\d+))? using the sharing API$/
 	 *
 	 * @param string $user
 	 * @param string $filepath
@@ -1074,6 +1049,8 @@ trait Sharing {
 	 *
 	 * @return void
 	 */
+	#[When('/^user "([^"]*)" shares (?:file|folder|entry) "([^"]*)" with group "([^"]*)" with permissions "([^"]*)" using the sharing API$/')]
+	#[When('/^user "([^"]*)" shares (?:file|folder|entry) "([^"]*)" with group "([^"]*)"(?: with permissions (\\d+))? using the sharing API$/')]
 	public function userSharesFileWithGroupUsingTheSharingApi(
 		string $user,
 		string $filepath,
@@ -1091,8 +1068,6 @@ trait Sharing {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" shares the following (?:files|folders|entries) with group "([^"]*)"(?: with permissions (\d+))? using the sharing API$/
-	 * @When /^user "([^"]*)" shares the following (?:files|folders|entries) with group "([^"]*)" with permissions "([^"]*)" using the sharing API$/
 	 *
 	 * @param string $user
 	 * @param string $group
@@ -1102,6 +1077,7 @@ trait Sharing {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('/^user "([^"]*)" shares the following (?:files|folders|entries) with group "([^"]*)" using the sharing API$/')]
 	public function userSharesTheFollowingFilesWithGroupUsingTheSharingApi(
 		string $user,
 		string $group,
@@ -1124,8 +1100,6 @@ trait Sharing {
 	}
 
 	/**
-	 * @Then /^user "([^"]*)" should not be able to share (?:file|folder|entry) "([^"]*)" with (user|group) "([^"]*)"(?: with permissions (\d+))? using the sharing API$/
-	 * @Then /^user "([^"]*)" should not be able to share (?:file|folder|entry) "([^"]*)" with (user|group) "([^"]*)" with permissions "([^"]*)" using the sharing API$/
 	 *
 	 * @param string $sharer
 	 * @param string $filepath
@@ -1136,6 +1110,7 @@ trait Sharing {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('/^user "([^"]*)" should not be able to share (?:file|folder|entry) "([^"]*)" with (user|group) "([^"]*)" with permissions "([^"]*)" using the sharing API$/')]
 	public function userTriesToShareFileUsingTheSharingApi(
 		string $sharer,
 		string $filepath,
@@ -1161,8 +1136,6 @@ trait Sharing {
 	}
 
 	/**
-	 * @Then /^user "([^"]*)" should be able to share (?:file|folder|entry) "([^"]*)" with (user|group) "([^"]*)"(?: with permissions (\d+))? using the sharing API$/
-	 * @Then /^user "([^"]*)" should be able to share (?:file|folder|entry) "([^"]*)" with (user|group) "([^"]*)" with permissions "([^"]*)" using the sharing API$/
 	 *
 	 * @param string $sharer
 	 * @param string $filepath
@@ -1173,6 +1146,7 @@ trait Sharing {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('/^user "([^"]*)" should be able to share (?:file|folder|entry) "([^"]*)" with (user|group) "([^"]*)" with permissions "([^"]*)" using the sharing API$/')]
 	public function userShouldBeAbleToShareUsingTheSharingApi(
 		string $sharer,
 		string $filepath,
@@ -1238,41 +1212,29 @@ trait Sharing {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" deletes the last share using the sharing API$/
 	 *
 	 * @param string $user
 	 *
 	 * @return void
 	 */
+	#[When('user :user deletes the last share using the sharing API')]
 	public function userDeletesLastShareUsingTheSharingApi(string $user): void {
 		$this->setResponse($this->deleteLastShareUsingSharingApi($user));
 		$this->pushToLastStatusCodesArrays();
 	}
 
 	/**
-	 * @When /^user "([^"]*)" deletes the last share of user "([^"]*)" using the sharing API$/
-	 * @When /^user "([^"]*)" tries to delete the last share of user "([^"]*)" using the sharing API$/
 	 *
 	 * @param string $user
 	 * @param string $sharer
 	 *
 	 * @return void
 	 */
+	#[When('user :user deletes the last share of user :sharer using the sharing API')]
+	#[When('user :user tries to delete the last share of user :sharer using the sharing API')]
 	public function userDeletesLastShareOfUserUsingTheSharingApi(string $user, string $sharer): void {
 		$this->setResponse($this->deleteLastShareUsingSharingApi($user, $sharer));
 		$this->pushToLastStatusCodesArrays();
-	}
-
-	/**
-	 * @Given /^user "([^"]*)" has deleted the last share$/
-	 *
-	 * @param string $user
-	 *
-	 * @return void
-	 */
-	public function userHasDeletedLastShareUsingTheSharingApi(string $user): void {
-		$response = $this->deleteLastShareUsingSharingApi($user);
-		$this->theHTTPStatusCodeShouldBeBetween(200, 299, $response);
 	}
 
 	/**
@@ -1300,13 +1262,13 @@ trait Sharing {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" gets the info of the last share using the sharing API$/
 	 *
 	 * @param string $user username that requests the information (might not be the user that has initiated the share)
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('user :user gets the info of the last share using the sharing API')]
 	public function userGetsInfoOfLastShareUsingTheSharingApi(string $user): void {
 		$response = $this->getLastShareInfo($user, "user");
 		$this->setResponse($response);
@@ -1314,13 +1276,13 @@ trait Sharing {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" gets the info of the last public link share using the sharing API$/
 	 *
 	 * @param string $user username that requests the information (might not be the user that has initiated the share)
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('user :user gets the info of the last public link share using the sharing API')]
 	public function userGetsInfoOfLastPublicLinkShareUsingTheSharingApi(string $user): void {
 		$response = $this->getLastShareInfo($user, "link");
 		$this->setResponse($response);
@@ -1328,7 +1290,6 @@ trait Sharing {
 	}
 
 	/**
-	 * @Then /^as "([^"]*)" the info about the last share by user "([^"]*)" with user "([^"]*)" should include$/
 	 *
 	 * @param string $requester
 	 * @param string $sharer
@@ -1338,6 +1299,7 @@ trait Sharing {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('as :requester the info about the last share by user :sharer with user :sharee should include')]
 	public function asLastShareInfoAboutUserSharingWithUserShouldInclude(
 		string    $requester,
 		string    $sharer,
@@ -1392,18 +1354,17 @@ trait Sharing {
 	}
 
 	/**
-	 * @When user :user gets all the shares shared with him/her using the sharing API
 	 *
 	 * @param string $user
 	 *
 	 * @return void
 	 */
+	#[When('user :user gets all the shares shared with him/her using the sharing API')]
 	public function userGetsAllTheSharesSharedWithHimUsingTheSharingApi(string $user): void {
 		$this->setResponse($this->getSharedWithMeShares($user));
 	}
 
 	/**
-	 * @Then as user :user the last share should include the following properties:
 	 *
 	 * @param string $user
 	 * @param TableNode $table
@@ -1411,6 +1372,7 @@ trait Sharing {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('as user :user the last share should include the following properties:')]
 	public function userGetsTheLastShareSharedWithHimUsingTheSharingApi(string $user, TableNode $table): void {
 		$user = $this->getActualUsername($user);
 		$this->verifyTableNodeRows($table, [], $this->shareResponseFields);
@@ -1436,7 +1398,6 @@ trait Sharing {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" gets the (|pending)\s?(user|group|user and group|public link) shares shared with (?:him|her) using the sharing API$/
 	 *
 	 * @param string $user
 	 * @param string $pending
@@ -1444,6 +1405,7 @@ trait Sharing {
 	 *
 	 * @return void
 	 */
+	#[When('/^user "([^"]*)" gets the (|pending)\\s?(user|group|user and group|public link) shares shared with (?:him|her) using the sharing API$/')]
 	public function userGetsFilteredSharesSharedWithHimUsingTheSharingApi(
 		string $user,
 		string $pending,
@@ -1474,13 +1436,13 @@ trait Sharing {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" gets all the shares shared with (?:him|her|them) that are received as (?:file|folder|entry) "([^"]*)" using the provisioning API$/
 	 *
 	 * @param string $user
 	 * @param string $path
 	 *
 	 * @return void
 	 */
+	#[When('/^user "([^"]*)" gets all the shares shared with (?:him|her|them) that are received as (?:file|folder|entry) "([^"]*)" using the provisioning API$/')]
 	public function userGetsAllSharesSharedWithHimFromFileOrFolderUsingTheProvisioningApi(
 		string $user,
 		string $path
@@ -1522,33 +1484,33 @@ trait Sharing {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" gets all shares shared by (?:him|her) using the sharing API$/
 	 *
 	 * @param string $user
 	 *
 	 * @return void
 	 */
+	#[When('/^user "([^"]*)" gets all shares shared by (?:him|her) using the sharing API$/')]
 	public function userGetsAllSharesSharedByHimUsingTheSharingApi(string $user): void {
 		$this->setResponse($this->getAllshares($user));
 	}
 
 	/**
-	 * @When /^the administrator gets all shares shared by (?:him|her) using the sharing API$/
 	 *
 	 * @return void
 	 */
+	#[When('/^the administrator gets all shares shared by (?:him|her) using the sharing API$/')]
 	public function theAdministratorGetsAllSharesSharedByHimUsingTheSharingApi(): void {
 		$this->setResponse($this->getAllShares($this->getAdminUsername()));
 	}
 
 	/**
-	 * @When /^user "([^"]*)" gets the (user|group|user and group|public link) shares shared by (?:him|her) using the sharing API$/
 	 *
 	 * @param string $user
 	 * @param string $shareType
 	 *
 	 * @return void
 	 */
+	#[When('/^user "([^"]*)" gets the (user|group|user and group|public link) shares shared by (?:him|her) using the sharing API$/')]
 	public function userGetsFilteredSharesSharedByHimUsingTheSharingApi(string $user, string $shareType): void {
 		if ($shareType === 'public link') {
 			$shareType = 'public_link';
@@ -1562,23 +1524,23 @@ trait Sharing {
 	}
 
 	/**
-	 * @When user :user gets all the shares of the file :path using the sharing API
 	 *
 	 * @param string $user
 	 * @param string $path
 	 *
 	 * @return void
 	 */
+	#[When('user :user gets all the shares of the file :path using the sharing API')]
 	public function userGetsAllTheSharesFromTheFileUsingTheSharingApi(string $user, string $path): void {
 		$this->setResponse($this->getAllShares($user, "?path=$path"));
 	}
 
 	/**
-	 * @Then /^the last share_id should be included in the response/
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('/^the last share_id should be included in the response/')]
 	public function checkingLastShareIDIsIncluded(): void {
 		$shareId = ($this->isUsingSharingNG())
 		? $this->shareNgGetLastCreatedUserGroupShareID() : $this->getLastCreatedUserGroupShareId();
@@ -1590,11 +1552,11 @@ trait Sharing {
 	}
 
 	/**
-	 * @Then /^the last share id should not be included in the response/
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('/^the last share id should not be included in the response/')]
 	public function checkLastShareIDIsNotIncluded(): void {
 		$shareId = $this->isUsingSharingNG()
 		? $this->shareNgGetLastCreatedUserGroupShareID() : $this->getLastCreatedUserGroupShareId();
@@ -1636,13 +1598,13 @@ trait Sharing {
 	}
 
 	/**
-	 * @Then user :user should not see the share id of the last share
 	 *
 	 * @param string $user
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('user :user should not see the share id of the last share')]
 	public function userShouldNotSeeShareIdOfLastShare(string $user): void {
 		$response = $this->getSharedWithMeShares($user);
 		$this->theHTTPStatusCodeShouldBe(200, "", $response);
@@ -1656,12 +1618,12 @@ trait Sharing {
 	}
 
 	/**
-	 * @Then user :user should not have any received shares
 	 *
 	 * @param string $user
 	 *
 	 * @return void
 	 */
+	#[Then('user :user should not have any received shares')]
 	public function userShouldNotHaveAnyReceivedShares(string $user): void {
 		$response = $this->getSharedWithMeShares($user);
 		$this->theHTTPStatusCodeShouldBe(200, "", $response);
@@ -1669,12 +1631,12 @@ trait Sharing {
 	}
 
 	/**
-	 * @Then /^the response should contain ([0-9]+) entries$/
 	 *
 	 * @param int $count
 	 *
 	 * @return void
 	 */
+	#[Then('/^the response should contain ([0-9]+) entries$/')]
 	public function checkingTheResponseEntriesCount(int $count): void {
 		$actualCount = \count(HttpRequestHelper::getResponseXml($this->response, __METHOD__)->data[0]);
 		Assert::assertEquals(
@@ -1685,7 +1647,6 @@ trait Sharing {
 	}
 
 	/**
-	 * @Then the fields of the last response to user :user should include
 	 *
 	 * @param string $user
 	 * @param TableNode|null $body
@@ -1693,6 +1654,7 @@ trait Sharing {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('the fields of the last response to user :user should include')]
 	public function checkFields(string $user, ?TableNode $body): void {
 		$this->checkTheFields($user, $body);
 	}
@@ -1734,7 +1696,6 @@ trait Sharing {
 	}
 
 	/**
-	 * @Then the fields of the last response to user :user and space :space should include
 	 *
 	 * @param string $user
 	 * @param string $space
@@ -1743,6 +1704,7 @@ trait Sharing {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('the fields of the last response to user :user and space :space should include')]
 	public function checkFieldsOfSpaceSharingResponse(string $user, string $space, ?TableNode $body): void {
 		$this->verifyTableNodeColumnsCount($body, 2);
 
@@ -1798,7 +1760,6 @@ trait Sharing {
 	}
 
 	/**
-	 * @Then /^the fields of the last response (?:to|about) user "([^"]*)" sharing with (?:user|group) "([^"]*)" should include$/
 	 *
 	 * @param string $sharer
 	 * @param string $sharee
@@ -1807,6 +1768,7 @@ trait Sharing {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('/^the fields of the last response (?:to|about) user "([^"]*)" sharing with (?:user|group) "([^"]*)" should include$/')]
 	public function checkFieldsOfLastResponseToUser(string $sharer, string $sharee, ?TableNode $body): void {
 		$this->checkTheFieldsOfLastResponseToUser($sharer, $sharee, $body);
 	}
@@ -1875,13 +1837,13 @@ trait Sharing {
 	}
 
 	/**
-	 * @Then the fields of the last response should not include
 	 *
 	 * @param TableNode|null $body
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('the fields of the last response should not include')]
 	public function checkFieldsNotInResponse(?TableNode $body): void {
 		$this->verifyTableNodeColumnsCount($body, 2);
 		$bodyRows = $body->getRowsHash();
@@ -1925,7 +1887,6 @@ trait Sharing {
 	}
 
 	/**
-	 * @Then /^as user "([^"]*)" the public shares of (?:file|folder) "([^"]*)" should be$/
 	 *
 	 * @param string $user
 	 * @param string $path
@@ -1934,6 +1895,7 @@ trait Sharing {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('/^as user "([^"]*)" the public shares of (?:file|folder) "([^"]*)" should be$/')]
 	public function checkPublicShares(string $user, string $path, ?TableNode $TableNode): void {
 		$user = $this->getActualUsername($user);
 		$response = $this->getShares($user, $path);
@@ -1975,7 +1937,6 @@ trait Sharing {
 	}
 
 	/**
-	 * @Then /^as user "([^"]*)" the (?:file|folder) "([^"]*)" should not have any shares$/
 	 *
 	 * @param string $user
 	 * @param string $path
@@ -1983,6 +1944,7 @@ trait Sharing {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('/^as user "([^"]*)" the (?:file|folder) "([^"]*)" should not have any shares$/')]
 	public function checkPublicSharesAreEmpty(string $user, string $path): void {
 		$user = $this->getActualUsername($user);
 		$response = $this->getShares($user, $path);
@@ -2037,7 +1999,6 @@ trait Sharing {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" deletes public link share named "([^"]*)" in (?:file|folder) "([^"]*)" using the sharing API$/
 	 *
 	 * @param string $user
 	 * @param string $name
@@ -2045,6 +2006,7 @@ trait Sharing {
 	 *
 	 * @return void
 	 */
+	#[When('/^user "([^"]*)" deletes public link share named "([^"]*)" in (?:file|folder) "([^"]*)" using the sharing API$/')]
 	public function userDeletesPublicLinkShareNamedUsingTheSharingApi(
 		string $user,
 		string $name,
@@ -2124,7 +2086,6 @@ trait Sharing {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" (declines|accepts) share "([^"]*)" offered by user "([^"]*)" using the sharing API$/
 	 *
 	 * @param string $user
 	 * @param string $action
@@ -2135,6 +2096,7 @@ trait Sharing {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('/^user "([^"]*)" (declines|accepts) share "([^"]*)" offered by user "([^"]*)" using the sharing API$/')]
 	public function userReactsToShareOfferedBy(
 		string $user,
 		string $action,
@@ -2153,7 +2115,6 @@ trait Sharing {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" (declines|accepts) the already (?:accepted|declined) share "([^"]*)" offered by user "([^"]*)" using the sharing API$/
 	 *
 	 * @param string $user
 	 * @param string $action
@@ -2164,6 +2125,7 @@ trait Sharing {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('/^user "([^"]*)" (declines|accepts) the already (?:accepted|declined) share "([^"]*)" offered by user "([^"]*)" using the sharing API$/')]
 	public function userAcceptsTheAlreadyAcceptedShareOfferedByUsingTheSharingApi(
 		string $user,
 		string $action,
@@ -2182,7 +2144,6 @@ trait Sharing {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" (declines|accepts) the following shares offered by user "([^"]*)" using the sharing API$/
 	 *
 	 * @param string $user
 	 * @param string $action
@@ -2192,6 +2153,7 @@ trait Sharing {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('/^user "([^"]*)" (declines|accepts) the following shares offered by user "([^"]*)" using the sharing API$/')]
 	public function userReactsToTheFollowingSharesOfferedBy(
 		string $user,
 		string $action,
@@ -2215,7 +2177,6 @@ trait Sharing {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" (declines|accepts) share with ID "([^"]*)" using the sharing API$/
 	 *
 	 * @param string $user
 	 * @param string $action
@@ -2224,6 +2185,7 @@ trait Sharing {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('/^user "([^"]*)" (declines|accepts) share with ID "([^"]*)" using the sharing API$/')]
 	public function userReactsToShareWithShareIDOfferedBy(string $user, string $action, string $share_id): void {
 		$user = $this->getActualUsername($user);
 
@@ -2247,7 +2209,6 @@ trait Sharing {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" has (declined|accepted) share "([^"]*)" offered by user "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $action
@@ -2257,6 +2218,7 @@ trait Sharing {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Given('/^user "([^"]*)" has (declined|accepted) share "([^"]*)" offered by user "([^"]*)"$/')]
 	public function userHasReactedToShareOfferedBy(
 		string $user,
 		string $action,
@@ -2284,7 +2246,6 @@ trait Sharing {
 	}
 
 	/**
-	 * @Then /^user "([^"]*)" should be able to (decline|accept) pending share "([^"]*)" offered by user "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $action
@@ -2294,6 +2255,7 @@ trait Sharing {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('/^user "([^"]*)" should be able to (decline|accept) pending share "([^"]*)" offered by user "([^"]*)"$/')]
 	public function userShouldBeAbleToAcceptShareOfferedBy(
 		string $user,
 		string $action,
@@ -2321,7 +2283,6 @@ trait Sharing {
 
 	/**
 	 *
-	 * @Then /^the sharing API should report to user "([^"]*)" that these shares are in the (pending|accepted|declined) state$/
 	 *
 	 * @param string $user
 	 * @param string $state
@@ -2331,6 +2292,7 @@ trait Sharing {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('/^the sharing API should report to user "([^"]*)" that these shares are in the (pending|accepted|declined) state$/')]
 	public function assertSharesOfUserAreInState(string $user, string $state, TableNode $table): void {
 		$this->verifyTableNodeColumns($table, ["path"], $this->shareResponseFields);
 		$usersShares = $this->getAllSharesSharedWithUser($user, $state);
@@ -2359,7 +2321,6 @@ trait Sharing {
 
 	/**
 	 *
-	 * @Then /^the sharing API should report to user "([^"]*)" that no shares are in the (pending|accepted|declined) state$/
 	 *
 	 * @param string $user
 	 * @param string $state
@@ -2367,6 +2328,7 @@ trait Sharing {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('/^the sharing API should report to user "([^"]*)" that no shares are in the (pending|accepted|declined) state$/')]
 	public function assertNoSharesOfUserAreInState(string $user, string $state): void {
 		$usersShares = $this->getAllSharesSharedWithUser($user, $state);
 		Assert::assertEmpty(
@@ -2407,7 +2369,6 @@ trait Sharing {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" unshares (?:folder|file|entity) "([^"]*)" shared to "([^"]*)"$/
 	 *
 	 * @param string $sharer
 	 * @param string $path
@@ -2416,19 +2377,20 @@ trait Sharing {
 	 * @return void
 	 * @throws JsonException
 	 */
+	#[When('/^user "([^"]*)" unshares (?:folder|file|entity) "([^"]*)" shared to "([^"]*)"$/')]
 	public function userUnsharesResourceSharedTo(string $sharer, string $path, string $sharee): void {
 		$response = $this->unshareResourceSharedTo($sharer, $path, $sharee);
 		$this->setResponse($response);
 	}
 
 	/**
-	 * @Then the sharing API should report that no shares are shared with user :user
 	 *
 	 * @param string $user
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('the sharing API should report that no shares are shared with user :user')]
 	public function assertThatNoSharesAreSharedWithUser(string $user): void {
 		$usersShares = $this->getAllSharesSharedWithUser($user);
 		Assert::assertEmpty(
@@ -2438,13 +2400,13 @@ trait Sharing {
 	}
 
 	/**
-	 * @When user :user gets share with id :share using the sharing API
 	 *
 	 * @param string $user
 	 * @param string $share_id
 	 *
 	 * @return ResponseInterface|null
 	 */
+	#[When('user :user gets share with id :share using the sharing API')]
 	public function userGetsTheLastShareWithTheShareIdUsingTheSharingApi(
 		string $user,
 		string $share_id
@@ -2530,12 +2492,12 @@ trait Sharing {
 	}
 
 	/**
-	 * @When the public accesses the preview of file :path from the last shared public link using the sharing API
 	 *
 	 * @param string $path
 	 *
 	 * @return void
 	 */
+	#[When('the public accesses the preview of file :path from the last shared public link using the sharing API')]
 	public function thePublicAccessesThePreviewOfTheSharedFileUsingTheSharingApi(string $path): void {
 		$token = ($this->isUsingSharingNG())
 		? $this->shareNgGetLastCreatedLinkShareToken() : $this->getLastCreatedPublicShareToken();
@@ -2545,13 +2507,13 @@ trait Sharing {
 	}
 
 	/**
-	 * @When the public accesses the preview of the following files from the last shared public link using the sharing API
 	 *
 	 * @param TableNode $table
 	 *
 	 * @throws Exception
 	 * @return void
 	 */
+	#[When('the public accesses the preview of the following files from the last shared public link using the sharing API')]
 	public function thePublicAccessesThePreviewOfTheFollowingSharedFileUsingTheSharingApi(
 		TableNode $table
 	): void {

--- a/tests/acceptance/bootstrap/SharingNgContext.php
+++ b/tests/acceptance/bootstrap/SharingNgContext.php
@@ -29,6 +29,9 @@ use TestHelpers\GraphHelper;
 use TestHelpers\WebDavHelper;
 use TestHelpers\HttpRequestHelper;
 use TestHelpers\BehatHelper;
+use Behat\Step\Given;
+use Behat\Step\Then;
+use Behat\Step\When;
 
 require_once 'bootstrap.php';
 
@@ -209,7 +212,6 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" gets permissions list for (folder|file) "([^"]*)" of the space "([^"]*)" using the Graph API$/
 	 *
 	 * @param string $user
 	 * @param string $fileOrFolder   (file|folder)
@@ -219,6 +221,7 @@ class SharingNgContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('/^user "([^"]*)" gets permissions list for (folder|file) "([^"]*)" of the space "([^"]*)" using the Graph API$/')]
 	public function userGetsPermissionsListForResourceOfTheSpaceUsingTheGraphAPI(
 		string $user,
 		string $fileOrFolder,
@@ -231,7 +234,6 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" lists the permissions of space "([^"]*)" using permissions endpoint of the Graph API$/
 	 *
 	 * @param string $user
 	 * @param string $space
@@ -239,6 +241,7 @@ class SharingNgContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('user :user lists the permissions of space :space using permissions endpoint of the Graph API')]
 	public function userListsThePermissionsOfSpaceUsingTheGraphApi(string $user, string $space): void {
 		$this->featureContext->setResponse(
 			$this->getPermissionsList($user, 'folder', $space)
@@ -246,7 +249,6 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" tries to list the permissions of space "([^"]*)" owned by "([^"]*)" using permissions endpoint of the Graph API$/
 	 *
 	 * @param string $user
 	 * @param string $space
@@ -255,6 +257,7 @@ class SharingNgContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('user :user tries to list the permissions of space :space owned by :spaceOwner using permissions endpoint of the Graph API')]
 	public function userTriesToListThePermissionsOfSpaceUsingPermissionsEndpointOfTheGraphApi(
 		string $user,
 		string $space,
@@ -439,7 +442,6 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" has sent the following resource share invitation:$/
 	 *
 	 * @param string $user
 	 * @param TableNode $table
@@ -448,6 +450,7 @@ class SharingNgContext implements Context {
 	 * @throws Exception
 	 * @throws GuzzleException
 	 */
+	#[Given('user :user has sent the following resource share invitation:')]
 	public function userHasSentTheFollowingResourceShareInvitation(string $user, TableNode $table): void {
 		$rows = $table->getRowsHash();
 		Assert::assertArrayHasKey(
@@ -460,7 +463,6 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" has sent the following resource share invitation to federated user:$/
 	 *
 	 * @param string $user
 	 * @param TableNode $table
@@ -469,6 +471,7 @@ class SharingNgContext implements Context {
 	 * @throws Exception
 	 * @throws GuzzleException
 	 */
+	#[Given('user :user has sent the following resource share invitation to federated user:')]
 	public function userHasSentTheFollowingResourceShareInvitationToFederatedUser(
 		string $user,
 		TableNode $table
@@ -484,7 +487,6 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" has sent the following space share invitation:$/
 	 *
 	 * @param string $user
 	 * @param TableNode $table
@@ -493,6 +495,7 @@ class SharingNgContext implements Context {
 	 * @throws Exception
 	 * @throws GuzzleException
 	 */
+	#[Given('user :user has sent the following space share invitation:')]
 	public function userHasSentTheFollowingShareShareInvitation(string $user, TableNode $table): void {
 		$rows = $table->getRowsHash();
 		Assert::assertArrayNotHasKey(
@@ -505,8 +508,6 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" sends the following resource share invitation using the Graph API:$/
-	 * @When /^user "([^"]*)" tries to send the following resource share invitation using the Graph API:$/
 	 *
 	 * @param string $user
 	 * @param TableNode $table
@@ -515,6 +516,8 @@ class SharingNgContext implements Context {
 	 * @throws Exception
 	 * @throws GuzzleException
 	 */
+	#[When('user :user sends the following resource share invitation using the Graph API:')]
+	#[When('user :user tries to send the following resource share invitation using the Graph API:')]
 	public function userSendsTheFollowingResourceShareInvitationUsingTheGraphApi(string $user, TableNode $table): void {
 		$rows = $table->getRowsHash();
 		Assert::assertArrayHasKey(
@@ -528,7 +531,6 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" sends the following resource share invitation to federated user using the Graph API:$/
 	 *
 	 * @param string $user
 	 * @param TableNode $table
@@ -537,6 +539,7 @@ class SharingNgContext implements Context {
 	 * @throws Exception
 	 * @throws GuzzleException
 	 */
+	#[When('user :user sends the following resource share invitation to federated user using the Graph API:')]
 	public function userSendsTheFollowingResourceShareInvitationToFederatedUserUsingTheGraphApi(
 		string $user,
 		TableNode $table
@@ -553,7 +556,6 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" sends the following space share invitation using permissions endpoint of the Graph API:$/
 	 *
 	 * @param string $user
 	 * @param TableNode $table
@@ -562,6 +564,7 @@ class SharingNgContext implements Context {
 	 * @throws Exception
 	 * @throws GuzzleException
 	 */
+	#[When('user :user sends the following space share invitation using permissions endpoint of the Graph API:')]
 	public function userSendsTheFollowingSpaceShareInvitationUsingPermissionsEndpointOfTheGraphApi(
 		string $user,
 		TableNode $table
@@ -578,7 +581,6 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" tries to send the following space share invitation to federated user using permissions endpoint of the Graph API:$/
 	 *
 	 * @param string $user
 	 * @param TableNode $table
@@ -587,6 +589,7 @@ class SharingNgContext implements Context {
 	 * @throws Exception
 	 * @throws GuzzleException
 	 */
+	#[When('user :user tries to send the following space share invitation to federated user using permissions endpoint of the Graph API:')]
 	public function userSendsTheFollowingSpaceShareInvitationToFederatedUserUsingPermissionsEndpointOfTheGraphApi(
 		string $user,
 		TableNode $table
@@ -603,13 +606,13 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @Given user :user has updated the last resource share with the following properties:
 	 *
 	 * @param string $user
 	 * @param TableNode $table
 	 *
 	 * @return void
 	 */
+	#[Given('user :user has updated the last resource share with the following properties:')]
 	public function userHasUpdatedTheLastResourceShareWithTheFollowingProperties(string $user, TableNode $table): void {
 		$permissionID = $this->featureContext->shareNgGetLastCreatedUserGroupShareID();
 		$response = $this->updateResourceShare(
@@ -621,13 +624,13 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @When user :user updates the last resource share with the following properties using the Graph API:
 	 *
 	 * @param string $user
 	 * @param TableNode $table
 	 *
 	 * @return void
 	 */
+	#[When('user :user updates the last resource share with the following properties using the Graph API:')]
 	public function userUpdatesTheLastShareWithFollowingPropertiesUsingGraphApi($user, TableNode $table) {
 		$permissionID = $this->featureContext->shareNgGetLastCreatedUserGroupShareID();
 		$this->featureContext->setResponse(
@@ -640,7 +643,6 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" updates the space share for (user|group) "([^"]*)" with the following using the Graph API:$/
 	 *
 	 * @param string $user
 	 * @param string $shareType
@@ -649,6 +651,7 @@ class SharingNgContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[When('/^user "([^"]*)" updates the space share for (user|group) "([^"]*)" with the following using the Graph API:$/')]
 	public function userUpdatesTheSpaceShareForUserOrGroupWithFollowingUsingGraphApi(
 		string $user,
 		string $shareType,
@@ -706,7 +709,6 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @When user :user sends the following share invitation with file-id :fileId using the Graph API:
 	 *
 	 * @param string $user
 	 * @param string $fileId
@@ -716,6 +718,7 @@ class SharingNgContext implements Context {
 	 * @throws JsonException
 	 * @throws GuzzleException
 	 */
+	#[When('user :user sends the following share invitation with file-id :fileId using the Graph API:')]
 	public function userSendsTheFollowingShareInvitationWithFileIdUsingTheGraphApi(
 		string $user,
 		string $fileId,
@@ -728,8 +731,6 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" creates the following resource link share using the Graph API:$/
-	 * @When /^user "([^"]*)" tries to create the following resource link share using the Graph API:$/
 	 *
 	 * @param string $user
 	 * @param TableNode $body
@@ -737,13 +738,14 @@ class SharingNgContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('user :user creates the following resource link share using the Graph API:')]
+	#[When('user :user tries to create the following resource link share using the Graph API:')]
 	public function userCreatesAPublicLinkShareWithSettings(string $user, TableNode  $body): void {
 		$response = $this->createLinkShare($user, $body);
 		$this->featureContext->setResponse($response);
 	}
 
 	/**
-	 * @When /^user "([^"]*)" (?:tries to create|creates) the following space link share using permissions endpoint of the Graph API:$/
 	 *
 	 * @param string $user
 	 * @param TableNode $body
@@ -751,6 +753,7 @@ class SharingNgContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('/^user "([^"]*)" (?:tries to create|creates) the following space link share using permissions endpoint of the Graph API:$/')]
 	public function userCreatesTheFollowingSpaceLinkShareUsingPermissionsEndpointOfTheGraphApi(
 		string $user,
 		TableNode $body
@@ -759,7 +762,6 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" has created the following resource link share:$/
 	 *
 	 * @param string $user
 	 * @param TableNode $body
@@ -767,6 +769,7 @@ class SharingNgContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[Given('user :user has created the following resource link share:')]
 	public function userHasCreatedTheFollowingResourceLinkShare(string $user, TableNode  $body): void {
 		$rows = $body->getRowsHash();
 		Assert::assertArrayHasKey(
@@ -780,7 +783,6 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" has created the following space link share:$/
 	 *
 	 * @param string $user
 	 * @param TableNode $body
@@ -788,6 +790,7 @@ class SharingNgContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[Given('user :user has created the following space link share:')]
 	public function userHasCreatedTheFollowingLinkShare(string $user, TableNode  $body): void {
 		$rows = $body->getRowsHash();
 		Assert::assertArrayNotHasKey(
@@ -801,7 +804,6 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @Given user :user has updated the last resource/space link share with
 	 *
 	 * @param string $user
 	 * @param TableNode $body
@@ -809,6 +811,7 @@ class SharingNgContext implements Context {
 	 * @return void
 	 * @throws Exception|GuzzleException
 	 */
+	#[Given('user :user has updated the last resource/space link share with')]
 	public function userHasUpdatedLastPublicLinkShare(string $user, TableNode  $body): void {
 		$response = $this->updateLinkShare(
 			$user,
@@ -819,8 +822,6 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @When user :user updates the last public link share using the permissions endpoint of the Graph API:
-	 * @When user :user tries to update the last public link share using the permissions endpoint of the Graph API:
 	 *
 	 * @param string $user
 	 * @param TableNode $body
@@ -828,6 +829,8 @@ class SharingNgContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('user :user updates the last public link share using the permissions endpoint of the Graph API:')]
+	#[When('user :user tries to update the last public link share using the permissions endpoint of the Graph API:')]
 	public function userUpdatesTheLastPublicLinkShareUsingThePermissionsEndpointOfTheGraphApi(
 		string $user,
 		TableNode  $body
@@ -921,7 +924,6 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @Given user :user has set the following password for the last link share:
 	 *
 	 * @param string $user
 	 * @param TableNode $body
@@ -929,6 +931,7 @@ class SharingNgContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Given('user :user has set the following password for the last link share:')]
 	public function userHasSetTheFollowingPasswordForTheLastLinkShare(string $user, TableNode  $body): void {
 		$response = $this->setLinkSharePassword(
 			$user,
@@ -943,8 +946,6 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @When user :user sets the following password for the last link share using the Graph API:
-	 * @When user :user tries to set the following password for the last link share using the Graph API:
 	 *
 	 * @param string $user
 	 * @param TableNode $body
@@ -952,6 +953,8 @@ class SharingNgContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('user :user sets the following password for the last link share using the Graph API:')]
+	#[When('user :user tries to set the following password for the last link share using the Graph API:')]
 	public function userSetsOrUpdatesFollowingPasswordForLastLinkShareUsingTheGraphApi(
 		string $user,
 		TableNode $body
@@ -1048,7 +1051,6 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" has removed the access of (user|group) "([^"]*)" from (?:file|folder|resource) "([^"]*)" of space "([^"]*)"$/
 	 *
 	 * @param string $sharer
 	 * @param string $recipientType (user|group)
@@ -1060,6 +1062,7 @@ class SharingNgContext implements Context {
 	 * @throws JsonException
 	 * @throws GuzzleException
 	 */
+	#[Given('/^user "([^"]*)" has removed the access of (user|group) "([^"]*)" from (?:file|folder|resource) "([^"]*)" of space "([^"]*)"$/')]
 	public function userHasRemovedAccessOfUserOrGroupFromResourceOfSpace(
 		string $sharer,
 		string $recipientType,
@@ -1072,7 +1075,6 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" removes the access of (user|group) "([^"]*)" from (?:file|folder|resource) "([^"]*)" of space "([^"]*)" using the Graph API$/
 	 *
 	 * @param string $sharer
 	 * @param string $recipientType (user|group)
@@ -1084,6 +1086,7 @@ class SharingNgContext implements Context {
 	 * @throws JsonException
 	 * @throws GuzzleException
 	 */
+	#[When('/^user "([^"]*)" removes the access of (user|group) "([^"]*)" from (?:file|folder|resource) "([^"]*)" of space "([^"]*)" using the Graph API$/')]
 	public function userRemovesAccessOfUserOrGroupFromResourceOfSpaceUsingGraphAPI(
 		string $sharer,
 		string $recipientType,
@@ -1097,7 +1100,6 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" removes the access of (user|group) "([^"]*)" from space "([^"]*)" using permissions endpoint of the Graph API$/
 	 *
 	 * @param string $sharer
 	 * @param string $recipientType (user|group)
@@ -1108,6 +1110,7 @@ class SharingNgContext implements Context {
 	 * @throws JsonException
 	 * @throws GuzzleException
 	 */
+	#[When('/^user "([^"]*)" removes the access of (user|group) "([^"]*)" from space "([^"]*)" using permissions endpoint of the Graph API$/')]
 	public function userRemovesAccessOfUserOrGroupFromSpaceUsingPermissionsEndpointOfGraphAPI(
 		string $sharer,
 		string $recipientType,
@@ -1120,7 +1123,6 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" has removed the last link share of (?:file|folder) "([^"]*)" from space "([^"]*)"$/
 	 *
 	 * @param string $sharer
 	 * @param string $resource
@@ -1130,6 +1132,7 @@ class SharingNgContext implements Context {
 	 * @throws JsonException
 	 * @throws GuzzleException
 	 */
+	#[When('/^user "([^"]*)" has removed the last link share of (?:file|folder) "([^"]*)" from space "([^"]*)"$/')]
 	public function userHasRemovedTheLastLinkShareOfFileOrFolderFromSpace(
 		string $sharer,
 		string $resource,
@@ -1140,7 +1143,6 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" removes the link of (?:file|folder) "([^"]*)" from space "([^"]*)" using the Graph API$/
 	 *
 	 * @param string $sharer
 	 * @param string $resource
@@ -1150,6 +1152,7 @@ class SharingNgContext implements Context {
 	 * @throws JsonException
 	 * @throws GuzzleException
 	 */
+	#[When('/^user "([^"]*)" removes the link of (?:file|folder) "([^"]*)" from space "([^"]*)" using the Graph API$/')]
 	public function userRemovesSharePermissionOfAResourceInLinkShareUsingGraphAPI(
 		string $sharer,
 		string $resource,
@@ -1161,8 +1164,6 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" removes the access of (user|group) "([^"]*)" from space "([^"]*)" using root endpoint of the Graph API$/
-	 * @When /^user "([^"]*)" tries to remove the access of (user|group) "([^"]*)" from space "([^"]*)" using root endpoint of the Graph API$/
 	 *
 	 * @param string $sharer
 	 * @param string $recipientType (user|group)
@@ -1173,6 +1174,8 @@ class SharingNgContext implements Context {
 	 * @throws JsonException
 	 * @throws GuzzleException
 	 */
+	#[When('/^user "([^"]*)" removes the access of (user|group) "([^"]*)" from space "([^"]*)" using root endpoint of the Graph API$/')]
+	#[When('/^user "([^"]*)" tries to remove the access of (user|group) "([^"]*)" from space "([^"]*)" using root endpoint of the Graph API$/')]
 	public function userRemovesAccessOfUserOrGroupFromSpaceUsingGraphAPI(
 		string $sharer,
 		string $recipientType,
@@ -1185,8 +1188,6 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" removes own access from space "([^"]*)" using root endpoint of the Graph API$/
-	 * @When /^user "([^"]*)" tries to remove own access from space "([^"]*)" using root endpoint of the Graph API$/
 	 *
 	 * @param string $user
 	 * @param string $space
@@ -1195,6 +1196,7 @@ class SharingNgContext implements Context {
 	 * @throws JsonException
 	 * @throws GuzzleException
 	 */
+	#[When('user :user tries to remove own access from space :space using root endpoint of the Graph API')]
 	public function userRemovesOwnAccessFromSpaceUsingGraphAPI(
 		string $user,
 		string $space
@@ -1205,7 +1207,6 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" has removed own access from space "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $space
@@ -1214,6 +1215,7 @@ class SharingNgContext implements Context {
 	 * @throws JsonException
 	 * @throws GuzzleException
 	 */
+	#[Given('user :user has removed own access from space :space')]
 	public function userHasRemovedOwnAccessFromSpace(
 		string $user,
 		string $space
@@ -1223,7 +1225,6 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" removes the link from space "([^"]*)" using root endpoint of the Graph API$/
 	 *
 	 * @param string $sharer
 	 * @param string $space
@@ -1232,6 +1233,7 @@ class SharingNgContext implements Context {
 	 * @throws JsonException
 	 * @throws GuzzleException
 	 */
+	#[When('user :sharer removes the link from space :space using root endpoint of the Graph API')]
 	public function userRemovesLinkFromSpaceUsingRootEndpointOfGraphAPI(
 		string $sharer,
 		string $space
@@ -1242,7 +1244,6 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" has removed the access of (user|group) "([^"]*)" from space "([^"]*)"$/
 	 *
 	 * @param string $sharer
 	 * @param string $recipientType (user|group)
@@ -1253,6 +1254,7 @@ class SharingNgContext implements Context {
 	 * @throws JsonException
 	 * @throws GuzzleException
 	 */
+	#[Given('/^user "([^"]*)" has removed the access of (user|group) "([^"]*)" from space "([^"]*)"$/')]
 	public function userHasRemovedAccessOfUserOrGroupFromSpace(
 		string $sharer,
 		string $recipientType,
@@ -1288,13 +1290,13 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @Given user :user has disabled sync of last shared resource
 	 *
 	 * @param string $user
 	 *
 	 * @return void
 	 * @throws Exception|GuzzleException
 	 */
+	#[Given('user :user has disabled sync of last shared resource')]
 	public function userHasDisabledSyncOfLastSharedResource(string $user): void {
 		$shareItemId = $this->featureContext->shareNgGetLastCreatedUserGroupShareID();
 		$shareSpaceId = GraphHelper::SHARES_SPACE_ID;
@@ -1315,14 +1317,14 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @When user :user disables sync of share :share using the Graph API
-	 * @When user :user tries to disable sync of share :share using the Graph API
 	 *
 	 * @param string $user
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('user :user disables sync of share :share using the Graph API')]
+	#[When('user :user tries to disable sync of share :share using the Graph API')]
 	public function userDisablesSyncOfShareUsingTheGraphApi(string $user): void {
 		$shareItemId = $this->featureContext->shareNgGetLastCreatedUserGroupShareID();
 		$shareSpaceId = GraphHelper::SHARES_SPACE_ID;
@@ -1342,7 +1344,6 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @When user :user hides the shared resource :sharedResource using the Graph API
 	 *
 	 * @param string $user
 	 *
@@ -1350,6 +1351,7 @@ class SharingNgContext implements Context {
 	 * @throws Exception
 	 * @throws GuzzleException
 	 */
+	#[When('user :user hides the shared resource :sharedResource using the Graph API')]
 	public function userHidesTheSharedResourceUsingTheGraphApi(string $user): void {
 		$shareItemId = $this->featureContext->shareNgGetLastCreatedUserGroupShareID();
 		$response = $this->hideOrUnhideSharedResource($user, $shareItemId);
@@ -1357,7 +1359,6 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @Given  user :user has hidden the share :sharedResource
 	 *
 	 * @param string $user
 	 *
@@ -1365,6 +1366,7 @@ class SharingNgContext implements Context {
 	 * @throws Exception
 	 * @throws GuzzleException
 	 */
+	#[Given('user :user has hidden the share :sharedResource')]
 	public function userHasHiddenTheShare(string $user): void {
 		$shareItemId = $this->featureContext->shareNgGetLastCreatedUserGroupShareID();
 		$response = $this->hideOrUnhideSharedResource($user, $shareItemId);
@@ -1372,7 +1374,6 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @When user :user unhides the shared resource :sharedResource using the Graph API
 	 *
 	 * @param string $user
 	 *
@@ -1380,6 +1381,7 @@ class SharingNgContext implements Context {
 	 * @throws Exception
 	 * @throws GuzzleException
 	 */
+	#[When('user :user unhides the shared resource :sharedResource using the Graph API')]
 	public function userUnhidesTheSharedResourceUsingTheGraphApi(string $user): void {
 		$shareItemId = $this->featureContext->shareNgGetLastCreatedUserGroupShareID();
 		$response = $this->hideOrUnhideSharedResource($user, $shareItemId, false);
@@ -1387,7 +1389,6 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @When user :user enables sync of share :share offered by :offeredBy from :space space using the Graph API
 	 *
 	 * @param string $user
 	 * @param string $share
@@ -1397,6 +1398,7 @@ class SharingNgContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('user :user enables sync of share :share offered by :offeredBy from :space space using the Graph API')]
 	public function userEnablesSyncOfShareUsingTheGraphApi(
 		string $user,
 		string $share,
@@ -1420,15 +1422,14 @@ class SharingNgContext implements Context {
 	/**
 	 * step definition for enabling sync for items for non-existing group|user|space sharer
 	 *
-	 * @When user :user tries to enable share sync of a resource :resource using the Graph API
-	 * @When user :user enables share sync of a resource :resource using the Graph API
-	 *
 	 * @param string $user
 	 * @param string $resource
 	 *
 	 * @return void
 	 * @throws Exception|GuzzleException
 	 */
+	#[When('user :user tries to enable share sync of a resource :resource using the Graph API')]
+	#[When('user :user enables share sync of a resource :resource using the Graph API')]
 	public function userTriesToEnableShareSyncOfResourceUsingTheGraphApi(string $user, string $resource): void {
 		$shareSpaceId = GraphHelper::SHARES_SPACE_ID;
 		$itemId = ($resource === 'nonexistent') ? WebDavHelper::generateUUIDv4() : $resource;
@@ -1445,7 +1446,6 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @When user :user tries to disable share sync of a resource :resource using the Graph API
 	 *
 	 * @param string $user
 	 * @param string $resource
@@ -1453,6 +1453,7 @@ class SharingNgContext implements Context {
 	 * @return void
 	 * @throws Exception|GuzzleException
 	 */
+	#[When('user :user tries to disable share sync of a resource :resource using the Graph API')]
 	public function userTriesToDisableShareSyncOfResourceUsingTheGraphApi(string $user, string $resource): void {
 		$shareSpaceId = GraphHelper::SHARES_SPACE_ID;
 		$shareID = ($resource === 'nonexistent') ? WebDavHelper::generateUUIDv4() : $resource;
@@ -1528,7 +1529,6 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @Then /^user "([^"]*)" has a share "([^"]*)" synced$/
 	 *
 	 * @param string $user
 	 * @param string $resource
@@ -1536,12 +1536,12 @@ class SharingNgContext implements Context {
 	 * @return void
 	 * @throws Exception|GuzzleException
 	 */
+	#[Then('user :user has a share :resource synced')]
 	public function userHasShareSynced(string $user, string $resource): void {
 		$this->waitAndCheckShareSyncStatus($user, $resource, "enabled");
 	}
 
 	/**
-	 * @Then /^user "([^"]*)" should have sync (enabled|disabled) for share "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $status
@@ -1550,12 +1550,12 @@ class SharingNgContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[Then('/^user "([^"]*)" should have sync (enabled|disabled) for share "([^"]*)"$/')]
 	public function userShouldHaveSyncEnabledOrDisabledForShare(string $user, string $status, string $resource): void {
 		$this->waitAndCheckShareSyncStatus($user, $resource, $status);
 	}
 
 	/**
-	 * @Then user :user should be able to send the following resource share invitation with all allowed permission roles
 	 *
 	 * @param string $user
 	 * @param TableNode $table
@@ -1564,6 +1564,7 @@ class SharingNgContext implements Context {
 	 * @throws Exception
 	 * @throws GuzzleException
 	 */
+	#[Then('user :user should be able to send the following resource share invitation with all allowed permission roles')]
 	public function userShouldBeAbleToSendShareTheFollowingInvitationWithAllAllowedPermissionRoles(
 		string $user,
 		TableNode $table
@@ -1615,7 +1616,6 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" (?:tries to list|lists) the permissions of space "([^"]*)" using root endpoint of the Graph API$/
 	 *
 	 * @param string $user
 	 * @param string $space
@@ -1625,12 +1625,12 @@ class SharingNgContext implements Context {
 	 * @throws GuzzleException
 	 *
 	 */
+	#[When('/^user "([^"]*)" (?:tries to list|lists) the permissions of space "([^"]*)" using root endpoint of the Graph API$/')]
 	public function userListsThePermissionsOfDriveUsingRootEndPointOFTheGraphApi(string $user, string $space): void {
 		$this->featureContext->setResponse($this->getDrivePermissionsList($user, $space));
 	}
 
 	/**
-	 * @When /^user "([^"]*)" (?:tries to send|sends) the following space share invitation using root endpoint of the Graph API:$/
 	 *
 	 * @param string $user
 	 * @param TableNode $table
@@ -1638,6 +1638,7 @@ class SharingNgContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('/^user "([^"]*)" (?:tries to send|sends) the following space share invitation using root endpoint of the Graph API:$/')]
 	public function userSendsTheFollowingShareInvitationUsingRootEndPointTheGraphApi(
 		string $user,
 		TableNode $table
@@ -1647,7 +1648,6 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" tries to send the following space share invitation to federated user using root endpoint of the Graph API:$/
 	 *
 	 * @param string $user
 	 * @param TableNode $table
@@ -1655,6 +1655,7 @@ class SharingNgContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('user :user tries to send the following space share invitation to federated user using root endpoint of the Graph API:')]
 	public function userSendsTheFollowingShareInvitationToFederatedUserUsingRootEndPointTheGraphApi(
 		string $user,
 		TableNode $table
@@ -1664,7 +1665,6 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @When user :user updates the last drive share with the following using root endpoint of the Graph API:
 	 *
 	 * @param string $user
 	 * @param TableNode $table
@@ -1672,6 +1672,7 @@ class SharingNgContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('user :user updates the last drive share with the following using root endpoint of the Graph API:')]
 	public function userUpdatesTheLastDriveShareWithTheFollowingUsingRootEndpointOfTheGraphApi(
 		string $user,
 		TableNode $table
@@ -1705,7 +1706,6 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" (?:tries to create|creates) the following space link share using root endpoint of the Graph API:$/
 	 *
 	 * @param string $user
 	 * @param TableNode $body
@@ -1713,6 +1713,7 @@ class SharingNgContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('/^user "([^"]*)" (?:tries to create|creates) the following space link share using root endpoint of the Graph API:$/')]
 	public function userCreatesTheFollowingSpaceLinkShareUsingRootEndpointOfTheGraphApi(
 		string $user,
 		TableNode $body
@@ -1729,7 +1730,6 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @When user :user sets the following password for the last space link share using root endpoint of the Graph API:
 	 *
 	 * @param string $user
 	 * @param TableNode $body
@@ -1737,6 +1737,7 @@ class SharingNgContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('user :user sets the following password for the last space link share using root endpoint of the Graph API:')]
 	public function userSetsTheFollowingPasswordForTheLastSpaceLinkShareUsingRootEndpointOfTheGraphAPI(
 		string $user,
 		TableNode $body
@@ -1769,7 +1770,6 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @When user :user tries to remove the link from space :space owned by :owner using root endpoint of the Graph API
 	 *
 	 * @param string $user
 	 * @param string $space
@@ -1778,6 +1778,7 @@ class SharingNgContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('user :user tries to remove the link from space :space owned by :owner using root endpoint of the Graph API')]
 	public function userTriesToRemoveShareLinkOfSpaceOwnedByUsingRootEndpointOfTheGraphApi(
 		string $user,
 		string $space,
@@ -1798,7 +1799,6 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @Then user :user should not have any :shareType permissions on space :space
 	 *
 	 * @param string $user
 	 * @param string $shareType
@@ -1807,6 +1807,7 @@ class SharingNgContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[Then('user :user should not have any :shareType permissions on space :space')]
 	public function userShouldNotHaveAnyPermissionsOnSpace(string $user, string $shareType, string $space): void {
 		$response = $this->getDrivePermissionsList($user, $space);
 		$responseBody = $this->featureContext->getJsonDecodedResponse($response);
@@ -1833,7 +1834,6 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @Then user :user should be able to send the following space share invitation with all allowed permission roles using root endpoint of the Graph API
 	 *
 	 * @param string $user
 	 * @param TableNode $table
@@ -1842,6 +1842,7 @@ class SharingNgContext implements Context {
 	 * @throws GuzzleException
 	 * @codingStandardsIgnoreStart
 	 */
+	#[Then('user :user should be able to send the following space share invitation with all allowed permission roles using root endpoint of the Graph API')]
 	public function userShouldBeAbleToSendTheFollowingSpaceShareInvitationWithAllAllowedPermissionRolesUsingRootEndpointOFTheGraphApi(
 		// @codingStandardsIgnoreEnd
 		string $user,
@@ -1893,7 +1894,6 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @When user :user tries to list the permissions of space :space owned by :spaceOwner using root endpoint of the Graph API
 	 *
 	 * @param string $user
 	 * @param string $space
@@ -1902,6 +1902,7 @@ class SharingNgContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('user :user tries to list the permissions of space :space owned by :spaceOwner using root endpoint of the Graph API')]
 	public function userTriesToListThePermissionsOfSpaceOwnedByUsingRootEndpointOfTheGraphApi(
 		string $user,
 		string $space,
@@ -1911,13 +1912,13 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @When user :user removes the last link share of space :space using permissions endpoint of the Graph API
 	 *
 	 * @param string $user
 	 * @param string $space
 	 *
 	 * @return void
 	 */
+	#[When('user :user removes the last link share of space :space using permissions endpoint of the Graph API')]
 	public function userRemovesTheLastLinkShareOfSpaceUsingPermissionsEndpointOfGraphApi(
 		string $user,
 		string $space
@@ -2010,7 +2011,6 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @Then /^user "([^"]*)" (should|should not) have a share "([^"]*)" shared by user "([^"]*)" from space "([^"]*)"$/
 	 *
 	 * @param string $sharee
 	 * @param string $shouldOrNot
@@ -2020,6 +2020,7 @@ class SharingNgContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[Then('/^user "([^"]*)" (should|should not) have a share "([^"]*)" shared by user "([^"]*)" from space "([^"]*)"$/')]
 	public function userShouldHaveShareSharedByUserFromSpace(
 		string $sharee,
 		string $shouldOrNot,
@@ -2031,7 +2032,6 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @Then /^user "([^"]*)" (should|should not) have a federated share "([^"]*)" shared by user "([^"]*)" from space "([^"]*)"$/
 	 *
 	 * @param string $sharee
 	 * @param string $shouldOrNot
@@ -2041,6 +2041,7 @@ class SharingNgContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[Then('/^user "([^"]*)" (should|should not) have a federated share "([^"]*)" shared by user "([^"]*)" from space "([^"]*)"$/')]
 	public function userShouldOrShouldNotHaveFederatedShareSharedByUserFromSpace(
 		string $sharee,
 		string $shouldOrNot,
@@ -2052,7 +2053,6 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" has shared the following (?:files|folders) from space "([^"]*)" with user "([^"]*)" and role "([^"]*)":$/
 	 *
 	 * @param string $sharer
 	 * @param string $space
@@ -2062,6 +2062,7 @@ class SharingNgContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[Given('/^user "([^"]*)" has shared the following (?:files|folders) from space "([^"]*)" with user "([^"]*)" and role "([^"]*)":$/')]
 	public function userHasSharedTheFollowingFilesFromSpaceWithUserAndRole(
 		string $sharer,
 		string $space,
@@ -2086,12 +2087,12 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @Then the json response should contain the following shares:
 	 *
 	 * @param TableNode $table
 	 *
 	 * @return void
 	 */
+	#[Then('the json response should contain the following shares:')]
 	public function theJsonResponseShouldContainTheFollowingShares(TableNode $table): void {
 		$responseBody = $this->featureContext->getJsonDecodedResponseBodyContent();
 
@@ -2115,7 +2116,6 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" gets the allowed roles for federated user of (folder|file) "([^"]*)" from the space "([^"]*)" using the Graph API$/
 	 *
 	 * @param string $user
 	 * @param string $fileOrFolder (file|folder)
@@ -2125,6 +2125,7 @@ class SharingNgContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('/^user "([^"]*)" gets the allowed roles for federated user of (folder|file) "([^"]*)" from the space "([^"]*)" using the Graph API$/')]
 	public function userGetsFederatedPermissionsListForFileOfTheSpaceUsingTheGraphApi(
 		string $user,
 		string $fileOrFolder,
@@ -2140,7 +2141,6 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" gets the permittion list of (folder|file) "([^"]*)" from the space "([^"]*)" using the Graph API with query "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $fileOrFolder (file|folder)
@@ -2151,6 +2151,7 @@ class SharingNgContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('/^user "([^"]*)" gets the permittion list of (folder|file) "([^"]*)" from the space "([^"]*)" using the Graph API with query "([^"]*)"$/')]
 	public function userGetsPermissionsListWithQueryForFileOfTheSpaceUsingTheGraphApi(
 		string $user,
 		string $fileOrFolder,
@@ -2164,7 +2165,6 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" gets the drive permittion list of the space "([^"]*)" using the Graph API with query "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $space
@@ -2173,6 +2173,7 @@ class SharingNgContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('user :user gets the drive permittion list of the space :space using the Graph API with query :query')]
 	public function userGetsDrivePermissionsListWithQueryUsingTheGraphApi(
 		string $user,
 		string $space,
@@ -2182,7 +2183,6 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @Then /^the JSON data of the response should (not |)contain the following keys:$/
 	 *
 	 * @param string|null $shouldOrNot (not| )
 	 * @param TableNode $table
@@ -2190,6 +2190,7 @@ class SharingNgContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('/^the JSON data of the response should (not |)contain the following keys:$/')]
 	public function theJsonDataResponseShouldOrNotContainData(string $shouldOrNot, TableNode $table): void {
 		$response = $this->featureContext->getJsonDecodedResponse($this->featureContext->getResponse());
 

--- a/tests/acceptance/bootstrap/SpacesContext.php
+++ b/tests/acceptance/bootstrap/SpacesContext.php
@@ -32,6 +32,9 @@ use TestHelpers\WebDavHelper;
 use TestHelpers\GraphHelper;
 use TestHelpers\OcHelper;
 use TestHelpers\BehatHelper;
+use Behat\Step\Given;
+use Behat\Step\Then;
+use Behat\Step\When;
 
 require_once 'bootstrap.php';
 
@@ -43,7 +46,6 @@ class SpacesContext implements Context {
 	private OCSContext $ocsContext;
 	private TrashbinContext $trashbinContext;
 	private WebDavPropertiesContext $webDavPropertiesContext;
-	private FavoritesContext $favoritesContext;
 	private ChecksumContext $checksumContext;
 	private FilesVersionsContext $filesVersionsContext;
 	private ArchiverContext $archiverContext;
@@ -472,7 +474,6 @@ class SpacesContext implements Context {
 		$this->ocsContext = BehatHelper::getContext($scope, $environment, 'OCSContext');
 		$this->trashbinContext = BehatHelper::getContext($scope, $environment, 'TrashbinContext');
 		$this->webDavPropertiesContext = BehatHelper::getContext($scope, $environment, 'WebDavPropertiesContext');
-		$this->favoritesContext = BehatHelper::getContext($scope, $environment, 'FavoritesContext');
 		$this->checksumContext = BehatHelper::getContext($scope, $environment, 'ChecksumContext');
 		$this->filesVersionsContext = BehatHelper::getContext($scope, $environment, 'FilesVersionsContext');
 		$this->archiverContext = BehatHelper::getContext($scope, $environment, 'ArchiverContext');
@@ -594,8 +595,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" lists all available spaces via the Graph API$/
-	 * @When /^user "([^"]*)" lists all available spaces via the Graph API with query "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $query
@@ -605,12 +604,13 @@ class SpacesContext implements Context {
 	 * @throws GuzzleException
 	 * @throws Exception
 	 */
+	#[When('user :user lists all available spaces via the Graph API')]
+	#[When('user :user lists all available spaces via the Graph API with query :query')]
 	public function theUserListsAllHisAvailableSpacesUsingTheGraphApi(string $user, string $query = ''): void {
 		$this->featureContext->setResponse($this->listAllAvailableSpacesOfUser($user, $query));
 	}
 
 	/**
-	 * @When /^user "([^"]*)" lists all available spaces with headers using the Graph API$/
 	 *
 	 * @param string $user
 	 * @param TableNode $headersTable
@@ -620,6 +620,7 @@ class SpacesContext implements Context {
 	 * @throws GuzzleException
 	 * @throws Exception
 	 */
+	#[When('user :user lists all available spaces with headers using the Graph API')]
 	public function theUserListsAllHisAvailableSpacesWithHeadersUsingTheGraphApi(
 		string $user,
 		TableNode $headersTable
@@ -659,9 +660,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" lists all spaces via the Graph API$/
-	 * @When /^user "([^"]*)" lists all spaces via the Graph API with query "([^"]*)"$/
-	 * @When /^user "([^"]*)" tries to list all spaces via the Graph API$/
 	 *
 	 * @param string $user
 	 * @param string $query
@@ -671,6 +669,9 @@ class SpacesContext implements Context {
 	 * @throws GuzzleException
 	 * @throws Exception
 	 */
+	#[When('user :user lists all spaces via the Graph API')]
+	#[When('user :user lists all spaces via the Graph API with query :query')]
+	#[When('user :user tries to list all spaces via the Graph API')]
 	public function theUserListsAllAvailableSpacesUsingTheGraphApi(string $user, string $query = ''): void {
 		$this->featureContext->setResponse(
 			$this->listAllAvailableSpaces($user, $query)
@@ -678,8 +679,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" looks up the single space "([^"]*)" via the Graph API by using its id$/
-	 * @When /^user "([^"]*)" tries to look up the single space "([^"]*)" owned by the user "([^"]*)" by using its id$/
 	 *
 	 * @param string $user
 	 * @param string $spaceName
@@ -688,6 +687,8 @@ class SpacesContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('user :user looks up the single space :spaceName via the Graph API by using its id')]
+	#[When('user :user tries to look up the single space :spaceName owned by the user :ownerUser by using its id')]
 	public function theUserLooksUpTheSingleSpaceUsingTheGraphApiByUsingItsId(
 		string $user,
 		string $spaceName,
@@ -709,8 +710,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" (?:creates|tries to create) a space "([^"]*)" of type "([^"]*)" with quota "([^"]*)" using the Graph API$/
-	 * @When /^user "([^"]*)" (?:creates|tries to create) a space "([^"]*)" of type "([^"]*)" with the default quota using the Graph API$/
 	 *
 	 * @param string $user
 	 * @param string $spaceName
@@ -722,6 +721,8 @@ class SpacesContext implements Context {
 	 * @throws GuzzleException
 	 * @throws Exception
 	 */
+	#[When('/^user "([^"]*)" (?:creates|tries to create) a space "([^"]*)" of type "([^"]*)" with quota "([^"]*)" using the Graph API$/')]
+	#[When('/^user "([^"]*)" (?:creates|tries to create) a space "([^"]*)" of type "([^"]*)" with the default quota using the Graph API$/')]
 	public function theUserCreatesASpaceWithQuotaUsingTheGraphApi(
 		string $user,
 		string $spaceName,
@@ -790,7 +791,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" lists the content of the space with the name "([^"]*)" using the WebDav Api$/
 	 *
 	 * @param string $user
 	 * @param string $spaceName
@@ -799,6 +799,7 @@ class SpacesContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('user :user lists the content of the space with the name :spaceName using the WebDav Api')]
 	public function theUserListsTheContentOfAPersonalSpaceRootUsingTheWebDAvApi(
 		string $user,
 		string $spaceName,
@@ -808,7 +809,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" sends PATCH request to the space "([^"]*)" of user "([^"]*)" with data "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $spaceName
@@ -818,6 +818,7 @@ class SpacesContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('user :user sends PATCH request to the space :spaceName of user :owner with data :data')]
 	public function userSendsPatchRequestToTheSpaceOfUserWithData(
 		string $user,
 		string $spaceName,
@@ -842,27 +843,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @Then /^the (?:propfind|search) result of the space should (not|)\s?contain these (?:files|entries):$/
-	 *
-	 * @param string    $shouldOrNot   (not|)
-	 * @param TableNode $expectedFiles
-	 *
-	 * @return void
-	 *
-	 * @throws Exception
-	 */
-	public function thePropfindResultShouldContainEntries(
-		string $shouldOrNot,
-		TableNode $expectedFiles
-	): void {
-		$this->featureContext->propfindResultShouldContainEntries(
-			$shouldOrNot,
-			$expectedFiles,
-		);
-	}
-
-	/**
-	 * @Then /^for user "([^"]*)" the space "([^"]*)" should (not|)\s?contain these (?:files|entries):$/
 	 *
 	 * @param string    $user
 	 * @param string    $spaceName
@@ -873,6 +853,7 @@ class SpacesContext implements Context {
 	 *
 	 * @throws Exception|GuzzleException
 	 */
+	#[Then('/^for user "([^"]*)" the space "([^"]*)" should (not|)\\s?contain these (?:files|entries):$/')]
 	public function userTheSpaceShouldContainEntries(
 		string $user,
 		string $spaceName,
@@ -892,7 +873,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @Then /^for user "([^"]*)" folder "([^"]*)" of the space "([^"]*)" should (not|)\s?contain these (?:files|entries):$/
 	 *
 	 * @param string    $user
 	 * @param string    $folderPath
@@ -904,6 +884,7 @@ class SpacesContext implements Context {
 	 *
 	 * @throws Exception|GuzzleException
 	 */
+	#[Then('/^for user "([^"]*)" folder "([^"]*)" of the space "([^"]*)" should (not|)\\s?contain these (?:files|entries):$/')]
 	public function folderOfTheSpaceShouldContainEntries(
 		string $user,
 		string $folderPath,
@@ -924,7 +905,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @Then /^for user "([^"]*)" the content of the file "([^"]*)" of the space "([^"]*)" should be "([^"]*)"$/
 	 *
 	 * @param string    $user
 	 * @param string    $file
@@ -935,6 +915,7 @@ class SpacesContext implements Context {
 	 *
 	 * @throws Exception|GuzzleException
 	 */
+	#[Then('for user :user the content of the file :file of the space :spaceName should be :fileContent')]
 	public function checkFileContent(
 		string $user,
 		string $file,
@@ -946,7 +927,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @Then /^for user "([^"]*)" the content of file "([^"]*)" of federated share "([^"]*)" should be "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $file
@@ -957,6 +937,7 @@ class SpacesContext implements Context {
 	 *
 	 * @throws Exception|GuzzleException
 	 */
+	#[Then('for user :user the content of file :file of federated share :share should be :fileContent')]
 	public function forUserTheContentOfFileOfFederatedShareShouldBe(
 		string $user,
 		string $file,
@@ -973,7 +954,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @Then /^the JSON response should contain space called "([^"]*)" (?:|(?:owned by|granted to) "([^"]*)" )(?:|(?:with description file|with space image) "([^"]*)" )and match$/
 	 *
 	 * @param string $spaceName
 	 * @param string|null $userName
@@ -982,6 +962,7 @@ class SpacesContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[Then('/^the JSON response should contain space called "([^"]*)" (?:|(?:owned by|granted to) "([^"]*)" )(?:|(?:with description file|with space image) "([^"]*)" )and match$/')]
 	public function theJsonDataFromLastResponseShouldMatch(
 		string $spaceName,
 		?string $userName = null,
@@ -1046,7 +1027,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @Then /^the user "([^"]*)" should have a space called "([^"]*)" granted to "([^"]*)" with role "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $spaceName
@@ -1056,6 +1036,7 @@ class SpacesContext implements Context {
 	 * @return void
 	 * @throws Exception|GuzzleException
 	 */
+	#[Then('the user :user should have a space called :spaceName granted to :grantedUser with role :role')]
 	public function checkPermissionsInResponse(
 		string $user,
 		string $spaceName,
@@ -1087,13 +1068,13 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @Then /^the json response should not contain a space with name "([^"]*)"$/
 	 *
 	 * @param string $spaceName
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('the json response should not contain a space with name :spaceName')]
 	public function jsonRespondedShouldNotContain(
 		string $spaceName
 	): void {
@@ -1104,7 +1085,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @Then /^the user "([^"]*)" should (not |)have a space called "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $shouldOrNot
@@ -1113,6 +1093,7 @@ class SpacesContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('/^the user "([^"]*)" should (not |)have a space called "([^"]*)"$/')]
 	public function userShouldNotHaveSpace(
 		string $user,
 		string $shouldOrNot,
@@ -1138,7 +1119,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @Then /^the user "([^"]*)" should have a space "([^"]*)" in the disable state$/
 	 *
 	 * @param string $user
 	 * @param string $spaceName
@@ -1146,6 +1126,7 @@ class SpacesContext implements Context {
 	 * @return mixed
 	 * @throws Exception
 	 */
+	#[Then('the user :user should have a space :spaceName in the disable state')]
 	public function theUserShouldHaveASpaceInTheDisableState(
 		string $user,
 		string $spaceName
@@ -1173,7 +1154,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @Then /^the json response should (not|only|)\s?contain spaces of type "([^"]*)"$/
 	 *
 	 * @param string $onlyOrNot (not|only|)
 	 * @param string $type
@@ -1181,6 +1161,7 @@ class SpacesContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('/^the json response should (not|only|)\\s?contain spaces of type "([^"]*)"$/')]
 	public function jsonRespondedShouldNotContainSpaceType(
 		string $onlyOrNot,
 		string $type
@@ -1249,7 +1230,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" creates a (?:folder|subfolder) "([^"]*)" in space "([^"]*)" using the WebDav Api$/
 	 *
 	 * @param string $user
 	 * @param string $folder
@@ -1259,6 +1239,7 @@ class SpacesContext implements Context {
 	 *
 	 * @throws GuzzleException
 	 */
+	#[When('/^user "([^"]*)" creates a (?:folder|subfolder) "([^"]*)" in space "([^"]*)" using the WebDav Api$/')]
 	public function theUserCreatesAFolderUsingTheGraphApi(
 		string $user,
 		string $folder,
@@ -1275,7 +1256,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" tries to create subfolder "([^"]*)" in a nonexistent folder of the space "([^"]*)" using the WebDav Api$/
 	 *
 	 * @param string $user
 	 * @param string $subfolder
@@ -1285,6 +1265,7 @@ class SpacesContext implements Context {
 	 *
 	 * @throws GuzzleException
 	 */
+	#[When('user :user tries to create subfolder :subfolder in a nonexistent folder of the space :spaceName using the WebDav Api')]
 	public function theUserTriesToCreateASubFolderUsingTheGraphApi(
 		string $user,
 		string $subfolder,
@@ -1295,7 +1276,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" has created a (?:folder|subfolder) "([^"]*)" in space "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $folder
@@ -1305,6 +1285,7 @@ class SpacesContext implements Context {
 	 *
 	 * @throws GuzzleException
 	 */
+	#[Given('/^user "([^"]*)" has created a (?:folder|subfolder) "([^"]*)" in space "([^"]*)"$/')]
 	public function userHasCreatedAFolderInSpace(
 		string $user,
 		string $folder,
@@ -1348,7 +1329,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" creates a folder "([^"]*)" in space "([^"]*)" owned by the user "([^"]*)" using the WebDav Api$/
 	 *
 	 * @param string $user
 	 * @param string $folder
@@ -1359,6 +1339,7 @@ class SpacesContext implements Context {
 	 *
 	 * @throws GuzzleException
 	 */
+	#[When('user :user creates a folder :folder in space :spaceName owned by the user :ownerUser using the WebDav Api')]
 	public function theUserCreatesAFolderToAnotherOwnerSpaceUsingTheGraphApi(
 		string $user,
 		string $folder,
@@ -1370,7 +1351,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" uploads a file inside space "([^"]*)" with content "([^"]*)" to "([^"]*)" using the WebDAV API$/
 	 *
 	 * @param string $user
 	 * @param string $spaceName
@@ -1381,6 +1361,7 @@ class SpacesContext implements Context {
 	 * @throws GuzzleException
 	 * @throws Exception
 	 */
+	#[When('user :user uploads a file inside space :spaceName with content :content to :destination using the WebDAV API')]
 	public function theUserUploadsAFileToSpace(
 		string $user,
 		string $spaceName,
@@ -1393,7 +1374,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @When user :user updates the content of federated share :share with :content using the WebDAV API
 	 *
 	 * @param string $user
 	 * @param string $share
@@ -1403,6 +1383,7 @@ class SpacesContext implements Context {
 	 * @throws GuzzleException
 	 * @throws Exception
 	 */
+	#[When('user :user updates the content of federated share :share with :content using the WebDAV API')]
 	public function userUpdatesTheContentOfFederatedShareWithUsingTheWebdavApi(
 		string $user,
 		string $share,
@@ -1420,7 +1401,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" uploads a file "([^"]*)" to "([^"]*)" in space "([^"]*)" using the WebDAV API$/
 	 *
 	 * @param string $user
 	 * @param string $source
@@ -1431,6 +1411,7 @@ class SpacesContext implements Context {
 	 * @throws GuzzleException
 	 * @throws Exception
 	 */
+	#[When('user :user uploads a file :source to :destination in space :spaceName using the WebDAV API')]
 	public function theUserUploadsALocalFileToSpace(
 		string $user,
 		string $source,
@@ -1443,7 +1424,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @Given user :user has uploaded a file :source to :destination in space :spaceName
 	 *
 	 * @param string $user
 	 * @param string $source
@@ -1454,6 +1434,7 @@ class SpacesContext implements Context {
 	 * @throws GuzzleException
 	 * @throws Exception
 	 */
+	#[Given('user :user has uploaded a file :source to :destination in space :spaceName')]
 	public function userHasUploadedAFileToInSpaceUsingTheWebdavApi(
 		string $user,
 		string $source,
@@ -1470,7 +1451,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" uploads a file inside space "([^"]*)" owned by the user "([^"]*)" with content "([^"]*)" to "([^"]*)" using the WebDAV API$/
 	 *
 	 * @param string $user
 	 * @param string $spaceName
@@ -1482,6 +1462,7 @@ class SpacesContext implements Context {
 	 * @throws GuzzleException
 	 * @throws Exception
 	 */
+	#[When('user :user uploads a file inside space :spaceName owned by the user :ownerUser with content :content to :destination using the WebDAV API')]
 	public function theUserUploadsAFileToAnotherOwnerSpace(
 		string $user,
 		string $spaceName,
@@ -1562,8 +1543,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" (?:changes|tries to change) the name of the "([^"]*)" space to "([^"]*)"$/
-	 * @When /^user "([^"]*)" (?:changes|tries to change) the name of the "([^"]*)" space to "([^"]*)" owned by user "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $spaceName
@@ -1574,6 +1553,8 @@ class SpacesContext implements Context {
 	 * @throws GuzzleException
 	 * @throws Exception
 	 */
+	#[When('/^user "([^"]*)" (?:changes|tries to change) the name of the "([^"]*)" space to "([^"]*)"$/')]
+	#[When('/^user "([^"]*)" (?:changes|tries to change) the name of the "([^"]*)" space to "([^"]*)" owned by user "([^"]*)"$/')]
 	public function updateSpaceName(
 		string $user,
 		string $spaceName,
@@ -1587,8 +1568,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" (?:changes|tries to change) the description of the "([^"]*)" space to "([^"]*)"$/
-	 * @When /^user "([^"]*)" (?:changes|tries to change) the description of the "([^"]*)" space to "([^"]*)" owned by user "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $spaceName
@@ -1599,6 +1578,8 @@ class SpacesContext implements Context {
 	 * @throws GuzzleException
 	 * @throws JsonException
 	 */
+	#[When('/^user "([^"]*)" (?:changes|tries to change) the description of the "([^"]*)" space to "([^"]*)"$/')]
+	#[When('/^user "([^"]*)" (?:changes|tries to change) the description of the "([^"]*)" space to "([^"]*)" owned by user "([^"]*)"$/')]
 	public function updateSpaceDescription(
 		string $user,
 		string $spaceName,
@@ -1612,7 +1593,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" has changed the description of the "([^"]*)" space to "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $spaceName
@@ -1622,6 +1602,7 @@ class SpacesContext implements Context {
 	 * @throws GuzzleException
 	 * @throws JsonException
 	 */
+	#[Given('user :user has changed the description of the :spaceName space to :newDescription')]
 	public function userHasChangedDescription(
 		string $user,
 		string $spaceName,
@@ -1637,8 +1618,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" (?:changes|tries to change) the quota of the "([^"]*)" space to "([^"]*)"$/
-	 * @When /^user "([^"]*)" (?:changes|tries to change) the quota of the "([^"]*)" space to "([^"]*)" owned by user "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $spaceName
@@ -1649,6 +1628,8 @@ class SpacesContext implements Context {
 	 * @throws GuzzleException
 	 * @throws Exception
 	 */
+	#[When('/^user "([^"]*)" (?:changes|tries to change) the quota of the "([^"]*)" space to "([^"]*)"$/')]
+	#[When('/^user "([^"]*)" (?:changes|tries to change) the quota of the "([^"]*)" space to "([^"]*)" owned by user "([^"]*)"$/')]
 	public function updateSpaceQuota(
 		string $user,
 		string $spaceName,
@@ -1662,7 +1643,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @When user :user changes the quota of the personal space of user :targetUser to :newQuota using the Graph API
 	 *
 	 * @param string $user
 	 * @param string $targetUser
@@ -1672,6 +1652,7 @@ class SpacesContext implements Context {
 	 * @throws GuzzleException
 	 * @throws Exception
 	 */
+	#[When('user :user changes the quota of the personal space of user :targetUser to :newQuota using the Graph API')]
 	public function updatePersonalSpaceQuota(
 		string $user,
 		string $targetUser,
@@ -1684,7 +1665,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @Given user :user has changed the quota of the personal space of user :targetUser to :newQuota
 	 *
 	 * @param string $user
 	 * @param string $targetUser
@@ -1694,6 +1674,7 @@ class SpacesContext implements Context {
 	 * @throws GuzzleException
 	 * @throws Exception
 	 */
+	#[Given('user :user has changed the quota of the personal space of user :targetUser to :newQuota')]
 	public function userHasChangedTheQuotaOfTheSpaceTo(
 		string $user,
 		string $targetUser,
@@ -1747,7 +1728,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" sets the file "([^"]*)" as a (description|space image)\s? in a special section of the "([^"]*)" space$/
 	 *
 	 * @param string $user
 	 * @param string $file
@@ -1758,6 +1738,7 @@ class SpacesContext implements Context {
 	 * @throws GuzzleException
 	 * @throws Exception
 	 */
+	#[When('/^user "([^"]*)" sets the file "([^"]*)" as a (description|space image)\\s? in a special section of the "([^"]*)" space$/')]
 	public function userSetsFileAsDescriptionOrImageInSpecialSectionOfSpace(
 		string $user,
 		string $file,
@@ -1775,7 +1756,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" has set the file "([^"]*)" as a (description|space image)\s? in a special section of the "([^"]*)" space$/
 	 *
 	 * @param string $user
 	 * @param string $file
@@ -1786,6 +1766,7 @@ class SpacesContext implements Context {
 	 * @throws GuzzleException
 	 * @throws Exception
 	 */
+	#[Given('/^user "([^"]*)" has set the file "([^"]*)" as a (description|space image)\\s? in a special section of the "([^"]*)" space$/')]
 	public function userHasUpdatedSpaceSpecialSection(
 		string $user,
 		string $file,
@@ -1801,7 +1782,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" has created a space "([^"]*)" of type "([^"]*)" with quota "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $spaceName
@@ -1811,6 +1791,7 @@ class SpacesContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[Given('user :user has created a space :spaceName of type :spaceType with quota :quota')]
 	public function userHasCreatedSpace(
 		string $user,
 		string $spaceName,
@@ -1827,7 +1808,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" has created a space "([^"]*)" with the default quota using the Graph API$/
 	 *
 	 * @param string $user
 	 * @param string $spaceName
@@ -1837,6 +1817,7 @@ class SpacesContext implements Context {
 	 * @throws GuzzleException
 	 * @throws Exception
 	 */
+	#[Given('user :user has created a space :spaceName with the default quota using the Graph API')]
 	public function theUserHasCreatedASpaceByDefaultUsingTheGraphApi(
 		string $user,
 		string $spaceName
@@ -1879,7 +1860,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" copies (?:file|folder) "([^"]*)" to "([^"]*)" inside space "([^"]*)" using the WebDAV API$/
 	 *
 	 * @param string $user
 	 * @param string $fileSource
@@ -1889,6 +1869,7 @@ class SpacesContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('/^user "([^"]*)" copies (?:file|folder) "([^"]*)" to "([^"]*)" inside space "([^"]*)" using the WebDAV API$/')]
 	public function userCopiesFileWithinSpaceUsingTheWebDAVAPI(
 		string $user,
 		string $fileSource,
@@ -1942,7 +1923,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" moves (?:file|folder) "([^"]*)" to "([^"]*)" in space "([^"]*)" using the WebDAV API$/
 	 *
 	 * @param string $user
 	 * @param string $fileSource
@@ -1952,6 +1932,7 @@ class SpacesContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('/^user "([^"]*)" moves (?:file|folder) "([^"]*)" to "([^"]*)" in space "([^"]*)" using the WebDAV API$/')]
 	public function userMovesFileWithinSpaceUsingTheWebDAVAPI(
 		string $user,
 		string $fileSource,
@@ -1970,7 +1951,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" has moved (?:file|folder) "([^"]*)" to "([^"]*)" in space "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $fileSource
@@ -1980,6 +1960,7 @@ class SpacesContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[Given('/^user "([^"]*)" has moved (?:file|folder) "([^"]*)" to "([^"]*)" in space "([^"]*)"$/')]
 	public function userHasMovedFileWithinSpaceUsingTheWebDAVAPI(
 		string $user,
 		string $fileSource,
@@ -2023,8 +2004,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" copies (?:file|folder) "([^"]*)" from space "([^"]*)" to "([^"]*)" inside space "([^"]*)" using the WebDAV API$/
-	 * @When /^user "([^"]*)" copies (?:file|folder) "([^"]*)" from space "([^"]*)" to "([^"]*)" inside space "([^"]*)"(?: with following headers) using the WebDAV API$/
 	 *
 	 * @param string $user
 	 * @param string $fileSource
@@ -2036,6 +2015,8 @@ class SpacesContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('/^user "([^"]*)" copies (?:file|folder) "([^"]*)" from space "([^"]*)" to "([^"]*)" inside space "([^"]*)" using the WebDAV API$/')]
+	#[When('/^user "([^"]*)" copies (?:file|folder) "([^"]*)" from space "([^"]*)" to "([^"]*)" inside space "([^"]*)"(?: with following headers) using the WebDAV API$/')]
 	public function userCopiesFileFromAndToSpaceBetweenSpaces(
 		string $user,
 		string $fileSource,
@@ -2070,7 +2051,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" overwrites file "([^"]*)" from space "([^"]*)" to "([^"]*)" inside space "([^"]*)" while (copying|moving)\s? using the WebDAV API$/
 	 *
 	 * @param string $user
 	 * @param string $fileSource
@@ -2082,6 +2062,7 @@ class SpacesContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('/^user "([^"]*)" overwrites file "([^"]*)" from space "([^"]*)" to "([^"]*)" inside space "([^"]*)" while (copying|moving)\\s? using the WebDAV API$/')]
 	public function userOverwritesFileFromAndToSpaceBetweenSpaces(
 		string $user,
 		string $fileSource,
@@ -2113,7 +2094,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @Then /^user "([^"]*)" (should|should not) be able to download file "([^"]*)" from space "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $shouldOrNot
@@ -2123,6 +2103,7 @@ class SpacesContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[Then('/^user "([^"]*)" (should|should not) be able to download file "([^"]*)" from space "([^"]*)"$/')]
 	public function userShouldOrShouldNotBeAbleToDownloadFileFromSpace(
 		string $user,
 		string $shouldOrNot,
@@ -2148,20 +2129,19 @@ class SpacesContext implements Context {
 				400,
 				$response->getStatusCode(),
 				__METHOD__
-				. ' download must fail'
+				. '  download must fail'
 			);
 			Assert::assertLessThanOrEqual(
 				499,
 				$response->getStatusCode(),
 				__METHOD__
-				. ' 4xx error expected but got status code "'
+				. '  4xx error expected but got status code "'
 				. $response->getStatusCode() . '"'
 			);
 		}
 	}
 
 	/**
-	 * @When /^user "([^"]*)" moves (?:file|folder) "([^"]*)" from space "([^"]*)" to "([^"]*)" inside space "([^"]*)" using the WebDAV API$/
 	 *
 	 * @param string $user
 	 * @param string $fileSource
@@ -2172,6 +2152,7 @@ class SpacesContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('/^user "([^"]*)" moves (?:file|folder) "([^"]*)" from space "([^"]*)" to "([^"]*)" inside space "([^"]*)" using the WebDAV API$/')]
 	public function userMovesFileFromAndToSpaceBetweenSpaces(
 		string $user,
 		string $fileSource,
@@ -2241,7 +2222,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" (copies|moves) file with id "([^"]*)" as "([^"]*)" into folder "([^"]*)" inside space "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $actionType
@@ -2253,6 +2233,7 @@ class SpacesContext implements Context {
 	 * @throws GuzzleException
 	 * @return void
 	 */
+	#[When('/^user "([^"]*)" (copies|moves) file with id "([^"]*)" as "([^"]*)" into folder "([^"]*)" inside space "([^"]*)"$/')]
 	public function userCopiesOrMovesFileWithIdAsIntoFolderInsideSpace(
 		string $user,
 		string $actionType,
@@ -2291,7 +2272,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" renames file with id "([^"]*)" to "([^"]*)" inside space "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $fileId
@@ -2301,6 +2281,7 @@ class SpacesContext implements Context {
 	 * @throws GuzzleException
 	 * @return void
 	 */
+	#[Given('user :user renames file with id :fileId to :destinationFile inside space :spaceName')]
 	public function userRenamesFileWithIdToInsideSpace(
 		string $user,
 		string $fileId,
@@ -2330,7 +2311,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" has (copied|moved) file with id "([^"]*)" as "([^"]*)" into folder "([^"]*)" inside space "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $actionType
@@ -2342,6 +2322,7 @@ class SpacesContext implements Context {
 	 * @throws GuzzleException
 	 * @return void
 	 */
+	#[Given('/^user "([^"]*)" has (copied|moved) file with id "([^"]*)" as "([^"]*)" into folder "([^"]*)" inside space "([^"]*)"$/')]
 	public function userHasCopiedOrMovedFileInsideSpaceUsingFileId(
 		string $user,
 		string $actionType,
@@ -2383,7 +2364,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" has renamed file with id "([^"]*)" to "([^"]*)" inside space "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $fileId
@@ -2393,6 +2373,7 @@ class SpacesContext implements Context {
 	 * @throws GuzzleException
 	 * @return void
 	 */
+	#[Given('user :user has renamed file with id :fileId to :destinationFile inside space :spaceName')]
 	public function userHasRenamedFileInsideSpaceUsingFileId(
 		string $user,
 		string $fileId,
@@ -2427,8 +2408,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" tries to move (?:file|folder) "([^"]*)" of space "([^"]*)" to (space|folder) "([^"]*)" using its id in destination path$/
-	 * @When /^user "([^"]*)" moves (?:file|folder) "([^"]*)" of space "([^"]*)" to (folder) "([^"]*)" using its id in destination path$/
 	 *
 	 * @param string $user
 	 * @param string $source
@@ -2439,6 +2418,8 @@ class SpacesContext implements Context {
 	 * @throws GuzzleException
 	 * @return void
 	 */
+	#[When('/^user "([^"]*)" tries to move (?:file|folder) "([^"]*)" of space "([^"]*)" to (space|folder) "([^"]*)" using its id in destination path$/')]
+	#[When('/^user "([^"]*)" moves (?:file|folder) "([^"]*)" of space "([^"]*)" to (folder) "([^"]*)" using its id in destination path$/')]
 	public function userMovesFileToResourceUsingItsIdAsDestinationPath(
 		string $user,
 		string $source,
@@ -2469,7 +2450,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" has uploaded a file inside space "([^"]*)" with content "([^"]*)" to "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $spaceName
@@ -2479,6 +2459,7 @@ class SpacesContext implements Context {
 	 * @return array
 	 * @throws GuzzleException
 	 */
+	#[Given('user :user has uploaded a file inside space :spaceName with content :fileContent to :destination')]
 	public function userHasUploadedFile(
 		string $user,
 		string $spaceName,
@@ -2500,8 +2481,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" shares a space "([^"]*)" with settings:$/
-	 * @When /^user "([^"]*)" updates the space "([^"]*)" with settings:$/
 	 *
 	 * @param  string $user
 	 * @param  string $spaceName
@@ -2510,6 +2489,8 @@ class SpacesContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('user :user shares a space :spaceName with settings:')]
+	#[When('user :user updates the space :spaceName with settings:')]
 	public function sendShareSpaceRequest(
 		string $user,
 		string $spaceName,
@@ -2558,7 +2539,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" expires the (user|group) share of space "([^"]*)" for (?:user|group) "([^"]*)"$/
 	 *
 	 * @param  string $user
 	 * @param  string $shareType
@@ -2568,6 +2548,7 @@ class SpacesContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('/^user "([^"]*)" expires the (user|group) share of space "([^"]*)" for (?:user|group) "([^"]*)"$/')]
 	public function userExpiresTheShareOfSpaceForUser(
 		string $user,
 		string $shareType,
@@ -2628,7 +2609,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" creates a share inside of space "([^"]*)" with settings:$/
 	 *
 	 * @param  string $user
 	 * @param  string $spaceName
@@ -2637,6 +2617,7 @@ class SpacesContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('user :user creates a share inside of space :spaceName with settings:')]
 	public function userCreatesShareInsideOfSpaceWithSettings(
 		string $user,
 		string $spaceName,
@@ -2648,26 +2629,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" has created a share inside of space "([^"]*)" with settings:$/
-	 *
-	 * @param  string $user
-	 * @param  string $spaceName
-	 * @param TableNode $table
-	 *
-	 * @return void
-	 * @throws GuzzleException
-	 */
-	public function userHasSharedTheFollowingEntityInsideOfSpace(
-		string $user,
-		string $spaceName,
-		TableNode $table
-	): void {
-		$response = $this->createShareResource($user, $spaceName, $table);
-		$this->featureContext->theHTTPStatusCodeShouldBe(200, "", $response);
-	}
-
-	/**
-	 * @When /^user "([^"]*)" changes the last share with settings:$/
 	 *
 	 * @param  string $user
 	 * @param TableNode $table
@@ -2675,6 +2636,7 @@ class SpacesContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('user :user changes the last share with settings:')]
 	public function changeShareResourceWithSettings(
 		string $user,
 		TableNode $table
@@ -2709,7 +2671,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @When user :user expires the last share of resource :resource inside of the space :spaceName
 	 *
 	 * @param string $user
 	 * @param string $resource
@@ -2718,6 +2679,7 @@ class SpacesContext implements Context {
 	 * @return void
 	 * @throws GuzzleException|JsonException
 	 */
+	#[When('user :user expires the last share of resource :resource inside of the space :spaceName')]
 	public function userExpiresTheLastShareOfResourceInsideOfTheSpace(
 		string $user,
 		string $resource,
@@ -2797,7 +2759,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" creates a public link share inside of space "([^"]*)" with settings:$/
 	 *
 	 * @param  string $user
 	 * @param  string $spaceName
@@ -2806,6 +2767,7 @@ class SpacesContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('user :user creates a public link share inside of space :spaceName with settings:')]
 	public function userCreatesPublicLinkShareInsideOfSpaceWithSettings(
 		string $user,
 		string $spaceName,
@@ -2813,53 +2775,6 @@ class SpacesContext implements Context {
 	): void {
 		$this->featureContext->setResponse(
 			$this->createPublicLinkToEntityInsideOfSpaceRequest($user, $spaceName, $table)
-		);
-	}
-
-	/**
-	 * @Given /^user "([^"]*)" has created a public link share inside of space "([^"]*)" with settings:$/
-	 *
-	 * @param  string $user
-	 * @param  string $spaceName
-	 * @param TableNode $table
-	 *
-	 * @return void
-	 * @throws GuzzleException
-	 */
-	public function userHasCreatedPublicLinkToEntityInsideOfSpaceRequest(
-		string $user,
-		string $spaceName,
-		TableNode $table
-	): void {
-		$response = $this->createPublicLinkToEntityInsideOfSpaceRequest($user, $spaceName, $table);
-
-		$this->featureContext->theHTTPStatusCodeShouldBe(
-			200,
-			"Expected response status code should be 200",
-			$response
-		);
-	}
-
-	/**
-	 * @Given user :user has unshared a space :spaceName shared with :recipient
-	 *
-	 * @param  string $user
-	 * @param  string $spaceName
-	 * @param  string $recipient
-	 *
-	 * @return void
-	 * @throws GuzzleException
-	 */
-	public function userHasUnsharedASpaceSharedWith(
-		string $user,
-		string $spaceName,
-		string $recipient
-	): void {
-		$response = $this->sendUnshareSpaceRequest($user, $spaceName, $recipient);
-		$this->featureContext->theHTTPStatusCodeShouldBe(
-			200,
-			"Expected response status code should be 200",
-			$response
 		);
 	}
 
@@ -2889,7 +2804,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" unshares a space "([^"]*)" to (?:user|group) "([^"]*)"$/
 	 *
 	 * @param  string $user
 	 * @param  string $spaceName
@@ -2898,6 +2812,7 @@ class SpacesContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('/^user "([^"]*)" unshares a space "([^"]*)" to (?:user|group) "([^"]*)"$/')]
 	public function userUnsharesSpace(
 		string $user,
 		string $spaceName,
@@ -2937,7 +2852,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" removes the (?:file|folder) "([^"]*)" from space "([^"]*)"$/
 	 *
 	 * @param  string $user
 	 * @param  string $object
@@ -2946,6 +2860,7 @@ class SpacesContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('/^user "([^"]*)" removes the (?:file|folder) "([^"]*)" from space "([^"]*)"$/')]
 	public function userRemovesFileOrFolderFromSpace(
 		string $user,
 		string $object,
@@ -2957,7 +2872,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" has deleted a space "([^"]*)"$/
 	 *
 	 * @param  string $user
 	 * @param  string $spaceName
@@ -2965,6 +2879,7 @@ class SpacesContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[Given('user :user has deleted a space :spaceName')]
 	public function userHasDeletedASpaceOwnedByUser(
 		string $user,
 		string $spaceName
@@ -3001,8 +2916,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" disables a space "([^"]*)"$/
-	 * @When /^user "([^"]*)" (?:disables|tries to disable) a space "([^"]*)" owned by user "([^"]*)"$/
 	 *
 	 * @param  string $user
 	 * @param  string $spaceName
@@ -3011,6 +2924,8 @@ class SpacesContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('user :user disables a space :spaceName')]
+	#[When('/^user "([^"]*)" (?:disables|tries to disable) a space "([^"]*)" owned by user "([^"]*)"$/')]
 	public function userDisablesSpace(
 		string $user,
 		string $spaceName,
@@ -3022,7 +2937,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" has removed the (?:file|folder) "([^"]*)" from space "([^"]*)"$/
 	 *
 	 * @param  string $user
 	 * @param  string $object
@@ -3031,6 +2945,7 @@ class SpacesContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[Given('/^user "([^"]*)" has removed the (?:file|folder) "([^"]*)" from space "([^"]*)"$/')]
 	public function userHasRemovedFileOrFolderFromSpace(
 		string $user,
 		string $object,
@@ -3046,7 +2961,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" has disabled a space "([^"]*)"$/
 	 *
 	 * @param  string $user
 	 * @param  string $spaceName
@@ -3054,6 +2968,7 @@ class SpacesContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[Given('user :user has disabled a space :spaceName')]
 	public function sendUserHasDisabledSpaceRequest(
 		string $user,
 		string $spaceName
@@ -3092,8 +3007,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" deletes a space "([^"]*)"$/
-	 * @When /^user "([^"]*)" (?:deletes|tries to delete) a space "([^"]*)" owned by user "([^"]*)"$/
 	 *
 	 * @param  string $user
 	 * @param  string $spaceName
@@ -3102,6 +3015,8 @@ class SpacesContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('user :user deletes a space :spaceName')]
+	#[When('/^user "([^"]*)" (?:deletes|tries to delete) a space "([^"]*)" owned by user "([^"]*)"$/')]
 	public function userDeletesSpace(
 		string $user,
 		string $spaceName,
@@ -3136,8 +3051,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" restores a disabled space "([^"]*)"$/
-	 * @When /^user "([^"]*)" (?:restores|tries to restore) a disabled space "([^"]*)" owned by user "([^"]*)"$/
 	 *
 	 * @param  string $user
 	 * @param  string $spaceName
@@ -3146,6 +3059,8 @@ class SpacesContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('user :user restores a disabled space :spaceName')]
+	#[When('/^user "([^"]*)" (?:restores|tries to restore) a disabled space "([^"]*)" owned by user "([^"]*)"$/')]
 	public function userRestoresADisabledSpace(
 		string $user,
 		string $spaceName,
@@ -3153,28 +3068,6 @@ class SpacesContext implements Context {
 	): void {
 		$this->featureContext->setResponse(
 			$this->restoreSpace($user, $spaceName, $owner)
-		);
-	}
-
-	/**
-	 * @Given /^user "([^"]*)" has restored a disabled space "([^"]*)"$/
-	 *
-	 * @param  string $user
-	 * @param  string $spaceName
-	 *
-	 * @return void
-	 * @throws GuzzleException
-	 */
-	public function userHasRestoredSpaceRequest(
-		string $user,
-		string $spaceName
-	): void {
-		$response = $this->restoreSpace($user, $spaceName);
-		$expectedHTTPStatus = "200";
-		$this->featureContext->theHTTPStatusCodeShouldBe(
-			$expectedHTTPStatus,
-			"Expected response status code should be $expectedHTTPStatus",
-			$response
 		);
 	}
 
@@ -3207,7 +3100,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" lists all deleted files in the trash bin of the space "([^"]*)"$/
 	 *
 	 * @param  string $user
 	 * @param  string $spaceName
@@ -3215,6 +3107,7 @@ class SpacesContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('user :user lists all deleted files in the trash bin of the space :spaceName')]
 	public function userListAllDeletedFilesInTrash(
 		string $user,
 		string $spaceName
@@ -3225,7 +3118,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" with admin permission lists all deleted files in the trash bin of the space "([^"]*)"$/
 	 *
 	 * @param  string $user
 	 * @param  string $spaceName
@@ -3233,6 +3125,7 @@ class SpacesContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('user :user with admin permission lists all deleted files in the trash bin of the space :spaceName')]
 	public function adminListAllDeletedFilesInTrash(
 		string $user,
 		string $spaceName
@@ -3291,7 +3184,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @Then /^as "([^"]*)" (?:file|folder|entry) "([^"]*)" should (not|)\s?exist in the trashbin of the space "([^"]*)"$/
 	 *
 	 * @param  string $user
 	 * @param  string $object
@@ -3301,6 +3193,7 @@ class SpacesContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[Then('/^as "([^"]*)" (?:file|folder|entry) "([^"]*)" should (not|)\\s?exist in the trashbin of the space "([^"]*)"$/')]
 	public function checkExistenceOfObjectsInTrashbin(
 		string $user,
 		string $object,
@@ -3323,7 +3216,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" restores the (?:file|folder) "([^"]*)" from the trash of the space "([^"]*)" to "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $object
@@ -3334,6 +3226,7 @@ class SpacesContext implements Context {
 	 * @throws GuzzleException
 	 * @throws Exception
 	 */
+	#[When('/^user "([^"]*)" restores the (?:file|folder) "([^"]*)" from the trash of the space "([^"]*)" to "([^"]*)"$/')]
 	public function userRestoresSpaceObjectsFromTrashRequest(
 		string $user,
 		string $object,
@@ -3377,8 +3270,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @When user :user deletes the file/folder :resource from the trash of the space :spaceName
-	 * @When user :user tries to delete the file/folder :resource from the trash of the space :spaceName
 	 *
 	 * @param string $user
 	 * @param string $object
@@ -3388,6 +3279,8 @@ class SpacesContext implements Context {
 	 * @throws GuzzleException
 	 * @throws Exception
 	 */
+	#[When('user :user deletes the file/folder :resource from the trash of the space :spaceName')]
+	#[When('user :user tries to delete the file/folder :resource from the trash of the space :spaceName')]
 	public function userDeletesObjectsFromTrashRequest(
 		string $user,
 		string $object,
@@ -3425,8 +3318,6 @@ class SpacesContext implements Context {
 	/**
 	 * User downloads a preview of the file inside the project space
 	 *
-	 * @When /^user "([^"]*)" downloads the preview of "([^"]*)" of the space "([^"]*)" with width "([^"]*)" and height "([^"]*)" using the WebDAV API$/
-	 *
 	 * @param  string $user
 	 * @param  string $fileName
 	 * @param  string $spaceName
@@ -3436,6 +3327,7 @@ class SpacesContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('user :user downloads the preview of :fileName of the space :spaceName with width :width and height :height using the WebDAV API')]
 	public function downloadPreview(
 		string $user,
 		string $fileName,
@@ -3469,7 +3361,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" downloads the file "([^"]*)" of the space "([^"]*)" using the WebDAV API$/
 	 *
 	 * @param  string $user
 	 * @param  string $fileName
@@ -3478,6 +3369,7 @@ class SpacesContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('user :user downloads the file :fileName of the space :spaceName using the WebDAV API')]
 	public function downloadFile(
 		string $user,
 		string $fileName,
@@ -3495,7 +3387,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" requests the checksum of (?:file|folder|entry) "([^"]*)" in space "([^"]*)" via propfind using the WebDAV API$/
 	 *
 	 * @param string $user
 	 * @param string $path
@@ -3504,6 +3395,7 @@ class SpacesContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('/^user "([^"]*)" requests the checksum of (?:file|folder|entry) "([^"]*)" in space "([^"]*)" via propfind using the WebDAV API$/')]
 	public function userRequestsTheChecksumViaPropfindInSpace(
 		string $user,
 		string $path,
@@ -3516,7 +3408,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" uploads file with checksum "([^"]*)" and content "([^"]*)" to "([^"]*)" in space "([^"]*)" using the WebDAV API$/
 	 *
 	 * @param string $user
 	 * @param string $checksum
@@ -3527,6 +3418,7 @@ class SpacesContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('user :user uploads file with checksum :checksum and content :content to :destination in space :spaceName using the WebDAV API')]
 	public function userUploadsFileWithChecksumWithContentInSpace(
 		string $user,
 		string $checksum,
@@ -3548,8 +3440,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" downloads version of the file "([^"]*)" with the index "([^"]*)" of the space "([^"]*)" using the WebDAV API$/
-	 * @When /^user "([^"]*)" tries to download version of the file "([^"]*)" with the index "([^"]*)" of the space "([^"]*)" using the WebDAV API$/
 	 *
 	 * @param  string $user
 	 * @param  string $fileName
@@ -3559,6 +3449,8 @@ class SpacesContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('user :user downloads version of the file :fileName with the index :index of the space :spaceName using the WebDAV API')]
+	#[When('user :user tries to download version of the file :fileName with the index :index of the space :spaceName using the WebDAV API')]
 	public function downloadVersionOfTheFile(
 		string $user,
 		string $fileName,
@@ -3572,7 +3464,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @When user :user tries to get versions of the file :file from the space :space using the WebDAV API
 	 *
 	 * @param string $user
 	 * @param string $file
@@ -3581,6 +3472,7 @@ class SpacesContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('user :user tries to get versions of the file :file from the space :space using the WebDAV API')]
 	public function userTriesToDownloadFileVersions(string $user, string $file, string $spaceName): void {
 		$spaceId = $this->getSpaceIdByName($user, $spaceName);
 		$this->featureContext->setResponse(
@@ -3664,7 +3556,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @Then /^these etags (should|should not) have changed$/
 	 *
 	 * @param string $action
 	 * @param TableNode $table
@@ -3672,6 +3563,7 @@ class SpacesContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[Then('/^these etags (should|should not) have changed$/')]
 	public function theseEtagsShouldShouldNotHaveChanged(string $action, TableNode $table): void {
 		$this->featureContext->verifyTableNodeColumns($table, ["user", "path", "space"]);
 		$this->featureContext->verifyTableNodeColumnsCount($table, 3);
@@ -3699,7 +3591,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" has stored etag of element "([^"]*)" inside space "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $path
@@ -3708,6 +3599,7 @@ class SpacesContext implements Context {
 	 * @return void
 	 * @throws GuzzleException | Exception
 	 */
+	#[Given('user :user has stored etag of element :path inside space :space')]
 	public function userHasStoredEtagOfElementFromSpace(string $user, string $path, string $space): void {
 		$user = $this->featureContext->getActualUsername($user);
 		$this->storeEtagOfElementInSpaceForUser(
@@ -3721,7 +3613,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" has stored etag of element "([^"]*)" on path "([^"]*)" inside space "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $path
@@ -3731,6 +3622,7 @@ class SpacesContext implements Context {
 	 * @return void
 	 * @throws Exception | GuzzleException
 	 */
+	#[Given('user :user has stored etag of element :path on path :storePath inside space :space')]
 	public function userHasStoredEtagOfElementOnPathFromSpace(
 		string $user,
 		string $path,
@@ -3800,7 +3692,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" creates a public link share of the space "([^"]*)" with settings:$/
 	 *
 	 * @param  string $user
 	 * @param  string $spaceName
@@ -3809,6 +3700,7 @@ class SpacesContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('user :user creates a public link share of the space :spaceName with settings:')]
 	public function userCreatesAPublicLinkShareOfSpaceWithSettings(
 		string $user,
 		string $spaceName,
@@ -3824,33 +3716,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" has created a public link share of the space "([^"]*)" with settings:$/
-	 *
-	 * @param  string $user
-	 * @param  string $spaceName
-	 * @param TableNode|null $table
-	 *
-	 * @return void
-	 * @throws GuzzleException
-	 */
-	public function userHasCreatedPublicLinkShareOfSpace(
-		string $user,
-		string $spaceName,
-		?TableNode $table
-	): void {
-		$response = $this->sendShareSpaceViaLinkRequest($user, $spaceName, $table);
-
-		$expectedHTTPStatus = "200";
-		$this->featureContext->theHTTPStatusCodeShouldBe(
-			$expectedHTTPStatus,
-			"Expected response status code should be $expectedHTTPStatus",
-			$response
-		);
-	}
-
-	/**
-	 * @Then /^for user "([^"]*)" the space "([^"]*)" should (not|)\s?contain the last created public link$/
-	 * @Then /^for user "([^"]*)" the space "([^"]*)" should (not|)\s?contain the last created (public link|share) of the file "([^"]*)"$/
 	 *
 	 * @param string    $user
 	 * @param string    $spaceName
@@ -3862,6 +3727,8 @@ class SpacesContext implements Context {
 	 *
 	 * @throws Exception|GuzzleException
 	 */
+	#[Then('/^for user "([^"]*)" the space "([^"]*)" should (not|)\\s?contain the last created public link$/')]
+	#[Then('/^for user "([^"]*)" the space "([^"]*)" should (not|)\\s?contain the last created (public link|share) of the file "([^"]*)"$/')]
 	public function forUserSpaceShouldContainLinks(
 		string $user,
 		string $spaceName,
@@ -3913,7 +3780,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" gets the following properties of (?:file|folder|entry|resource) "([^"]*)" inside space "([^"]*)" using the WebDAV API$/
 	 *
 	 * @param string    $user
 	 * @param string    $resourceName
@@ -3924,6 +3790,7 @@ class SpacesContext implements Context {
 	 *
 	 * @throws Exception|GuzzleException
 	 */
+	#[When('/^user "([^"]*)" gets the following properties of (?:file|folder|entry|resource) "([^"]*)" inside space "([^"]*)" using the WebDAV API$/')]
 	public function userGetsTheFollowingPropertiesOfFileInsideSpaceUsingTheWebdavApi(
 		string $user,
 		string $resourceName,
@@ -3941,7 +3808,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" gets the following extracted properties of (?:file|folder|entry|resource) "([^"]*)" inside space "([^"]*)" using the WebDAV API$/
 	 *
 	 * @param string    $user
 	 * @param string    $resourceName
@@ -3952,6 +3818,7 @@ class SpacesContext implements Context {
 	 *
 	 * @throws Exception|GuzzleException
 	 */
+	#[When('/^user "([^"]*)" gets the following extracted properties of (?:file|folder|entry|resource) "([^"]*)" inside space "([^"]*)" using the WebDAV API$/')]
 	public function userGetsTheFollowingExtractedPropertiesOfFileInsideSpaceUsingTheWebdavApi(
 		string $user,
 		string $resourceName,
@@ -3972,7 +3839,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @Then /^as user "([^"]*)" (?:file|folder|entry|resource) "([^"]*)" inside space "([^"]*)" should contain a property "([^"]*)" with value "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $resourceName
@@ -3984,6 +3850,7 @@ class SpacesContext implements Context {
 	 *
 	 * @throws Exception|GuzzleException
 	 */
+	#[Then('/^as user "([^"]*)" (?:file|folder|entry|resource) "([^"]*)" inside space "([^"]*)" should contain a property "([^"]*)" with value "([^"]*)"$/')]
 	public function userGetsTheFollowingPropertiesOfFileInsideSpaceWithValueUsingTheWebdavApi(
 		string $user,
 		string $resourceName,
@@ -4003,95 +3870,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @Then /^as user "([^"]*)" (?:file|folder|entry) "([^"]*)" inside space "([^"]*)" (should|should not) be favorited$/
-	 *
-	 * @param string $user
-	 * @param string $path
-	 * @param string $spaceName
-	 * @param string $shouldOrNot
-	 *
-	 * @return void
-	 */
-	public function asUserFileOrFolderInsideSpaceShouldOrNotBeFavorited(
-		string $user,
-		string $path,
-		string $spaceName,
-		string $shouldOrNot
-	): void {
-		$spaceId = $this->getSpaceIdByName($user, $spaceName);
-		$this->favoritesContext->asUserFileOrFolderShouldBeFavorited(
-			$user,
-			$path,
-			($shouldOrNot === 'should') ? 1 : 0,
-			$spaceId
-		);
-	}
-
-	/**
-	 * @When /^user "([^"]*)" favorites element "([^"]*)" in space "([^"]*)" using the WebDAV API$/
-	 *
-	 * @param string $user
-	 * @param string $path
-	 * @param string $spaceName
-	 *
-	 * @return void
-	 * @throws GuzzleException
-	 */
-	public function userFavoritesElementInSpaceUsingTheWebdavApi(string $user, string $path, string $spaceName): void {
-		$spaceId = $this->getSpaceIdByName($user, $spaceName);
-		$this->featureContext->setResponse($this->favoritesContext->userFavoritesElement($user, $path, $spaceId));
-	}
-
-	/**
-	 * @Given /^user "([^"]*)" has stored id of (?:file|folder) "([^"]*)" of the space "([^"]*)"$/
-	 *
-	 * @param string $user
-	 * @param string $path
-	 * @param string $spaceName
-	 *
-	 * @return void
-	 *
-	 * @throws GuzzleException
-	 */
-	public function userHasStoredIdOfPathOfTheSpace(string $user, string $path, string $spaceName): void {
-		$this->getSpaceIdByName($user, $spaceName);
-		$this->featureContext->setStoredFileID($this->featureContext->getFileIdForPath($user, $path));
-	}
-
-	/**
-	 * @Then /^user "([^"]*)" (folder|file) "([^"]*)" of the space "([^"]*)" should have the previously stored id$/
-	 *
-	 * @param string $user
-	 * @param string $fileOrFolder
-	 * @param string $path
-	 * @param string $spaceName
-	 *
-	 * @return void
-	 *
-	 * @throws GuzzleException
-	 * @throws JsonException
-	 */
-	public function userFolderOfTheSpaceShouldHaveThePreviouslyStoredId(
-		string $user,
-		string $fileOrFolder,
-		string $path,
-		string $spaceName
-	): void {
-		$this->getSpaceIdByName($user, $spaceName);
-		$user = $this->featureContext->getActualUsername($user);
-		$currentFileID = $this->featureContext->getFileIdForPath($user, $path);
-		$storedFileID = $this->featureContext->getStoredFileID();
-		Assert::assertEquals(
-			$currentFileID,
-			$storedFileID,
-			__METHOD__
-			. " User '$user' $fileOrFolder '$path' does not have the previously stored id '"
-			. $storedFileID . "', but has '$currentFileID'."
-		);
-	}
-
-	/**
-	 * @Then /^for user "([^"]*)" the search result should contain space "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $spaceName
@@ -4099,6 +3877,7 @@ class SpacesContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[Then('for user :user the search result should contain space :spaceName')]
 	public function searchResultShouldContainSpace(string $user, string $spaceName): void {
 		$responseArray = json_decode(
 			json_encode(
@@ -4138,8 +3917,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" sends PROPFIND request to space "([^"]*)" using the WebDAV API$/
-	 * @When /^user "([^"]*)" sends PROPFIND request to space "([^"]*)" with depth "([^"]*)" using the WebDAV API$/
 	 *
 	 * @param string $user
 	 * @param string $spaceName
@@ -4151,6 +3928,8 @@ class SpacesContext implements Context {
 	 *
 	 * @throws GuzzleException
 	 */
+	#[When('user :user sends PROPFIND request to space :spaceName using the WebDAV API')]
+	#[When('user :user sends PROPFIND request to space :spaceName with depth :folderDepth using the WebDAV API')]
 	public function userSendsPropfindRequestToSpaceUsingTheWebdavApi(
 		string $user,
 		string $spaceName,
@@ -4162,8 +3941,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" sends PROPFIND request from the space "([^"]*)" to the resource "([^"]*)" with depth "([^"]*)" using the WebDAV API$/
-	 * @When user :user sends PROPFIND request from the space :spaceName to the resource :resource using the WebDAV API
 	 *
 	 * @param string $user
 	 * @param string $spaceName
@@ -4176,6 +3953,8 @@ class SpacesContext implements Context {
 	 *
 	 * @throws GuzzleException
 	 */
+	#[When('user :user sends PROPFIND request from the space :spaceName to the resource :resource with depth :folderDepth using the WebDAV API')]
+	#[When('user :user sends PROPFIND request from the space :spaceName to the resource :resource using the WebDAV API')]
 	public function userSendsPropfindRequestFromTheSpaceToTheResourceWithDepthUsingTheWebdavApi(
 		string $user,
 		string $spaceName,
@@ -4187,7 +3966,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" sends PROPFIND request to space "([^"]*)" with headers using the WebDAV API$/
 	 *
 	 * @param string $user
 	 * @param string $spaceName
@@ -4199,6 +3977,7 @@ class SpacesContext implements Context {
 	 *
 	 * @throws GuzzleException
 	 */
+	#[When('user :user sends PROPFIND request to space :spaceName with headers using the WebDAV API')]
 	public function userSendsPropfindRequestToSpaceWithHeaders(
 		string $user,
 		string $spaceName,
@@ -4286,7 +4065,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @Then /^as user "([^"]*)" the (?:PROPFIND|REPORT) response should contain a (resource|space) "([^"]*)" with these key and value pairs:$/
 	 *
 	 * @param string $user
 	 * @param string $type	# type should be either resource or space
@@ -4297,6 +4075,7 @@ class SpacesContext implements Context {
 	 * @throws GuzzleException
 	 * @throws JsonException
 	 */
+	#[Then('/^as user "([^"]*)" the (?:PROPFIND|REPORT) response should contain a (resource|space) "([^"]*)" with these key and value pairs:$/')]
 	public function asUsertheXMLResponseShouldContainMountpointWithTheseKeyAndValuePair(
 		string $user,
 		string $type,
@@ -4536,7 +4315,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @Then as user :user the key :key from PROPFIND response should match with shared-with-me drive-item-id of share :resource
 	 *
 	 * @param string $user
 	 * @param string $key
@@ -4545,6 +4323,7 @@ class SpacesContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[Then('as user :user the key :key from PROPFIND response should match with shared-with-me drive-item-id of share :resource')]
 	public function asUserTheKeyFromPropfindResponseShouldMatchWithSharedwithmeDriveitemidOfShare(
 		string $user,
 		string $key,
@@ -4573,7 +4352,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @When /^public downloads the folder "([^"]*)" from the last created public link using the public files API$/
 	 *
 	 * @param string $resource
 	 *
@@ -4581,6 +4359,7 @@ class SpacesContext implements Context {
 	 * @throws GuzzleException
 	 * @throws Exception
 	 */
+	#[When('public downloads the folder :resource from the last created public link using the public files API')]
 	public function publicDownloadsTheFolderFromTheLastCreatedPublicLink(string $resource) {
 		$token = ($this->featureContext->isUsingSharingNG())
 		? $this->featureContext->shareNgGetLastCreatedLinkShareToken()
@@ -4609,13 +4388,13 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @Then the relative quota amount should be :quota_amount
 	 *
 	 * @param string $quotaAmount
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('the relative quota amount should be :quota_amount')]
 	public function theRelativeQuotaAmountShouldBe(string $quotaAmount): void {
 		$data = $this->ocsContext->getOCSResponseData($this->featureContext->getResponse());
 		if (isset($data->quota, $data->quota->relative)) {
@@ -4630,8 +4409,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @Then /^the user "([^"]*)" should have a space called "([^"]*)" granted to (user|group)\s? "([^"]*)" with role "([^"]*)"$/
-	 * @Then /^the user "([^"]*)" should have a space called "([^"]*)" granted to (user|group)\s? "([^"]*)" with role "([^"]*)" and expiration date "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $spaceName
@@ -4644,6 +4421,8 @@ class SpacesContext implements Context {
 	 *
 	 * @throws GuzzleException
 	 */
+	#[Then('/^the user "([^"]*)" should have a space called "([^"]*)" granted to (user|group)\\s? "([^"]*)" with role "([^"]*)"$/')]
+	#[Then('/^the user "([^"]*)" should have a space called "([^"]*)" granted to (user|group)\\s? "([^"]*)" with role "([^"]*)" and expiration date "([^"]*)"$/')]
 	public function theUserShouldHaveSpaceWithRecipient(
 		string $user,
 		string $spaceName,
@@ -4686,8 +4465,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @When user :user tries to download the space :spaceName owned by user :owner using the WebDAV API
-	 * @When /^user "([^"]*)" (?:downloads|tries to download) the space "([^"]*)" using the WebDAV API$/
 	 *
 	 * @param string $user
 	 * @param string $spaceName
@@ -4697,6 +4474,8 @@ class SpacesContext implements Context {
 	 *
 	 * @throws GuzzleException
 	 */
+	#[When('user :user tries to download the space :spaceName owned by user :owner using the WebDAV API')]
+	#[When('/^user "([^"]*)" (?:downloads|tries to download) the space "([^"]*)" using the WebDAV API$/')]
 	public function userDownloadsTheSpaceUsingTheWebdavApi(string $user, string $spaceName, string $owner = ''): void {
 		$space = $this->getSpaceByName($owner ?: $user, $spaceName);
 		$url = $this->archiverContext->getArchiverUrl('id=' . $space['id']);
@@ -4711,51 +4490,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @Given user :sharer has shared resource :path inside space :space with user :sharee
-	 *
-	 * @param $sharer string
-	 * @param $path string
-	 * @param $space string
-	 * @param $sharee string
-	 *
-	 * @return void
-	 * @throws GuzzleException
-	 */
-	public function userHasSharedResourceInsideSpaceWithUser(
-		string $sharer,
-		string $path,
-		string $space,
-		string $sharee
-	): void {
-		$sharer = $this->featureContext->getActualUsername($sharer);
-		$resource_id = $this->getResourceId($sharer, $space, $path);
-		$response = $this->featureContext->createShare(
-			$sharer,
-			$path,
-			'0',
-			$this->featureContext->getActualUsername($sharee),
-			null,
-			null,
-			null,
-			null,
-			null,
-			$resource_id
-		);
-		$this->featureContext->theHTTPStatusCodeShouldBe(200, "", $response);
-		$responseStatusCode = $this->ocsContext->getOCSResponseStatusCode(
-			$response
-		);
-		$statusCodes = ["100", "200"];
-		Assert::assertContainsEquals(
-			$responseStatusCode,
-			$statusCodes,
-			"OCS status code is not any of the expected values "
-			. \implode(",", $statusCodes) . " got " . $responseStatusCode
-		);
-	}
-
-	/**
-	 * @When user :user gets the file :file from space :space using the Graph API
 	 *
 	 * @param string $user
 	 * @param string $file
@@ -4763,6 +4497,7 @@ class SpacesContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[When('user :user gets the file :file from space :space using the Graph API')]
 	public function userGetsTheDriveItemInSpace(string $user, string $file, string $space): void {
 		$spaceId = ($this->getSpaceByName($user, $space))["id"];
 		$itemId = '';

--- a/tests/acceptance/bootstrap/SpacesTUSContext.php
+++ b/tests/acceptance/bootstrap/SpacesTUSContext.php
@@ -14,6 +14,9 @@ use GuzzleHttp\Exception\GuzzleException;
 use PHPUnit\Framework\Assert;
 use TestHelpers\WebDavHelper;
 use TestHelpers\BehatHelper;
+use Behat\Step\Given;
+use Behat\Step\Then;
+use Behat\Step\When;
 
 require_once 'bootstrap.php';
 
@@ -45,7 +48,6 @@ class SpacesTUSContext implements Context {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" has uploaded a file from "([^"]*)" to "([^"]*)" via TUS inside of the space "([^"]*)" using the WebDAV API$/
 	 *
 	 * @param string $user
 	 * @param string $source
@@ -57,6 +59,7 @@ class SpacesTUSContext implements Context {
 	 * @throws Exception
 	 * @throws GuzzleException
 	 */
+	#[Given('user :user has uploaded a file from :source to :destination via TUS inside of the space :spaceName using the WebDAV API')]
 	public function userHasUploadedFileViaTusInSpace(
 		string $user,
 		string $source,
@@ -69,7 +72,6 @@ class SpacesTUSContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" uploads a file from "([^"]*)" to "([^"]*)" via TUS inside of the space "([^"]*)" using the WebDAV API$/
 	 *
 	 * @param string $user
 	 * @param string $source
@@ -80,6 +82,7 @@ class SpacesTUSContext implements Context {
 	 * @throws Exception
 	 * @throws GuzzleException
 	 */
+	#[When('user :user uploads a file from :source to :destination via TUS inside of the space :spaceName using the WebDAV API')]
 	public function userUploadsAFileViaTusInsideOfTheSpaceUsingTheWebdavApi(
 		string $user,
 		string $source,
@@ -92,7 +95,6 @@ class SpacesTUSContext implements Context {
 	}
 
 	/**
-	 * @Given user :user has created a new TUS resource in the space :spaceName with the following headers:
 	 *
 	 * @param string $user
 	 * @param string $spaceName
@@ -103,6 +105,7 @@ class SpacesTUSContext implements Context {
 	 * @throws Exception
 	 * @throws GuzzleException
 	 */
+	#[Given('user :user has created a new TUS resource in the space :spaceName with the following headers:')]
 	public function userHasCreatedANewTusResourceForTheSpaceUsingTheWebdavApiWithTheseHeaders(
 		string $user,
 		string $spaceName,
@@ -114,7 +117,6 @@ class SpacesTUSContext implements Context {
 	}
 
 	/**
-	 * @When user :user creates a new TUS resource for the space :spaceName with content :content using the WebDAV API with these headers:
 	 *
 	 * @param string $user
 	 * @param string $spaceName
@@ -126,6 +128,7 @@ class SpacesTUSContext implements Context {
 	 * @throws Exception
 	 * @throws GuzzleException
 	 */
+	#[When('user :user creates a new TUS resource for the space :spaceName with content :content using the WebDAV API with these headers:')]
 	public function userCreatesANewTusResourceForTheSpaceUsingTheWebdavApiWithTheseHeaders(
 		string $user,
 		string $spaceName,
@@ -166,7 +169,6 @@ class SpacesTUSContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" uploads a file with content "([^"]*)" to "([^"]*)" inside federated share "([^"]*)" via TUS using the WebDAV API$/
 	 *
 	 * @param string $user
 	 * @param string $content
@@ -176,6 +178,7 @@ class SpacesTUSContext implements Context {
 	 * @return void
 	 * @throws Exception|GuzzleException
 	 */
+	#[When('user :user uploads a file with content :content to :file inside federated share :destination via TUS using the WebDAV API')]
 	public function userUploadsAFileWithContentToInsideFederatedShareViaTusUsingTheWebdavApi(
 		string $user,
 		string $content,
@@ -196,7 +199,6 @@ class SpacesTUSContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" uploads a file with content "([^"]*)" to "([^"]*)" via TUS inside of the space "([^"]*)" using the WebDAV API$/
 	 *
 	 * @param string $user
 	 * @param string $content
@@ -206,6 +208,7 @@ class SpacesTUSContext implements Context {
 	 * @return void
 	 * @throws Exception|GuzzleException
 	 */
+	#[When('user :user uploads a file with content :content to :resource via TUS inside of the space :spaceName using the WebDAV API')]
 	public function userUploadsAFileWithContentToViaTusInsideOfTheSpaceUsingTheWebdavApi(
 		string $user,
 		string $content,
@@ -216,7 +219,6 @@ class SpacesTUSContext implements Context {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" has uploaded a file with content "([^"]*)" to "([^"]*)" via TUS inside of the space "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $content
@@ -226,6 +228,7 @@ class SpacesTUSContext implements Context {
 	 * @return void
 	 * @throws Exception|GuzzleException
 	 */
+	#[Given('user :user has uploaded a file with content :content to :resource via TUS inside of the space :spaceName')]
 	public function userHasUploadedAFileWithContentToViaTusInsideOfTheSpace(
 		string $user,
 		string $content,
@@ -236,7 +239,6 @@ class SpacesTUSContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" uploads a file "([^"]*)" to "([^"]*)" with mtime "([^"]*)" via TUS inside of the space "([^"]*)" using the WebDAV API$/
 	 *
 	 * @param string $user
 	 * @param string $source
@@ -249,6 +251,7 @@ class SpacesTUSContext implements Context {
 	 * @throws Exception
 	 * @throws GuzzleException
 	 */
+	#[When('user :user uploads a file :source to :destination with mtime :mtime via TUS inside of the space :spaceName using the WebDAV API')]
 	public function userUploadsAFileToWithMtimeViaTusInsideOfTheSpaceUsingTheWebdavApi(
 		string $user,
 		string $source,
@@ -289,7 +292,6 @@ class SpacesTUSContext implements Context {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" has uploaded file with checksum "([^"]*)" to the last created TUS Location with offset "([^"]*)" and content "([^"]*)" via TUS inside of the space "([^"]*)" using the WebDAV API$/
 	 *
 	 * @param string $user
 	 * @param string $checksum
@@ -301,6 +303,7 @@ class SpacesTUSContext implements Context {
 	 * @throws Exception|GuzzleException
 	 * @codingStandardsIgnoreStart
 	 */
+	#[Given('user :user has uploaded file with checksum :checksum to the last created TUS Location with offset :offset and content :content via TUS inside of the space :spaceName using the WebDAV API')]
 	public function userHasUploadedFileWithChecksumToTheLastCreatedTusLocationWithOffsetAndContentViaTusInsideOfTheSpaceUsingTheWebdavApi(
 		// @codingStandardsIgnoreEnd
 		string $user,
@@ -315,7 +318,6 @@ class SpacesTUSContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" uploads file with checksum "([^"]*)" to the last created TUS Location with offset "([^"]*)" and content "([^"]*)" via TUS inside of the space "([^"]*)" using the WebDAV API$/
 	 *
 	 * @param string $user
 	 * @param string $checksum
@@ -327,6 +329,7 @@ class SpacesTUSContext implements Context {
 	 * @throws Exception|GuzzleException
 	 * @codingStandardsIgnoreStart
 	 */
+	#[When('user :user uploads file with checksum :checksum to the last created TUS Location with offset :offset and content :content via TUS inside of the space :spaceName using the WebDAV API')]
 	public function userUploadsFileWithChecksumToTheLastCreatedTusLocationWithOffsetAndContentViaTusInsideOfTheSpaceUsingTheWebdavApi(
 		// @codingStandardsIgnoreEnd
 		string $user,
@@ -341,7 +344,6 @@ class SpacesTUSContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" sends a chunk to the last created TUS Location with offset "([^"]*)" and data "([^"]*)" with checksum "([^"]*)" via TUS inside of the space "([^"]*)" using the WebDAV API$/
 	 *
 	 * @param string $user
 	 * @param string $offset
@@ -353,6 +355,7 @@ class SpacesTUSContext implements Context {
 	 * @throws Exception|GuzzleException
 	 * @codingStandardsIgnoreStart
 	 */
+	#[When('user :user sends a chunk to the last created TUS Location with offset :offset and data :data with checksum :checksum via TUS inside of the space :spaceName using the WebDAV API')]
 	public function userSendsAChunkToTheLastCreatedTusLocationWithOffsetAndDataWithChecksumViaTusInsideOfTheSpaceUsingTheWebdavApi(
 		// @codingStandardsIgnoreEnd
 		string $user,
@@ -367,7 +370,6 @@ class SpacesTUSContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" sends a chunk to the last created TUS Location with data "([^"]*)" with the following headers:$/
 	 *
 	 * @param string $user
 	 * @param string $data
@@ -376,6 +378,7 @@ class SpacesTUSContext implements Context {
 	 * @return void
 	 * @throws Exception|GuzzleException
 	 */
+	#[When('user :user sends a chunk to the last created TUS Location with data :data with the following headers:')]
 	public function userSendsAChunkToTheLastCreatedTusLocationWithDataInsideOfTheSpaceWithHeaders(
 		string $user,
 		string $data,
@@ -395,7 +398,6 @@ class SpacesTUSContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" overwrites recently shared file with offset "([^"]*)" and data "([^"]*)" with checksum "([^"]*)" via TUS inside of the space "([^"]*)" using the WebDAV API with these headers:$/
 	 *
 	 * @param string $user
 	 * @param string $offset
@@ -408,6 +410,7 @@ class SpacesTUSContext implements Context {
 	 * @throws GuzzleException
 	 * @codingStandardsIgnoreStart
 	 */
+	#[When('user :user overwrites recently shared file with offset :offset and data :data with checksum :checksum via TUS inside of the space :spaceName using the WebDAV API with these headers:')]
 	public function userOverwritesRecentlySharedFileWithOffsetAndDataWithChecksumViaTusInsideOfTheSpaceUsingTheWebdavApiWithTheseHeaders(
 		// @codingStandardsIgnoreEnd
 		string $user,
@@ -426,7 +429,6 @@ class SpacesTUSContext implements Context {
 	}
 
 	/**
-	 * @Then /^as "([^"]*)" the mtime of the file "([^"]*)" in space "([^"]*)" should be "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $resource
@@ -436,6 +438,7 @@ class SpacesTUSContext implements Context {
 	 * @return void
 	 * @throws Exception|GuzzleException
 	 */
+	#[Then('as :user the mtime of the file :resource in space :spaceName should be :mtime')]
 	public function theMtimeOfTheFileInSpaceShouldBe(
 		string $user,
 		string $resource,

--- a/tests/acceptance/bootstrap/TUSContext.php
+++ b/tests/acceptance/bootstrap/TUSContext.php
@@ -33,6 +33,8 @@ use TestHelpers\HttpRequestHelper;
 use TestHelpers\WebDavHelper;
 use TestHelpers\BehatHelper;
 use TestHelpers\UploadHelper;
+use Behat\Step\Given;
+use Behat\Step\When;
 
 require_once 'bootstrap.php';
 
@@ -130,7 +132,6 @@ class TUSContext implements Context {
 	}
 
 	/**
-	 * @When user :user creates a new TUS resource on the WebDAV API with these headers:
 	 *
 	 * @param string $user
 	 * @param TableNode $headers
@@ -141,13 +142,13 @@ class TUSContext implements Context {
 	 * @throws Exception
 	 * @throws GuzzleException
 	 */
+	#[When('user :user creates a new TUS resource on the WebDAV API with these headers:')]
 	public function userCreateNewTUSResourceWithHeaders(string $user, TableNode $headers, string $content = ''): void {
 		$response = $this->createNewTUSResourceWithHeaders($user, $headers, $content);
 		$this->featureContext->setResponse($response);
 	}
 
 	/**
-	 * @Given user :user has created a new TUS resource on the WebDAV API with these headers:
 	 *
 	 * @param string $user
 	 * @param TableNode $headers Tus-Resumable: 1.0.0 header is added automatically
@@ -157,6 +158,7 @@ class TUSContext implements Context {
 	 * @throws Exception
 	 * @throws GuzzleException
 	 */
+	#[Given('user :user has created a new TUS resource on the WebDAV API with these headers:')]
 	public function userHasCreatedNewTUSResourceWithHeaders(string $user, TableNode $headers): void {
 		$response = $this->createNewTUSResource($user, $headers);
 		$this->featureContext->theHTTPStatusCodeShouldBe(201, "", $response);
@@ -218,7 +220,6 @@ class TUSContext implements Context {
 	}
 
 	/**
-	 * @When user :user sends a chunk to the last created TUS Location with offset :offset and data :data with retry on offset mismatch using the WebDAV API
 	 *
 	 * @param string $user
 	 * @param string $offset
@@ -229,6 +230,7 @@ class TUSContext implements Context {
 	 * @throws GuzzleException
 	 * @throws JsonException
 	 */
+	#[When('user :user sends a chunk to the last created TUS Location with offset :offset and data :data with retry on offset mismatch using the WebDAV API')]
 	public function userSendsAChunkToTUSLocationWithOffsetAndDataWithRetryOnOffsetMismatch(
 		string $user,
 		string $offset,
@@ -256,7 +258,6 @@ class TUSContext implements Context {
 	}
 
 	/**
-	 * @When user :user sends a chunk to the last created TUS Location with offset :offset and data :data using the WebDAV API
 	 *
 	 * @param string $user
 	 * @param string $offset
@@ -267,6 +268,7 @@ class TUSContext implements Context {
 	 * @throws GuzzleException
 	 * @throws JsonException
 	 */
+	#[When('user :user sends a chunk to the last created TUS Location with offset :offset and data :data using the WebDAV API')]
 	public function userSendsAChunkToTUSLocationWithOffsetAndData(string $user, string $offset, string $data): void {
 		$resourceLocation = $this->getLastTusResourceLocation();
 		$response = $this->uploadChunkToTUSLocation($user, $resourceLocation, $offset, $data);
@@ -274,7 +276,6 @@ class TUSContext implements Context {
 	}
 
 	/**
-	 * @When user :user uploads file :source to :destination using the TUS protocol on the WebDAV API
 	 *
 	 * @param string|null $user
 	 * @param string $source
@@ -294,6 +295,7 @@ class TUSContext implements Context {
 	 * @throws ReflectionException
 	 * @throws TusException
 	 */
+	#[When('user :user uploads file :source to :destination using the TUS protocol on the WebDAV API')]
 	public function userUploadsUsingTusAFileTo(
 		?string $user,
 		string  $source,
@@ -384,7 +386,6 @@ class TUSContext implements Context {
 	}
 
 	/**
-	 * @When user :user uploads file with content :content to :destination using the TUS protocol on the WebDAV API
 	 *
 	 * @param string $user
 	 * @param string $content
@@ -394,6 +395,7 @@ class TUSContext implements Context {
 	 * @throws GuzzleException
 	 * @throws Exception
 	 */
+	#[When('user :user uploads file with content :content to :destination using the TUS protocol on the WebDAV API')]
 	public function userUploadsAFileWithContentToUsingTus(
 		string $user,
 		string $content,
@@ -414,7 +416,6 @@ class TUSContext implements Context {
 	}
 
 	/**
-	 * @When user :user uploads file with content :content in :noOfChunks chunks to :destination using the TUS protocol on the WebDAV API
 	 *
 	 * @param string|null $user
 	 * @param string $content
@@ -430,6 +431,7 @@ class TUSContext implements Context {
 	 * @throws Exception
 	 * @throws GuzzleException
 	 */
+	#[When('user :user uploads file with content :content in :noOfChunks chunks to :destination using the TUS protocol on the WebDAV API')]
 	public function userUploadsAFileWithContentInChunksUsingTus(
 		?string $user,
 		string  $content,
@@ -450,7 +452,6 @@ class TUSContext implements Context {
 	}
 
 	/**
-	 * @Given user :user has uploaded file :source to :destination with mtime :mtime using the TUS protocol
 	 *
 	 * @param string $user
 	 * @param string $source
@@ -461,6 +462,7 @@ class TUSContext implements Context {
 	 * @throws Exception
 	 * @throws GuzzleException
 	 */
+	#[Given('user :user has uploaded file :source to :destination with mtime :mtime using the TUS protocol')]
 	public function userHasUploadedFileWithMtimeUsingTUS(
 		string $user,
 		string $source,
@@ -481,7 +483,6 @@ class TUSContext implements Context {
 	}
 
 	/**
-	 * @When user :user uploads file :source to :destination with mtime :mtime using the TUS protocol on the WebDAV API
 	 *
 	 * @param string $user
 	 * @param string $source
@@ -492,6 +493,7 @@ class TUSContext implements Context {
 	 * @throws Exception
 	 * @throws GuzzleException
 	 */
+	#[When('user :user uploads file :source to :destination with mtime :mtime using the TUS protocol on the WebDAV API')]
 	public function userUploadsFileWithContentToWithMtimeUsingTUS(
 		string $user,
 		string $source,
@@ -551,7 +553,6 @@ class TUSContext implements Context {
 	}
 
 	/**
-	 * @When user :user creates a new TUS resource with content :content on the WebDAV API with these headers:
 	 *
 	 * @param string $user
 	 * @param string $content
@@ -561,6 +562,7 @@ class TUSContext implements Context {
 	 * @throws Exception
 	 * @throws GuzzleException
 	 */
+	#[When('user :user creates a new TUS resource with content :content on the WebDAV API with these headers:')]
 	public function userCreatesWithUpload(
 		string    $user,
 		string    $content,
@@ -571,7 +573,6 @@ class TUSContext implements Context {
 	}
 
 	/**
-	 * @When user :user creates file :source and uploads content :content in the same request using the TUS protocol on the WebDAV API
 	 *
 	 * @param string $user
 	 * @param string $source
@@ -580,6 +581,7 @@ class TUSContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('user :user creates file :source and uploads content :content in the same request using the TUS protocol on the WebDAV API')]
 	public function userUploadsWithCreatesWithUpload(
 		string $user,
 		string $source,
@@ -600,7 +602,6 @@ class TUSContext implements Context {
 	}
 
 	/**
-	 * @When user :user uploads file with checksum :checksum to the last created TUS Location with offset :offset and content :content using the TUS protocol on the WebDAV API
 	 *
 	 * @param string $user
 	 * @param string $checksum
@@ -610,6 +611,7 @@ class TUSContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('user :user uploads file with checksum :checksum to the last created TUS Location with offset :offset and content :content using the TUS protocol on the WebDAV API')]
 	public function userUploadsFileWithChecksum(
 		string $user,
 		string $checksum,
@@ -622,8 +624,6 @@ class TUSContext implements Context {
 	}
 
 	/**
-	 * @When user :user uploads content :content with checksum :checksum and offset :offset to the index :locationIndex location of file :filename using the TUS protocol
-	 * @When user :user tries to upload content :content with checksum :checksum and offset :offset to the index :locationIndex location of file :filename using the TUS protocol
 	 *
 	 * @param string $user
 	 * @param string $content
@@ -635,6 +635,8 @@ class TUSContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('user :user uploads content :content with checksum :checksum and offset :offset to the index :locationIndex location of file :filename using the TUS protocol')]
+	#[When('user :user tries to upload content :content with checksum :checksum and offset :offset to the index :locationIndex location of file :filename using the TUS protocol')]
 	public function userUploadsContentWithChecksumAndOffsetToIndexLocationUsingTUSProtocol(
 		string $user,
 		string $content,
@@ -650,7 +652,6 @@ class TUSContext implements Context {
 	}
 
 	/**
-	 * @Given user :user has uploaded file with checksum :checksum to the last created TUS Location with offset :offset and content :content using the TUS protocol on the WebDAV API
 	 *
 	 * @param string $user
 	 * @param string $checksum
@@ -660,6 +661,7 @@ class TUSContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Given('user :user has uploaded file with checksum :checksum to the last created TUS Location with offset :offset and content :content using the TUS protocol on the WebDAV API')]
 	public function userHasUploadedFileWithChecksum(
 		string $user,
 		string $checksum,
@@ -672,7 +674,6 @@ class TUSContext implements Context {
 	}
 
 	/**
-	 * @When user :user sends a chunk to the last created TUS Location with offset :offset and data :data with checksum :checksum using the TUS protocol on the WebDAV API
 	 *
 	 * @param string $user
 	 * @param string $offset
@@ -682,6 +683,7 @@ class TUSContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('user :user sends a chunk to the last created TUS Location with offset :offset and data :data with checksum :checksum using the TUS protocol on the WebDAV API')]
 	public function userUploadsChunkFileWithChecksum(
 		string $user,
 		string $offset,
@@ -694,7 +696,6 @@ class TUSContext implements Context {
 	}
 
 	/**
-	 * @Given user :user has uploaded a chunk to the last created TUS Location with offset :offset and data :data with checksum :checksum using the TUS protocol on the WebDAV API
 	 *
 	 * @param string $user
 	 * @param string $offset
@@ -704,6 +705,7 @@ class TUSContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Given('user :user has uploaded a chunk to the last created TUS Location with offset :offset and data :data with checksum :checksum using the TUS protocol on the WebDAV API')]
 	public function userHasUploadedChunkFileWithChecksum(
 		string $user,
 		string $offset,
@@ -716,8 +718,6 @@ class TUSContext implements Context {
 	}
 
 	/**
-	 * @When user :user overwrites recently shared file with offset :offset and data :data with checksum :checksum using the TUS protocol on the WebDAV API with these headers:
-	 * @When user :user overwrites existing file with offset :offset and data :data with checksum :checksum using the TUS protocol on the WebDAV API with these headers:
 	 *
 	 * @param string $user
 	 * @param string $offset
@@ -730,6 +730,8 @@ class TUSContext implements Context {
 	 * @throws GuzzleException
 	 * @throws Exception
 	 */
+	#[When('user :user overwrites recently shared file with offset :offset and data :data with checksum :checksum using the TUS protocol on the WebDAV API with these headers:')]
+	#[When('user :user overwrites existing file with offset :offset and data :data with checksum :checksum using the TUS protocol on the WebDAV API with these headers:')]
 	public function userOverwritesFileWithChecksum(
 		string $user,
 		string $offset,

--- a/tests/acceptance/bootstrap/TagContext.php
+++ b/tests/acceptance/bootstrap/TagContext.php
@@ -26,6 +26,9 @@ use PHPUnit\Framework\Assert;
 use Psr\Http\Message\ResponseInterface;
 use TestHelpers\GraphHelper;
 use TestHelpers\BehatHelper;
+use Behat\Step\Given;
+use Behat\Step\Then;
+use Behat\Step\When;
 
 require_once 'bootstrap.php';
 
@@ -92,7 +95,6 @@ class TagContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" creates the following tags for (folder|file) "([^"]*)" of space "([^"]*)":$/
 	 *
 	 * @param string $user
 	 * @param string $fileOrFolder   (file|folder)
@@ -103,6 +105,7 @@ class TagContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('/^user "([^"]*)" creates the following tags for (folder|file) "([^"]*)" of space "([^"]*)":$/')]
 	public function theUserCreatesFollowingTags(
 		string $user,
 		string $fileOrFolder,
@@ -115,7 +118,6 @@ class TagContext implements Context {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" has created the following tags for (folder|file)\s?"([^"]*)" of the space "([^"]*)":$/
 	 *
 	 * @param string $user
 	 * @param string $fileOrFolder   (file|folder)
@@ -126,6 +128,7 @@ class TagContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Given('/^user "([^"]*)" has created the following tags for (folder|file)\\s?"([^"]*)" of the space "([^"]*)":$/')]
 	public function theUserHasCreatedFollowingTags(
 		string $user,
 		string $fileOrFolder,
@@ -138,7 +141,6 @@ class TagContext implements Context {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" has tagged the following (folders|files) of the space "([^"]*)":$/
 	 *
 	 * @param string $user
 	 * @param string $filesOrFolders (files|folders)
@@ -148,6 +150,7 @@ class TagContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Given('/^user "([^"]*)" has tagged the following (folders|files) of the space "([^"]*)":$/')]
 	public function userHasCreatedTheFollowingTagsForFilesOfTheSpace(
 		string $user,
 		string $filesOrFolders,
@@ -164,13 +167,13 @@ class TagContext implements Context {
 	}
 
 	/**
-	 * @When user :user lists all available tag(s) via the Graph API
 	 *
 	 * @param string $user
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('user :user lists all available tag(s) via the Graph API')]
 	public function theUserGetsAllAvailableTags(string $user): void {
 		// Note: after creating or deleting tags, in some cases tags do not appear or disappear immediately,
 		// So wait is necessary before listing tags
@@ -186,7 +189,6 @@ class TagContext implements Context {
 	}
 
 	/**
-	 * @Then /^the response should (not|)\s?contain following tag(s):$/
 	 *
 	 * @param string    $shouldOrNot   (not|)
 	 * @param TableNode $table
@@ -194,6 +196,7 @@ class TagContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('/^the response should (not|)\\s?contain following tag(s):$/')]
 	public function theFollowingTagsShouldExistForUser(string $shouldOrNot, TableNode $table): void {
 		$rows = $table->getRows();
 		foreach ($rows as $row) {
@@ -255,7 +258,6 @@ class TagContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" removes the following tags for (folder|file) "([^"]*)" of space "([^"]*)":$/
 	 *
 	 * @param string $user
 	 * @param string $fileOrFolder   (file|folder)
@@ -266,6 +268,7 @@ class TagContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('/^user "([^"]*)" removes the following tags for (folder|file) "([^"]*)" of space "([^"]*)":$/')]
 	public function userRemovesTagsFromResourceOfTheSpace(
 		string $user,
 		string $fileOrFolder,
@@ -284,7 +287,6 @@ class TagContext implements Context {
 	}
 
 	/**
-	 * @Given  /^user "([^"]*)" has removed the following tags for (folder|file) "([^"]*)" of space "([^"]*)":$/
 	 *
 	 * @param string $user
 	 * @param string $fileOrFolder   (file|folder)
@@ -295,6 +297,7 @@ class TagContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Given('/^user "([^"]*)" has removed the following tags for (folder|file) "([^"]*)" of space "([^"]*)":$/')]
 	public function userHAsRemovedTheFollowingTagsForFileOfSpace(
 		string $user,
 		string $fileOrFolder,

--- a/tests/acceptance/bootstrap/TrashbinContext.php
+++ b/tests/acceptance/bootstrap/TrashbinContext.php
@@ -28,6 +28,9 @@ use Psr\Http\Message\ResponseInterface;
 use TestHelpers\HttpRequestHelper;
 use TestHelpers\WebDavHelper;
 use TestHelpers\BehatHelper;
+use Behat\Step\Given;
+use Behat\Step\Then;
+use Behat\Step\When;
 
 require_once 'bootstrap.php';
 
@@ -61,12 +64,12 @@ class TrashbinContext implements Context {
 	}
 
 	/**
-	 * @When user :user empties the trashbin using the trashbin API
 	 *
 	 * @param string $user user
 	 *
 	 * @return void
 	 */
+	#[When('user :user empties the trashbin using the trashbin API')]
 	public function userEmptiesTrashbin(string $user): void {
 		$this->featureContext->setResponse($this->emptyTrashbin($user));
 	}
@@ -323,7 +326,6 @@ class TrashbinContext implements Context {
 	}
 
 	/**
-	 * @When user :user lists the resources in the trashbin with depth :depth using the WebDAV API
 	 *
 	 * @param string $user
 	 * @param string $depth
@@ -331,18 +333,19 @@ class TrashbinContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('user :user lists the resources in the trashbin with depth :depth using the WebDAV API')]
 	public function userGetsFilesInTheTrashbinWithDepthUsingTheWebdavApi(string $user, string $depth): void {
 		$this->listTopOfTrashbinFolder($user, $depth);
 	}
 
 	/**
-	 * @Then the trashbin DAV response should not contain these nodes
 	 *
 	 * @param TableNode $table
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('the trashbin DAV response should not contain these nodes')]
 	public function theTrashbinDavResponseShouldNotContainTheseNodes(TableNode $table): void {
 		$this->featureContext->verifyTableNodeColumns($table, ['name']);
 		$files = $this->getTrashbinContentFromResponseXml(
@@ -360,13 +363,13 @@ class TrashbinContext implements Context {
 	}
 
 	/**
-	 * @Then the trashbin DAV response should contain these nodes
 	 *
 	 * @param TableNode $table
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('the trashbin DAV response should contain these nodes')]
 	public function theTrashbinDavResponseShouldContainTheseNodes(TableNode $table): void {
 		$this->featureContext->verifyTableNodeColumns($table, ['name']);
 
@@ -428,7 +431,6 @@ class TrashbinContext implements Context {
 	}
 
 	/**
-	 * @When user :asUser tries to list the trashbin content for user :user
 	 *
 	 * @param string $asUser
 	 * @param string $user
@@ -436,6 +438,7 @@ class TrashbinContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('user :asUser tries to list the trashbin content for user :user')]
 	public function userTriesToListTheTrashbinContentForUser(string $asUser, string $user) {
 		$user = $this->featureContext->getActualUsername($user);
 		$asUser = $this->featureContext->getActualUsername($asUser);
@@ -444,7 +447,6 @@ class TrashbinContext implements Context {
 	}
 
 	/**
-	 * @When user :asUser tries to list the trashbin content for user :user using password :password
 	 *
 	 * @param string $asUser
 	 * @param string $user
@@ -453,6 +455,7 @@ class TrashbinContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('user :asUser tries to list the trashbin content for user :user using password :password')]
 	public function userTriesToListTheTrashbinContentForUserUsingPassword(
 		string $asUser,
 		string $user,
@@ -463,13 +466,13 @@ class TrashbinContext implements Context {
 	}
 
 	/**
-	 * @Then the last webdav response should not contain the following elements
 	 *
 	 * @param TableNode $elements
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('the last webdav response should not contain the following elements')]
 	public function theLastWebdavResponseShouldNotContainFollowingElements(TableNode $elements): void {
 		$files = $this->getTrashbinContentFromResponseXml(
 			HttpRequestHelper::getResponseXml($this->featureContext->getResponse())
@@ -495,7 +498,6 @@ class TrashbinContext implements Context {
 	}
 
 	/**
-	 * @When user :user tries to delete the file with original path :path from the trashbin of user :ofUser using the trashbin API
 	 *
 	 * @param string $user
 	 * @param string $path
@@ -504,13 +506,13 @@ class TrashbinContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('user :user tries to delete the file with original path :path from the trashbin of user :ofUser using the trashbin API')]
 	public function userTriesToDeleteFromTrashbinOfUser(string $user, string $path, string $ofUser): void {
 		$response = $this->deleteItemFromTrashbin($user, $path, $ofUser);
 		$this->featureContext->setResponse($response);
 	}
 
 	/**
-	 * @When user :user tries to delete the file with original path :path from the trashbin of user :ofUser using the password :password and the trashbin API
 	 *
 	 * @param string $user
 	 * @param string $path
@@ -521,6 +523,7 @@ class TrashbinContext implements Context {
 	 * @throws JsonException
 	 * @throws Exception
 	 */
+	#[When('user :user tries to delete the file with original path :path from the trashbin of user :ofUser using the password :password and the trashbin API')]
 	public function userTriesToDeleteFromTrashbinOfUserUsingPassword(
 		string $user,
 		string $path,
@@ -532,7 +535,6 @@ class TrashbinContext implements Context {
 	}
 
 	/**
-	 * @When user :asUser tries to restore the file with original path :path from the trashbin of user :user using the trashbin API
 	 *
 	 * @param string|null $asUser
 	 * @param string|null $path
@@ -542,6 +544,7 @@ class TrashbinContext implements Context {
 	 * @throws JsonException
 	 * @throws Exception
 	 */
+	#[When('user :asUser tries to restore the file with original path :path from the trashbin of user :user using the trashbin API')]
 	public function userTriesToRestoreFromTrashbinOfUser(?string $asUser, ?string $path, ?string $user): void {
 		$user = $this->featureContext->getActualUsername($user);
 		$asUser = $this->featureContext->getActualUsername($asUser);
@@ -550,7 +553,6 @@ class TrashbinContext implements Context {
 	}
 
 	/**
-	 * @When user :asUser tries to restore the file with original path :path from the trashbin of user :user using the password :password and the trashbin API
 	 *
 	 * @param string|null $asUser
 	 * @param string|null $path
@@ -561,6 +563,7 @@ class TrashbinContext implements Context {
 	 * @throws JsonException
 	 * @throws Exception
 	 */
+	#[When('user :asUser tries to restore the file with original path :path from the trashbin of user :user using the password :password and the trashbin API')]
 	public function userTriesToRestoreFromTrashbinOfUserUsingPassword(
 		?string $asUser,
 		?string $path,
@@ -587,22 +590,6 @@ class TrashbinContext implements Context {
 		$parts = \explode('/', $trashItemHRef);
 		$decodedParts = \array_slice($parts, 2);
 		return '/' . \join('/', $decodedParts);
-	}
-
-	/**
-	 * @When /^user "([^"]*)" tries to delete the (?:file|folder|entry) with original path "([^"]*)" from the trashbin using the trashbin API$/
-	 *
-	 * @param string $user
-	 * @param string $originalPath
-	 *
-	 * @return void
-	 */
-	public function userTriesToDeleteFileWithOriginalPathFromTrashbinUsingTrashbinAPI(
-		string $user,
-		string $originalPath
-	): void {
-		$response = $this->deleteItemFromTrashbin($user, $originalPath);
-		$this->featureContext->setResponse($response);
 	}
 
 	/**
@@ -657,7 +644,6 @@ class TrashbinContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" deletes the (?:file|folder|entry) with original path "([^"]*)" from the trashbin using the trashbin API$/
 	 *
 	 * @param string $user
 	 * @param string $originalPath
@@ -665,6 +651,7 @@ class TrashbinContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('/^user "([^"]*)" deletes the (?:file|folder|entry) with original path "([^"]*)" from the trashbin using the trashbin API$/')]
 	public function deleteFileFromTrashbin(string $user, string $originalPath): void {
 		$response = $this->deleteItemFromTrashbin($user, $originalPath);
 		$this->featureContext->setResponse($response);
@@ -672,7 +659,6 @@ class TrashbinContext implements Context {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" has deleted the (?:file|folder|entry) with original path "([^"]*)" from the trashbin$/
 	 *
 	 * @param string $user
 	 * @param string $originalPath
@@ -680,13 +666,13 @@ class TrashbinContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Given('/^user "([^"]*)" has deleted the (?:file|folder|entry) with original path "([^"]*)" from the trashbin$/')]
 	public function userHasDeletedTheFolderWithOriginalPathFromTheTrashbin(string $user, string $originalPath): void {
 		$response = $this->deleteItemFromTrashbin($user, $originalPath);
 		$this->featureContext->theHTTPStatusCodeShouldBe(204, '', $response);
 	}
 
 	/**
-	 * @When /^user "([^"]*)" deletes the following (?:files|folders|entries) with original path from the trashbin$/
 	 *
 	 * @param string $user
 	 * @param TableNode $table
@@ -694,6 +680,7 @@ class TrashbinContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('/^user "([^"]*)" deletes the following (?:files|folders|entries) with original path from the trashbin$/')]
 	public function deleteFollowingFilesFromTrashbin(string $user, TableNode $table): void {
 		$this->featureContext->verifyTableNodeColumns($table, ["path"]);
 		$paths = $table->getHash();
@@ -706,7 +693,6 @@ class TrashbinContext implements Context {
 	}
 
 	/**
-	 * @Then /^as "([^"]*)" (?:file|folder|entry) "([^"]*)" should exist in the trashbin$/
 	 *
 	 * @param string|null $user
 	 * @param string|null $path
@@ -715,6 +701,7 @@ class TrashbinContext implements Context {
 	 * @throws JsonException
 	 * @throws Exception
 	 */
+	#[Then('/^as "([^"]*)" (?:file|folder|entry) "([^"]*)" should exist in the trashbin$/')]
 	public function asFileOrFolderExistsInTrash(?string $user, ?string $path): void {
 		$user = $this->featureContext->getActualUsername($user);
 		$path = \trim($path, '/');
@@ -883,7 +870,6 @@ class TrashbinContext implements Context {
 	}
 
 	/**
-	 * @When user :user restores the folder/file with original path :originalPath without specifying the destination using the trashbin API
 	 *
 	 * @param $user string
 	 * @param $originalPath string
@@ -891,6 +877,7 @@ class TrashbinContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('user :user restores the folder/file with original path :originalPath without specifying the destination using the trashbin API')]
 	public function userRestoresResourceWithOriginalPathWithoutSpecifyingDestinationUsingTrashbinApi(
 		string $user,
 		string $originalPath
@@ -917,7 +904,6 @@ class TrashbinContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" restores the (?:file|folder|entry) with original path "([^"]*)" using the trashbin API$/
 	 *
 	 * @param string|null $user
 	 * @param string $originalPath
@@ -926,13 +912,13 @@ class TrashbinContext implements Context {
 	 * @throws JsonException
 	 * @throws Exception
 	 */
+	#[When('/^user "([^"]*)" restores the (?:file|folder|entry) with original path "([^"]*)" using the trashbin API$/')]
 	public function elementInTrashIsRestored(?string $user, string $originalPath): void {
 		$user = $this->featureContext->getActualUsername($user);
 		$this->featureContext->setResponse($this->restoreElement($user, $originalPath));
 	}
 
 	/**
-	 * @When /^user "([^"]*)" restores the following (?:files|folders|entries) with original path$/
 	 *
 	 * @param string $user
 	 * @param TableNode $table
@@ -940,6 +926,7 @@ class TrashbinContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('/^user "([^"]*)" restores the following (?:files|folders|entries) with original path$/')]
 	public function userRestoresFollowingFiles(string $user, TableNode $table): void {
 		$this->featureContext->verifyTableNodeColumns($table, ["path"]);
 		$paths = $table->getHash();
@@ -952,7 +939,6 @@ class TrashbinContext implements Context {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" has restored the (?:file|folder|entry) with original path "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $originalPath
@@ -960,6 +946,7 @@ class TrashbinContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Given('/^user "([^"]*)" has restored the (?:file|folder|entry) with original path "([^"]*)"$/')]
 	public function elementInTrashHasBeenRestored(string $user, string $originalPath): void {
 		$response = $this->restoreElement($user, $originalPath);
 		$this->featureContext->theHTTPStatusCodeShouldBe(201, "", $response);
@@ -969,7 +956,6 @@ class TrashbinContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" restores the (?:file|folder|entry) with original path "([^"]*)" to "([^"]*)" using the trashbin API$/
 	 *
 	 * @param string|null $user
 	 * @param string|null $originalPath
@@ -979,6 +965,7 @@ class TrashbinContext implements Context {
 	 * @throws JsonException
 	 * @throws Exception
 	 */
+	#[When('/^user "([^"]*)" restores the (?:file|folder|entry) with original path "([^"]*)" to "([^"]*)" using the trashbin API$/')]
 	public function userRestoresTheFileWithOriginalPathToUsingTheTrashbinApi(
 		?string $user,
 		?string $originalPath,
@@ -989,7 +976,6 @@ class TrashbinContext implements Context {
 	}
 
 	/**
-	 * @Then /^as "([^"]*)" the (?:file|folder|entry) with original path "([^"]*)" should exist in the trashbin$/
 	 *
 	 * @param string|null $user
 	 * @param string|null $originalPath
@@ -998,6 +984,7 @@ class TrashbinContext implements Context {
 	 * @throws JsonException
 	 * @throws Exception
 	 */
+	#[Then('/^as "([^"]*)" the (?:file|folder|entry) with original path "([^"]*)" should exist in the trashbin$/')]
 	public function elementIsInTrashCheckingOriginalPath(
 		?string $user,
 		?string $originalPath
@@ -1010,7 +997,6 @@ class TrashbinContext implements Context {
 	}
 
 	/**
-	 * @Then /^as "([^"]*)" the (?:file|folder|entry) with original path "([^"]*)" should not exist in the trashbin/
 	 *
 	 * @param string|null $user
 	 * @param string $originalPath
@@ -1018,6 +1004,7 @@ class TrashbinContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('/^as "([^"]*)" the (?:file|folder|entry) with original path "([^"]*)" should not exist in the trashbin/')]
 	public function elementIsNotInTrashCheckingOriginalPath(
 		?string $user,
 		string $originalPath
@@ -1030,7 +1017,6 @@ class TrashbinContext implements Context {
 	}
 
 	/**
-	 * @Then /^as "([^"]*)" the (?:files|folders|entries) with following original paths should not exist in the trashbin$/
 	 *
 	 * @param string $user
 	 * @param TableNode $table
@@ -1038,6 +1024,7 @@ class TrashbinContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('/^as "([^"]*)" the (?:files|folders|entries) with following original paths should not exist in the trashbin$/')]
 	public function followingElementsAreNotInTrashCheckingOriginalPath(
 		string $user,
 		TableNode $table
@@ -1055,7 +1042,6 @@ class TrashbinContext implements Context {
 	}
 
 	/**
-	 * @Then /^as "([^"]*)" the (?:files|folders|entries) with following original paths should exist in the trashbin$/
 	 *
 	 * @param string $user
 	 * @param TableNode $table
@@ -1063,6 +1049,7 @@ class TrashbinContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('/^as "([^"]*)" the (?:files|folders|entries) with following original paths should exist in the trashbin$/')]
 	public function followingElementsAreInTrashCheckingOriginalPath(
 		string $user,
 		TableNode $table
@@ -1118,12 +1105,12 @@ class TrashbinContext implements Context {
 	}
 
 	/**
-	 * @Then /^the deleted (?:file|folder) "([^"]*)" should have the correct deletion mtime in the response$/
 	 *
 	 * @param string $resource file or folder in trashbin
 	 *
 	 * @return void
 	 */
+	#[Then('/^the deleted (?:file|folder) "([^"]*)" should have the correct deletion mtime in the response$/')]
 	public function theDeletedFileFolderShouldHaveCorrectDeletionMtimeInTheResponse(string $resource): void {
 		$files = $this->getTrashbinContentFromResponseXml(
 			HttpRequestHelper::getResponseXml($this->featureContext->getResponse())

--- a/tests/acceptance/bootstrap/WebDav.php
+++ b/tests/acceptance/bootstrap/WebDav.php
@@ -32,6 +32,9 @@ use TestHelpers\WebDavHelper;
 use TestHelpers\HttpRequestHelper;
 use TestHelpers\Asserts\WebDav as WebDavAssert;
 use TestHelpers\GraphHelper;
+use Behat\Step\Given;
+use Behat\Step\Then;
+use Behat\Step\When;
 
 /**
  * WebDav functions
@@ -179,12 +182,12 @@ trait WebDav {
 	}
 
 	/**
-	 * @Given /^using (old|new|spaces) DAV path$/
 	 *
 	 * @param string $davChoice
 	 *
 	 * @return void
 	 */
+	#[Given('/^using (old|new|spaces) DAV path$/')]
 	public function usingOldOrNewOrSpacesDavPath(string $davChoice): void {
 		switch ($davChoice) {
 			case 'old':
@@ -415,13 +418,13 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then the number of versions should be :arg1
 	 *
 	 * @param int $number
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('the number of versions should be :arg1')]
 	public function theNumberOfVersionsShouldBe(int $number): void {
 		$responseXmlObject = HttpRequestHelper::getResponseXml($this->getResponse(), __METHOD__);
 		$xmlPart = $responseXmlObject->xpath("//d:getlastmodified");
@@ -434,13 +437,13 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then the number of etag elements in the response should be :number
 	 *
 	 * @param int $number
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('the number of etag elements in the response should be :number')]
 	public function theNumberOfEtagElementInTheResponseShouldBe(int $number): void {
 		$responseXmlObject = HttpRequestHelper::getResponseXml($this->getResponse());
 		$xmlPart = $responseXmlObject->xpath("//d:getetag");
@@ -482,7 +485,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" has moved (?:file|folder|entry) "([^"]*)" to "([^"]*)"$/
 	 *
 	 * @param string|null $user
 	 * @param string|null $fileSource
@@ -490,6 +492,7 @@ trait WebDav {
 	 *
 	 * @return void
 	 */
+	#[Given('/^user "([^"]*)" has moved (?:file|folder|entry) "([^"]*)" to "([^"]*)"$/')]
 	public function userHasMovedFile(
 		?string $user,
 		?string $fileSource,
@@ -527,8 +530,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @When user :user moves file :source to :destination using the WebDAV API
-	 * @When user :user moves folder :source to :destination using the WebDAV API
 	 *
 	 * @param string $user
 	 * @param string $source
@@ -538,6 +539,8 @@ trait WebDav {
 	 * @throws JsonException
 	 * @throws GuzzleException
 	 */
+	#[When('user :user moves file :source to :destination using the WebDAV API')]
+	#[When('user :user moves folder :source to :destination using the WebDAV API')]
 	public function userMovesFileOrFolderUsingTheWebDavAPI(
 		string $user,
 		string $source,
@@ -549,7 +552,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @When user :user moves the following file using the WebDAV API
 	 *
 	 * @param string $user
 	 * @param TableNode $table
@@ -557,6 +559,7 @@ trait WebDav {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('user :user moves the following file using the WebDAV API')]
 	public function userMovesTheFollowingFileUsingTheWebdavApi(string $user, TableNode $table): void {
 		$this->verifyTableNodeColumns($table, ["source",  "destination"]);
 		$rows = $table->getHash();
@@ -570,7 +573,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" moves the following (?:files|folders|entries)\s?(asynchronously|) using the WebDAV API$/
 	 *
 	 * @param string $user
 	 * @param string $type "asynchronously" or empty
@@ -579,6 +581,7 @@ trait WebDav {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('/^user "([^"]*)" moves the following (?:files|folders|entries)\\s?(asynchronously|) using the WebDAV API$/')]
 	public function userMovesFollowingFileUsingTheAPI(
 		string $user,
 		string $type,
@@ -596,7 +599,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then /^user "([^"]*)" should be able to rename (file|folder|entry) "([^"]*)" to "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $entry
@@ -606,6 +608,7 @@ trait WebDav {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('/^user "([^"]*)" should be able to rename (file|folder|entry) "([^"]*)" to "([^"]*)"$/')]
 	public function theUserShouldBeAbleToRenameEntryTo(
 		string $user,
 		string $entry,
@@ -621,7 +624,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then /^user "([^"]*)" should not be able to rename (file|folder|entry) "([^"]*)" to "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $entry
@@ -631,6 +633,7 @@ trait WebDav {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('/^user "([^"]*)" should not be able to rename (file|folder|entry) "([^"]*)" to "([^"]*)"$/')]
 	public function theUserShouldNotBeAbleToRenameEntryTo(
 		string $user,
 		string $entry,
@@ -670,7 +673,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" copies (?:file|folder) "([^"]*)" to "([^"]*)" using the WebDAV API$/
 	 *
 	 * @param string $user
 	 * @param string $fileSource
@@ -678,6 +680,7 @@ trait WebDav {
 	 *
 	 * @return void
 	 */
+	#[When('/^user "([^"]*)" copies (?:file|folder) "([^"]*)" to "([^"]*)" using the WebDAV API$/')]
 	public function userCopiesFileUsingTheAPI(
 		string $user,
 		string $fileSource,
@@ -689,7 +692,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" has copied (?:file|folder) "([^"]*)" to "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $fileSource
@@ -697,6 +699,7 @@ trait WebDav {
 	 *
 	 * @return void
 	 */
+	#[Given('/^user "([^"]*)" has copied (?:file|folder) "([^"]*)" to "([^"]*)"$/')]
 	public function userHasCopiedFileUsingTheAPI(
 		string $user,
 		string $fileSource,
@@ -730,7 +733,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" downloads file "([^"]*)" with range "([^"]*)" using the WebDAV API$/
 	 *
 	 * @param string $user
 	 * @param string $fileSource
@@ -738,56 +740,24 @@ trait WebDav {
 	 *
 	 * @return void
 	 */
+	#[When('user :user downloads file :fileSource with range :range using the WebDAV API')]
 	public function userDownloadsFileWithRangeUsingWebDavApi(string $user, string $fileSource, string $range): void {
 		$this->setResponse($this->downloadFileWithRange($user, $fileSource, $range));
 	}
 
 	/**
-	 * @When the user waits for :time seconds for postprocessing to finish
-	 * @When the user waits for :time seconds
 	 *
 	 * @param int $time
 	 *
 	 * @return void
 	 */
+	#[When('the user waits for :time seconds for postprocessing to finish')]
+	#[When('the user waits for :time seconds')]
 	public function waitForCertainSeconds(int $time): void {
 		\sleep($time);
 	}
 
 	/**
-	 * @Then /^user "([^"]*)" using password "([^"]*)" should not be able to download file "([^"]*)"$/
-	 *
-	 * @param string $user
-	 * @param string $password
-	 * @param string $fileName
-	 *
-	 * @return void
-	 */
-	public function userUsingPasswordShouldNotBeAbleToDownloadFile(
-		string $user,
-		string $password,
-		string $fileName
-	): void {
-		$user = $this->getActualUsername($user);
-		$password = $this->getActualPassword($password);
-		$response = $this->downloadFileAsUserUsingPassword($user, $fileName, $password);
-		Assert::assertGreaterThanOrEqual(
-			400,
-			$response->getStatusCode(),
-			__METHOD__
-			. ' download must fail'
-		);
-		Assert::assertLessThanOrEqual(
-			499,
-			$response->getStatusCode(),
-			__METHOD__
-			. ' 4xx error expected but got status code "'
-			. $response->getStatusCode() . '"'
-		);
-	}
-
-	/**
-	 * @Then /^user "([^"]*)" should not be able to download file "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $fileName
@@ -795,6 +765,7 @@ trait WebDav {
 	 * @return void
 	 * @throws JsonException
 	 */
+	#[Then('user :user should not be able to download file :fileName')]
 	public function userShouldNotBeAbleToDownloadFile(
 		string $user,
 		string $fileName
@@ -806,24 +777,24 @@ trait WebDav {
 			400,
 			$response->getStatusCode(),
 			__METHOD__
-			. ' download must fail'
+			. '  download must fail'
 		);
 		Assert::assertLessThanOrEqual(
 			499,
 			$response->getStatusCode(),
 			__METHOD__
-			. ' 4xx error expected but got status code "'
+			. '  4xx error expected but got status code "'
 			. $response->getStatusCode() . '"'
 		);
 	}
 
 	/**
-	 * @Then the size of the downloaded file should be :size bytes
 	 *
 	 * @param string $size
 	 *
 	 * @return void
 	 */
+	#[Then('the size of the downloaded file should be :size bytes')]
 	public function sizeOfDownloadedFileShouldBe(string $size): void {
 		$actualSize = \strlen((string) $this->response->getBody());
 		Assert::assertEquals(
@@ -834,12 +805,12 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then /^the downloaded content should end with "([^"]*)"$/
 	 *
 	 * @param string $content
 	 *
 	 * @return void
 	 */
+	#[Then('the downloaded content should end with :content')]
 	public function downloadedContentShouldEndWith(string $content): void {
 		$actualContent = \substr((string) $this->response->getBody(), -\strlen($content));
 		Assert::assertEquals(
@@ -850,12 +821,12 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then /^the downloaded content should be "([^"]*)"$/
 	 *
 	 * @param string $content
 	 *
 	 * @return void
 	 */
+	#[Then('the downloaded content should be :content')]
 	public function downloadedContentShouldBe(string $content): void {
 		$this->checkDownloadedContentMatches($content, '', $this->getResponse());
 	}
@@ -891,23 +862,23 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then the content in the response should match the following content:
 	 *
 	 * @param PyStringNode $content
 	 *
 	 * @return void
 	 */
+	#[Then('the content in the response should match the following content:')]
 	public function theContentInTheResponseShouldMatchTheFollowingContent(PyStringNode $content): void {
 		$this->checkDownloadedContentMatches($content->getRaw(), '', $this->getResponse());
 	}
 
 	/**
-	 * @Then the content in the response should include the following content:
 	 *
 	 * @param PyStringNode $content
 	 *
 	 * @return void
 	 */
+	#[Then('the content in the response should include the following content:')]
 	public function theContentInTheResponseShouldIncludeTheFollowingContent(PyStringNode $content): void {
 		Assert::assertStringContainsString(
 			$content->getRaw(),
@@ -916,7 +887,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then /^if the HTTP status code was "([^"]*)" then the downloaded content for multipart byterange should be:$/
 	 *
 	 * @param int $statusCode
 	 * @param PyStringNode $content
@@ -924,6 +894,7 @@ trait WebDav {
 	 * @return void
 	 *
 	 */
+	#[Then('if the HTTP status code was :statusCode then the downloaded content for multipart byterange should be:')]
 	public function theDownloadedContentForMultipartByteRangeShouldBe(int $statusCode, PyStringNode $content): void {
 		$actualStatusCode = $this->response->getStatusCode();
 		if ($actualStatusCode === $statusCode) {
@@ -941,13 +912,13 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then /^if the HTTP status code was "([^"]*)" then the downloaded content should be "([^"]*)"$/
 	 *
 	 * @param int $statusCode
 	 * @param string $content
 	 *
 	 * @return void
 	 */
+	#[Then('if the HTTP status code was :statusCode then the downloaded content should be :content')]
 	public function checkStatusCodeForDownloadedContentShouldBe(int $statusCode, string $content): void {
 		$actualStatusCode = $this->response->getStatusCode();
 		if ($actualStatusCode === $statusCode) {
@@ -956,7 +927,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then the content of file :fileName for user :user should be :content
 	 *
 	 * @param string $fileName
 	 * @param string $user
@@ -964,6 +934,7 @@ trait WebDav {
 	 *
 	 * @return void
 	 */
+	#[Then('the content of file :fileName for user :user should be :content')]
 	public function contentOfFileForUserShouldBe(string $fileName, string $user, string $content): void {
 		$response = $this->downloadFileAsUserUsingPassword($this->getActualUsername($user), $fileName);
 		$actualStatus = $response->getStatusCode();
@@ -1018,7 +989,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then as :user the final content of file :fileName should be :content
 	 *
 	 * @param string $user
 	 * @param string $fileName
@@ -1026,12 +996,12 @@ trait WebDav {
 	 *
 	 * @return void
 	 */
+	#[Then('as :user the final content of file :fileName should be :content')]
 	public function asUserFinalContentOfFileShouldBe(string $user, string $fileName, string $content): void {
 		$this->checkFileContentWithRetry($user, $fileName, $content);
 	}
 
 	/**
-	 * @Then /^the content of the following files for user "([^"]*)" should be "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $content
@@ -1040,6 +1010,7 @@ trait WebDav {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('the content of the following files for user :user should be :content')]
 	public function contentOfFollowingFilesShouldBe(string $user, string $content, TableNode $table): void {
 		$this->verifyTableNodeColumns($table, ["path"]);
 		$paths = $table->getHash();
@@ -1058,7 +1029,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then /^the content of file "([^"]*)" for user "([^"]*)" using password "([^"]*)" should be "([^"]*)"$/
 	 *
 	 * @param string $fileName
 	 * @param string $user
@@ -1067,6 +1037,7 @@ trait WebDav {
 	 *
 	 * @return void
 	 */
+	#[Then('the content of file :fileName for user :user using password :password should be :content')]
 	public function contentOfFileForUserUsingPasswordShouldBe(
 		string $fileName,
 		string $user,
@@ -1080,7 +1051,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then /^the content of file "([^"]*)" for user "([^"]*)" should be:$/
 	 *
 	 * @param string $fileName
 	 * @param string $user
@@ -1088,6 +1058,7 @@ trait WebDav {
 	 *
 	 * @return void
 	 */
+	#[Then('the content of file :fileName for user :user should be:')]
 	public function contentOfFileForUserShouldBePyString(
 		string $fileName,
 		string $user,
@@ -1105,14 +1076,14 @@ trait WebDav {
 	}
 
 	/**
-	 * @When user :user downloads file :fileName using the WebDAV API
-	 * @When user :user tries to download file :fileName using the WebDAV API
 	 *
 	 * @param string $user
 	 * @param string $fileName
 	 *
 	 * @return void
 	 */
+	#[When('user :user downloads file :fileName using the WebDAV API')]
+	#[When('user :user tries to download file :fileName using the WebDAV API')]
 	public function userDownloadsFileUsingTheAPI(
 		string $user,
 		string $fileName
@@ -1153,11 +1124,11 @@ trait WebDav {
 	}
 
 	/**
-	 * @When the public gets the size of the last shared public link using the WebDAV API
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('the public gets the size of the last shared public link using the WebDAV API')]
 	public function publicGetsSizeOfLastSharedPublicLinkUsingTheWebdavApi(): void {
 		$token = ($this->isUsingSharingNG())
 		? $this->shareNgGetLastCreatedLinkShareToken() : $this->getLastCreatedPublicShareToken();
@@ -1171,7 +1142,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @When user :user gets the size of file :resource using the WebDAV API
 	 *
 	 * @param string $user
 	 * @param string $resource
@@ -1179,6 +1149,7 @@ trait WebDav {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('user :user gets the size of file :resource using the WebDAV API')]
 	public function userGetsSizeOfFileUsingTheWebdavApi(string $user, string $resource): void {
 		$user = $this->getActualUsername($user);
 		$password = $this->getPasswordForUser($user);
@@ -1197,13 +1168,13 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then the size of the file should be :size
 	 *
 	 * @param string $size
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('the size of the file should be :size')]
 	public function theSizeOfTheFileShouldBe(string $size): void {
 		$responseXmlObject = HttpRequestHelper::getResponseXml(
 			$this->response,
@@ -1220,7 +1191,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then /^the content of file "([^"]*)" for user "([^"]*)" should be "([^"]*)" plus end-of-line$/
 	 *
 	 * @param string $fileName
 	 * @param string $user
@@ -1228,6 +1198,7 @@ trait WebDav {
 	 *
 	 * @return void
 	 */
+	#[Then('the content of file :fileName for user :user should be :content plus end-of-line')]
 	public function contentOfFileForUserShouldBePlusEndOfLine(string $fileName, string $user, string $content): void {
 		$user = $this->getActualUsername($user);
 		$response = $this->downloadFileAsUserUsingPassword($user, $fileName);
@@ -1241,13 +1212,13 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then the following headers should be set
 	 *
 	 * @param TableNode $table
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('the following headers should be set')]
 	public function theFollowingHeadersShouldBeSet(TableNode $table): void {
 		$this->verifyTableNodeColumns(
 			$table,
@@ -1279,7 +1250,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then as :user :entry :path should not exist
 	 *
 	 * @param string $user
 	 * @param string $entry
@@ -1288,6 +1258,7 @@ trait WebDav {
 	 * @return ResponseInterface
 	 * @throws Exception
 	 */
+	#[Then('as :user :entry :path should not exist')]
 	public function asFileOrFolderShouldNotExist(
 		string $user,
 		string $entry,
@@ -1354,7 +1325,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then /^as "([^"]*)" the following (files|folders) should not exist$/
 	 *
 	 * @param string $user
 	 * @param string $entry
@@ -1363,6 +1333,7 @@ trait WebDav {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('/^as "([^"]*)" the following (files|folders) should not exist$/')]
 	public function followingFilesShouldNotExist(
 		string $user,
 		string $entry,
@@ -1378,7 +1349,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then as :user :entry :path should exist
 	 *
 	 * @param string $user
 	 * @param string $entry
@@ -1387,6 +1357,7 @@ trait WebDav {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('as :user :entry :path should exist')]
 	public function asFileOrFolderShouldExist(
 		string $user,
 		string $entry,
@@ -1436,7 +1407,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then /^as "([^"]*)" the following (files|folders) should exist$/
 	 *
 	 * @param string $user
 	 * @param string $entry
@@ -1445,6 +1415,7 @@ trait WebDav {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('/^as "([^"]*)" the following (files|folders) should exist$/')]
 	public function followingFilesOrFoldersShouldExist(
 		string $user,
 		string $entry,
@@ -1517,7 +1488,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then /^user "([^"]*)" should (not|)\s?see the following elements$/
 	 *
 	 * @param string $user
 	 * @param string $shouldOrNot
@@ -1527,6 +1497,7 @@ trait WebDav {
 	 * @throws InvalidArgumentException|Exception
 	 *
 	 */
+	#[Then('/^user "([^"]*)" should (not|)\\s?see the following elements$/')]
 	public function userShouldSeeTheElements(string $user, string $shouldOrNot, TableNode $elements): void {
 		$should = ($shouldOrNot !== "not");
 		$this->checkElementList($user, $elements, $should);
@@ -1670,7 +1641,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @When user :user uploads file :source to :destination using the WebDAV API
 	 *
 	 * @param string $user
 	 * @param string $source
@@ -1678,6 +1648,7 @@ trait WebDav {
 	 *
 	 * @return void
 	 */
+	#[When('user :user uploads file :source to :destination using the WebDAV API')]
 	public function userUploadsAFileToUsingWebDavApi(
 		string $user,
 		string $source,
@@ -1691,7 +1662,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @Given user :user has uploaded file :source to :destination
 	 *
 	 * @param string $user
 	 * @param string $source
@@ -1699,6 +1669,7 @@ trait WebDav {
 	 *
 	 * @return array
 	 */
+	#[Given('user :user has uploaded file :source to :destination')]
 	public function userHasUploadedAFileTo(string $user, string $source, string $destination): array {
 		$response = $this->uploadFile($user, $source, $destination, null, true);
 		$this->theHTTPStatusCodeShouldBe(
@@ -1789,7 +1760,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" uploads file "([^"]*)" to "([^"]*)" in (\d+) chunks using the WebDAV API$/
 	 *
 	 * @param string $user
 	 * @param string $source
@@ -1799,6 +1769,7 @@ trait WebDav {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('/^user "([^"]*)" uploads file "([^"]*)" to "([^"]*)" in (\\d+) chunks using the WebDAV API$/')]
 	public function userUploadsAFileToWithChunks(
 		string $user,
 		string $source,
@@ -1811,13 +1782,13 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then the HTTP status code of responses on all endpoints should be :statusCode
 	 *
 	 * @param int $statusCode
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('the HTTP status code of responses on all endpoints should be :statusCode')]
 	public function theHTTPStatusCodeOfResponsesOnAllEndpointsShouldBe(int $statusCode): void {
 		$duplicateRemovedStatusCodes = \array_unique($this->lastHttpStatusCodesArray);
 		if (\count($duplicateRemovedStatusCodes) === 1) {
@@ -1866,46 +1837,25 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then the HTTP status code of responses on each endpoint should be :statusCodes respectively
 	 *
 	 * @param string $statusCodes a comma-separated string of expected HTTP status codes
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('the HTTP status code of responses on each endpoint should be :statusCodes respectively')]
 	public function theHTTPStatusCodeOfResponsesOnEachEndpointShouldBe(string $statusCodes): void {
 		$this->checkTheHTTPStatusCodeOfResponsesOnEachEndpoint($statusCodes);
 	}
 
 	/**
-	 * @Then the HTTP status code of responses on each endpoint should be :ocStatusCodes on OpenCloud or :revaStatusCodes on reva
-	 *
-	 * @param string $ocStatusCodes a comma-separated string of expected HTTP status codes when running on OpenCloud
-	 * @param string $revaStatusCodes a comma-separated string of expected HTTP status codes when running on reva
-	 *
-	 * @return void
-	 * @throws Exception
-	 */
-	public function theHTTPStatusCodeOfResponsesOnEachEndpointShouldBeOcReva(
-		string $ocStatusCodes,
-		string $revaStatusCodes
-	): void {
-		if (OcHelper::isTestingOnReva()) {
-			$expectedStatusCodes = $revaStatusCodes;
-		} else {
-			$expectedStatusCodes = $ocStatusCodes;
-		}
-		$this->checkTheHTTPStatusCodeOfResponsesOnEachEndpoint($expectedStatusCodes);
-	}
-
-	/**
-	 * @Then the OCS status code of responses on each endpoint should be :statusCode respectively
 	 *
 	 * @param string $statusCodes
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('the OCS status code of responses on each endpoint should be :statusCode respectively')]
 	public function theOCStatusCodeOfResponsesOnEachEndpointShouldBe(string $statusCodes): void {
 		$statusCodes = \explode(',', $statusCodes);
 		$count = \count($statusCodes);
@@ -1926,13 +1876,13 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then the OCS status code of responses on all endpoints should be :statusCode
 	 *
 	 * @param string $statusCode
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('the OCS status code of responses on all endpoints should be :statusCode')]
 	public function theOCSStatusCodeOfResponsesOnAllEndpointsShouldBe(string $statusCode): void {
 		$duplicateRemovedStatusCodes = \array_unique($this->lastOCSStatusCodesArray);
 		if (\count($duplicateRemovedStatusCodes) === 1) {
@@ -1951,7 +1901,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then user :user should be able to upload file :source to :destination
 	 *
 	 * @param string $user
 	 * @param string $source
@@ -1960,6 +1909,7 @@ trait WebDav {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('user :user should be able to upload file :source to :destination')]
 	public function userShouldBeAbleToUploadFileTo(string $user, string $source, string $destination): void {
 		$user = $this->getActualUsername($user);
 		$response = $this->uploadFile($user, $source, $destination);
@@ -1972,7 +1922,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then user :user should not be able to upload file :source to :destination
 	 *
 	 * @param string $user
 	 * @param string $source
@@ -1981,6 +1930,7 @@ trait WebDav {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('user :user should not be able to upload file :source to :destination')]
 	public function theUserShouldNotBeAbleToUploadFileTo(string $user, string $source, string $destination): void {
 		$fileAlreadyExists = $this->fileOrFolderExists($user, "file", $destination);
 		if ($fileAlreadyExists) {
@@ -2057,7 +2007,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @Given user :user has uploaded file :destination of size :bytes bytes
 	 *
 	 * @param string $user
 	 * @param string $destination
@@ -2066,6 +2015,7 @@ trait WebDav {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Given('user :user has uploaded file :destination of size :bytes bytes')]
 	public function userHasUploadedFileToOfSizeBytes(string $user, string $destination, string $bytes): void {
 		$user = $this->getActualUsername($user);
 		$filename = "filespecificSize.txt";
@@ -2078,7 +2028,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @Given user :user has uploaded file :destination ending with :text of size :bytes bytes
 	 *
 	 * @param string $user
 	 * @param string $destination
@@ -2088,6 +2037,7 @@ trait WebDav {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Given('user :user has uploaded file :destination ending with :text of size :bytes bytes')]
 	public function userHasUploadedFileToEndingWithOfSizeBytes(
 		string $user,
 		string $destination,
@@ -2151,7 +2101,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @When user :user uploads file with content :content to :destination using the WebDAV API
 	 *
 	 * @param string $user
 	 * @param string|null $content
@@ -2161,6 +2110,7 @@ trait WebDav {
 	 * @throws GuzzleException
 	 * @throws JsonException
 	 */
+	#[When('user :user uploads file with content :content to :destination using the WebDAV API')]
 	public function userUploadsAFileWithContentTo(
 		string $user,
 		?string $content,
@@ -2172,7 +2122,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" uploads the following files with content "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string|null $content
@@ -2181,6 +2130,7 @@ trait WebDav {
 	 * @return void
 	 * @throws Exception|GuzzleException
 	 */
+	#[When('user :user uploads the following files with content :content')]
 	public function userUploadsFollowingFilesWithContentTo(
 		string $user,
 		?string $content,
@@ -2197,7 +2147,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @When user :user uploads file :source to :destination with mtime :mtime using the WebDAV API
 	 *
 	 * @param string $user
 	 * @param string $source
@@ -2208,6 +2157,7 @@ trait WebDav {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('user :user uploads file :source to :destination with mtime :mtime using the WebDAV API')]
 	public function userUploadsFileToWithMtimeUsingTheWebdavApi(
 		string $user,
 		string $source,
@@ -2234,7 +2184,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @Given user :user has uploaded file :source to :destination with mtime :mtime
 	 *
 	 * @param string $user
 	 * @param string $source
@@ -2244,6 +2193,7 @@ trait WebDav {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Given('user :user has uploaded file :source to :destination with mtime :mtime')]
 	public function userHasUploadedFileToWithMtimeUsingTheWebdavApi(
 		string $user,
 		string $source,
@@ -2274,7 +2224,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then as :user the mtime of the file :resource should be :mtime
 	 *
 	 * @param string $user
 	 * @param string $resource
@@ -2283,6 +2232,7 @@ trait WebDav {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('as :user the mtime of the file :resource should be :mtime')]
 	public function theMtimeOfTheFileShouldBe(
 		string $user,
 		string $resource,
@@ -2307,7 +2257,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @Given user :user has uploaded file with content :content to :destination
 	 *
 	 * @param string $user
 	 * @param string|null $content
@@ -2317,6 +2266,7 @@ trait WebDav {
 	 * @throws GuzzleException
 	 * @throws JsonException
 	 */
+	#[Given('user :user has uploaded file with content :content to :destination')]
 	public function userHasUploadedAFileWithContentTo(
 		string $user,
 		?string $content,
@@ -2338,7 +2288,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" has uploaded the following files with content "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string|null $content
@@ -2347,6 +2296,7 @@ trait WebDav {
 	 * @return void
 	 * @throws Exception|GuzzleException
 	 */
+	#[Given('user :user has uploaded the following files with content :content')]
 	public function userHasUploadedFollowingFilesWithContent(
 		string $user,
 		?string $content,
@@ -2368,7 +2318,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" downloads the following files using the WebDAV API$/
 	 *
 	 * @param string $user
 	 * @param TableNode $table
@@ -2376,6 +2325,7 @@ trait WebDav {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('user :user downloads the following files using the WebDAV API')]
 	public function userDownloadsFollowingFiles(
 		string $user,
 		TableNode $table
@@ -2391,7 +2341,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @When user :user uploads a file with content :content and mtime :mtime to :destination using the WebDAV API
 	 *
 	 * @param string $user
 	 * @param string|null $content
@@ -2401,6 +2350,7 @@ trait WebDav {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('user :user uploads a file with content :content and mtime :mtime to :destination using the WebDAV API')]
 	public function userUploadsAFileWithContentAndMtimeTo(
 		string $user,
 		?string $content,
@@ -2459,7 +2409,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @When user :user uploads file with checksum :checksum and content :content to :destination using the WebDAV API
 	 *
 	 * @param string $user
 	 * @param string $checksum
@@ -2468,6 +2417,7 @@ trait WebDav {
 	 *
 	 * @return void
 	 */
+	#[When('user :user uploads file with checksum :checksum and content :content to :destination using the WebDAV API')]
 	public function userUploadsAFileWithChecksumAndContentTo(
 		string $user,
 		string $checksum,
@@ -2479,7 +2429,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @Given user :user has uploaded file with checksum :checksum and content :content to :destination
 	 *
 	 * @param string $user
 	 * @param string $checksum
@@ -2488,6 +2437,7 @@ trait WebDav {
 	 *
 	 * @return void
 	 */
+	#[Given('user :user has uploaded file with checksum :checksum and content :content to :destination')]
 	public function userHasUploadedAFileWithChecksumAndContentTo(
 		string $user,
 		string $checksum,
@@ -2510,7 +2460,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then /^user "([^"]*)" should be able to delete (file|folder|entry) "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $entry
@@ -2519,6 +2468,7 @@ trait WebDav {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('/^user "([^"]*)" should be able to delete (file|folder|entry) "([^"]*)"$/')]
 	public function userShouldBeAbleToDeleteEntry(string $user, string $entry, string $source): void {
 		$user = $this->getActualUsername($user);
 		$this->checkFileOrFolderExistsForUser($user, $entry, $source);
@@ -2527,7 +2477,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then /^user "([^"]*)" should not be able to delete (file|folder|entry) "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $entry
@@ -2536,6 +2485,7 @@ trait WebDav {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('/^user "([^"]*)" should not be able to delete (file|folder|entry) "([^"]*)"$/')]
 	public function theUserShouldNotBeAbleToDeleteEntry(string $user, string $entry, string $source): void {
 		$this->checkFileOrFolderExistsForUser($user, $entry, $source);
 		$this->deleteFile($user, $source);
@@ -2557,13 +2507,13 @@ trait WebDav {
 	}
 
 	/**
-	 * @When user :user deletes file/folder :resource using the WebDAV API
 	 *
 	 * @param string $user
 	 * @param string $resource
 	 *
 	 * @return void
 	 */
+	#[When('user :user deletes file/folder :resource using the WebDAV API')]
 	public function userDeletesFile(string $user, string $resource): void {
 		$response = $this->deleteFile($user, $resource);
 		$this->setResponse($response);
@@ -2571,7 +2521,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @When user :user deletes file :filename from space :space using file-id :fileId
 	 *
 	 * @param string $user
 	 * @param string $filename
@@ -2580,6 +2529,7 @@ trait WebDav {
 	 *
 	 * @return void
 	 */
+	#[When('user :user deletes file :filename from space :space using file-id :fileId')]
 	public function userDeletesFileFromSpaceUsingFileIdPath(
 		string $user,
 		string $filename,
@@ -2603,7 +2553,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @Given user :user has updated a file with content :content using file-id :fileId
 	 *
 	 * @param string $user
 	 * @param string $content
@@ -2611,6 +2560,7 @@ trait WebDav {
 	 *
 	 * @return void
 	 */
+	#[Given('user :user has updated a file with content :content using file-id :fileId')]
 	public function userHasUpdatedAFileWithContentUsingFileId(string $user, string $content, string $fileId): void {
 		$baseUrl = $this->getBaseUrl();
 		$sourceDavPath = WebdavHelper::getDavPath($this->getDavPathVersion());
@@ -2628,7 +2578,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" has deleted (?:file|folder|entity) "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $resource
@@ -2636,6 +2585,7 @@ trait WebDav {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Given('/^user "([^"]*)" has deleted (?:file|folder|entity) "([^"]*)"$/')]
 	public function userHasDeletedResource(string $user, string $resource): void {
 		$user = $this->getActualUsername($user);
 		$response = $this->deleteFile($user, $resource);
@@ -2654,7 +2604,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" has deleted the following (?:files|folders|resources)$/
 	 *
 	 * @param string $user
 	 * @param TableNode $table
@@ -2662,6 +2611,7 @@ trait WebDav {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Given('/^user "([^"]*)" has deleted the following (?:files|folders|resources)$/')]
 	public function userHasDeletedFollowingFiles(string $user, TableNode $table): void {
 		$this->verifyTableNodeColumns($table, ["path"]);
 		$paths = $table->getHash();
@@ -2679,7 +2629,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" deletes the following (?:files|folders)$/
 	 *
 	 * @param string $user
 	 * @param TableNode $table
@@ -2687,6 +2636,7 @@ trait WebDav {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('/^user "([^"]*)" deletes the following (?:files|folders)$/')]
 	public function userDeletesFollowingFiles(string $user, TableNode $table): void {
 		$user = $this->getActualUsername($user);
 		$this->verifyTableNodeColumns($table, ["path"]);
@@ -2701,7 +2651,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" deletes these (?:files|folders|entries) without delays using the WebDAV API$/
 	 *
 	 * @param string $user
 	 * @param TableNode $table of files or folders to delete
@@ -2709,6 +2658,7 @@ trait WebDav {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('/^user "([^"]*)" deletes these (?:files|folders|entries) without delays using the WebDAV API$/')]
 	public function userDeletesFilesFoldersWithoutDelays(string $user, TableNode $table): void {
 		$user = $this->getActualUsername($user);
 		$this->verifyTableNodeColumnsCount($table, 1);
@@ -2721,7 +2671,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @When user :user creates folder :destination using the WebDAV API
 	 *
 	 * @param string $user
 	 * @param string $destination
@@ -2730,13 +2679,13 @@ trait WebDav {
 	 * @throws JsonException
 	 * @throws GuzzleException
 	 */
+	#[When('user :user creates folder :destination using the WebDAV API')]
 	public function userCreatesFolder(string $user, string $destination): void {
 		$response = $this->createFolder($user, $destination);
 		$this->setResponse($response);
 	}
 
 	/**
-	 * @Given user :user has created folder :destination
 	 *
 	 * @param string $user
 	 * @param string $destination
@@ -2745,6 +2694,7 @@ trait WebDav {
 	 * @throws JsonException
 	 * @throws GuzzleException
 	 */
+	#[Given('user :user has created folder :destination')]
 	public function userHasCreatedFolder(string $user, string $destination): void {
 		$user = $this->getActualUsername($user);
 		$response = $this->createFolder($user, $destination, true);
@@ -2756,7 +2706,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @Given admin has created folder :destination
 	 *
 	 * @param string $destination
 	 *
@@ -2764,6 +2713,7 @@ trait WebDav {
 	 * @throws JsonException
 	 * @throws GuzzleException
 	 */
+	#[Given('admin has created folder :destination')]
 	public function adminHasCreatedFolder(string $destination): void {
 		$admin = $this->getAdminUsername();
 		Assert::assertEquals(
@@ -2781,7 +2731,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" has created the following folders$/
 	 *
 	 * @param string $user
 	 * @param TableNode $table
@@ -2789,6 +2738,7 @@ trait WebDav {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Given('user :user has created the following folders')]
 	public function userHasCreatedFollowingFolders(string $user, TableNode $table): void {
 		$this->verifyTableNodeColumns($table, ["path"]);
 		$paths = $table->getHash();
@@ -2806,7 +2756,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then user :user should be able to create folder :destination
 	 *
 	 * @param string $user
 	 * @param string $destination
@@ -2814,6 +2763,7 @@ trait WebDav {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('user :user should be able to create folder :destination')]
 	public function userShouldBeAbleToCreateFolder(string $user, string $destination): void {
 		$user = $this->getActualUsername($user);
 		$response = $this->createFolder($user, $destination, true);
@@ -2830,7 +2780,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then user :user should be able to create folder :destination using password :password
 	 *
 	 * @param string $user
 	 * @param string $destination
@@ -2839,6 +2788,7 @@ trait WebDav {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('user :user should be able to create folder :destination using password :password')]
 	public function userShouldBeAbleToCreateFolderUsingPassword(
 		string $user,
 		string $destination,
@@ -2859,7 +2809,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then user :user should not be able to create folder :destination
 	 *
 	 * @param string $user
 	 * @param string $destination
@@ -2867,6 +2816,7 @@ trait WebDav {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('user :user should not be able to create folder :destination')]
 	public function userShouldNotBeAbleToCreateFolder(string $user, string $destination): void {
 		$user = $this->getActualUsername($user);
 		$response = $this->createFolder($user, $destination);
@@ -2879,33 +2829,7 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then user :user should not be able to create folder :destination using password :password
-	 *
-	 * @param string $user
-	 * @param string $destination
-	 * @param string $password
-	 *
-	 * @return void
-	 * @throws Exception
-	 */
-	public function userShouldNotBeAbleToCreateFolderUsingPassword(
-		string $user,
-		string $destination,
-		string $password
-	): void {
-		$user = $this->getActualUsername($user);
-		$response = $this->createFolder($user, $destination, false, $password);
-		$this->theHTTPStatusCodeShouldBeBetween(400, 499, $response);
-		$this->checkFileOrFolderDoesNotExistsForUser(
-			$user,
-			"folder",
-			$destination
-		);
-	}
-	/**
 	 * Old style chunking upload
-	 *
-	 * @When user :user uploads the following :total chunks to :file with old chunking and using the WebDAV API
 	 *
 	 * @param string $user
 	 * @param string $total
@@ -2920,6 +2844,7 @@ trait WebDav {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('user :user uploads the following :total chunks to :file with old chunking and using the WebDAV API')]
 	public function userUploadsTheFollowingTotalChunksUsingOldChunking(
 		string $user,
 		string $total,
@@ -2937,8 +2862,6 @@ trait WebDav {
 	/**
 	 * Old style chunking upload
 	 *
-	 * @When user :user uploads the following chunks to :file with old chunking and using the WebDAV API
-	 *
 	 * @param string $user
 	 * @param string $file
 	 * @param TableNode $chunkDetails table of 2 columns, chunk number and chunk
@@ -2951,6 +2874,7 @@ trait WebDav {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('user :user uploads the following chunks to :file with old chunking and using the WebDAV API')]
 	public function userUploadsTheFollowingChunksUsingOldChunking(
 		string $user,
 		string $file,
@@ -3199,109 +3123,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" moves new chunk file with id "([^"]*)"\s?(asynchronously|) to "([^"]*)" using the WebDAV API$/
-	 *
-	 * @param string $user
-	 * @param string $id
-	 * @param string $type "asynchronously" or empty
-	 * @param string $dest
-	 *
-	 * @return void
-	 */
-	public function userMovesNewChunkFileWithIdToMychunkedfile(
-		string $user,
-		string $id,
-		string $type,
-		string $dest
-	): void {
-		$this->setResponse($this->userMoveNewChunkFileWithIdToMychunkedfile($user, $id, $type, $dest));
-	}
-
-	/**
-	 * @param string $user
-	 * @param string $id
-	 * @param string $type "asynchronously" or empty
-	 * @param string $dest
-	 * @param int $size
-	 *
-	 * @return ResponseInterface
-	 */
-	public function userMoveNewChunkFileWithIdToMychunkedfileWithSize(
-		string $user,
-		string $id,
-		string $type,
-		string $dest,
-		int $size
-	): ResponseInterface {
-		$headers = ['OC-Total-Length' => $size];
-		if ($type === "asynchronously") {
-			$headers['OC-LazyOps'] = 'true';
-		}
-		return $this->moveNewDavChunkToFinalFile(
-			$user,
-			$id,
-			$dest,
-			$headers
-		);
-	}
-
-	/**
-	 * @param string $user
-	 * @param string $id
-	 * @param string $type "asynchronously" or empty
-	 * @param string $dest
-	 * @param string $checksum
-	 *
-	 * @return ResponseInterface
-	 */
-	public function userMoveNewChunkFileWithIdToMychunkedfileWithChecksum(
-		string $user,
-		string $id,
-		string $type,
-		string $dest,
-		string $checksum
-	): ResponseInterface {
-		$headers = ['OC-Checksum' => $checksum];
-		if ($type === "asynchronously") {
-			$headers['OC-LazyOps'] = 'true';
-		}
-		return $this->moveNewDavChunkToFinalFile(
-			$user,
-			$id,
-			$dest,
-			$headers
-		);
-	}
-
-	/**
-	 * @Given /^user "([^"]*)" has moved new chunk file with id "([^"]*)"\s?(asynchronously|) to "([^"]*)" with checksum "([^"]*)"
-	 *
-	 * @param string $user
-	 * @param string $id
-	 * @param string $type "asynchronously" or empty
-	 * @param string $dest
-	 * @param string $checksum
-	 *
-	 * @return void
-	 */
-	public function userHasMovedNewChunkFileWithIdToMychunkedfileWithChecksum(
-		string $user,
-		string $id,
-		string $type,
-		string $dest,
-		string $checksum
-	): void {
-		$response = $this->userMoveNewChunkFileWithIdToMychunkedfileWithChecksum(
-			$user,
-			$id,
-			$type,
-			$dest,
-			$checksum
-		);
-		$this->theHTTPStatusCodeShouldBe("201", "", $response);
-	}
-
-	/**
 	 * Move chunked new DAV file to final file
 	 *
 	 * @param string $user user
@@ -3393,20 +3214,20 @@ trait WebDav {
 	}
 
 	/**
-	 * @When an unauthenticated client connects to the DAV endpoint using the WebDAV API
 	 *
 	 * @return void
 	 */
+	#[When('an unauthenticated client connects to the DAV endpoint using the WebDAV API')]
 	public function connectingToDavEndpoint(): void {
 		$this->setResponse($this->connectToDavEndpoint());
 	}
 
 	/**
-	 * @Then there should be no duplicate headers
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('there should be no duplicate headers')]
 	public function thereAreNoDuplicateHeaders(): void {
 		$headers = $this->response->getHeaders();
 		foreach ($headers as $headerName => $headerValues) {
@@ -3420,13 +3241,13 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then the following headers should not be set
 	 *
 	 * @param TableNode $table
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('the following headers should not be set')]
 	public function theFollowingHeadersShouldNotBeSet(TableNode $table): void {
 		$this->verifyTableNodeColumns(
 			$table,
@@ -3446,13 +3267,13 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then the following headers should match these regular expressions
 	 *
 	 * @param TableNode $table
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('the following headers should match these regular expressions')]
 	public function theFollowingHeadersShouldMatchTheseRegularExpressions(TableNode $table): void {
 		$this->headersShouldMatchRegularExpressions($table);
 	}
@@ -3483,7 +3304,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then /^if the HTTP status code was "([^"]*)" then the following headers should match these regular expressions$/
 	 *
 	 * @param int $statusCode
 	 * @param TableNode $table
@@ -3491,6 +3311,7 @@ trait WebDav {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('if the HTTP status code was :statusCode then the following headers should match these regular expressions')]
 	public function statusCodeShouldMatchTheseRegularExpressions(int $statusCode, TableNode $table): void {
 		$actualStatusCode = $this->response->getStatusCode();
 		if ($actualStatusCode === $statusCode) {
@@ -3499,7 +3320,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then the following headers should match these regular expressions for user :user
 	 *
 	 * @param string $user
 	 * @param TableNode $table
@@ -3507,6 +3327,7 @@ trait WebDav {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('the following headers should match these regular expressions for user :user')]
 	public function headersShouldMatchRegularExpressionsForUser(string $user, TableNode $table): void {
 		$this->verifyTableNodeColumnsCount($table, 2);
 		$user = $this->getActualUsername($user);
@@ -3529,7 +3350,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" deletes everything from folder "([^"]*)" using the WebDAV API$/
 	 *
 	 * @param string $user
 	 * @param string $folder
@@ -3537,6 +3357,7 @@ trait WebDav {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('user :user deletes everything from folder :folder using the WebDAV API')]
 	public function userDeletesEverythingInFolder(
 		string $user,
 		string $folder
@@ -3588,8 +3409,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @When user :user downloads the preview of :path with width :width and height :height using the WebDAV API
-	 * @When user :user tries to download the preview of nonexistent file :path with width :width and height :height using the WebDAV API
 	 *
 	 * @param string $user
 	 * @param string $path
@@ -3598,6 +3417,8 @@ trait WebDav {
 	 *
 	 * @return void
 	 */
+	#[When('user :user downloads the preview of :path with width :width and height :height using the WebDAV API')]
+	#[When('user :user tries to download the preview of nonexistent file :path with width :width and height :height using the WebDAV API')]
 	public function downloadPreviewOfFiles(string $user, string $path, string $width, string $height): void {
 		$response = $this->downloadPreviews(
 			$user,
@@ -3610,7 +3431,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @When user :user tries to download the preview of :path with width :width and height :height and preview set to 0 using the WebDAV API
 	 *
 	 * @param string $user
 	 * @param string $path
@@ -3619,6 +3439,7 @@ trait WebDav {
 	 *
 	 * @return void
 	 */
+	#[When('user :user tries to download the preview of :path with width :width and height :height and preview set to 0 using the WebDAV API')]
 	public function userDownloadsThePreviewOfWithPreviewZero(
 		string $user,
 		string $path,
@@ -3648,7 +3469,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @When user :user downloads the preview of shared resource :path with width :width and height :height using the WebDAV API
 	 *
 	 * @param string $user
 	 * @param string $path
@@ -3657,6 +3477,7 @@ trait WebDav {
 	 *
 	 * @return void
 	 */
+	#[When('user :user downloads the preview of shared resource :path with width :width and height :height using the WebDAV API')]
 	public function userDownloadsThePreviewOfSharedResourceWithWidthAndHeightUsingTheWebdavApi(
 		string $user,
 		string $path,
@@ -3671,7 +3492,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @When user :user downloads the preview of :path with width :width and height :height and processor :processor using the WebDAV API
 	 *
 	 * @param string $user
 	 * @param string $path
@@ -3681,6 +3501,7 @@ trait WebDav {
 	 *
 	 * @return void
 	 */
+	#[When('user :user downloads the preview of :path with width :width and height :height and processor :processor using the WebDAV API')]
 	public function userDownloadsThePreviewOfWithWidthHeightProcessorUsingWebDAVAPI(
 		string $user,
 		string $path,
@@ -3712,7 +3533,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @When user :user downloads the preview of federated share image :path with width :width and height :height using the WebDAV API
 	 *
 	 * @param string $user
 	 * @param string $path
@@ -3721,6 +3541,7 @@ trait WebDav {
 	 *
 	 * @return void
 	 */
+	#[When('user :user downloads the preview of federated share image :path with width :width and height :height using the WebDAV API')]
 	public function userDownloadsThePreviewOfFederatedShareImageWithWidthHeightUsingWebDAVAPI(
 		string $user,
 		string $path,
@@ -3752,7 +3573,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @Given user :user has downloaded the preview of shared resource :path with width :width and height :height
 	 *
 	 * @param string $user
 	 * @param string $path
@@ -3761,6 +3581,7 @@ trait WebDav {
 	 *
 	 * @return void
 	 */
+	#[Given('user :user has downloaded the preview of shared resource :path with width :width and height :height')]
 	public function userHasDownloadedThePreviewOfSharedResourceWithWidthAndHeight(
 		string $user,
 		string $path,
@@ -3781,7 +3602,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then as user :user the preview of shared resource :path with width :width and height :height should have been changed
 	 *
 	 * @param string $user
 	 * @param string $path
@@ -3790,6 +3610,7 @@ trait WebDav {
 	 *
 	 * @return void
 	 */
+	#[Then('as user :user the preview of shared resource :path with width :width and height :height should have been changed')]
 	public function asUserThePreviewOfSharedResourceWithWidthAndHeightShouldHaveBeenChanged(
 		string $user,
 		string $path,
@@ -3816,7 +3637,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @When user :user uploads file with content :content to shared resource :destination using the WebDAV API
 	 *
 	 * @param string $user
 	 * @param string $content
@@ -3824,6 +3644,7 @@ trait WebDav {
 	 *
 	 * @return void
 	 */
+	#[When('user :user uploads file with content :content to shared resource :destination using the WebDAV API')]
 	public function userUploadsFileWithContentSharedResourceToUsingTheWebdavApi(
 		string $user,
 		string $content,
@@ -3910,7 +3731,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @When user :user downloads the preview of :path of :ofUser with width :width and height :height using the WebDAV API
 	 *
 	 * @param string $user
 	 * @param string $path
@@ -3920,6 +3740,7 @@ trait WebDav {
 	 *
 	 * @return void
 	 */
+	#[When('user :user downloads the preview of :path of :ofUser with width :width and height :height using the WebDAV API')]
 	public function downloadPreviewOfOtherUser(
 		string $user,
 		string $path,
@@ -3938,13 +3759,13 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then the downloaded image should be :width pixels wide and :height pixels high
 	 *
 	 * @param string $width
 	 * @param string $height
 	 *
 	 * @return void
 	 */
+	#[Then('the downloaded image should be :width pixels wide and :height pixels high')]
 	public function imageDimensionsShouldBe(string $width, string $height): void {
 		$this->checkImageDimensions($width, $height);
 	}
@@ -3967,13 +3788,13 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then the downloaded preview content should match with :preview fixtures preview content
 	 *
 	 * @param string $filename relative path from fixtures directory
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('the downloaded preview content should match with :preview fixtures preview content')]
 	public function theDownloadedPreviewContentShouldMatchWithFixturesPreviewContentFor(string $filename): void {
 		$expectedPreview = \file_get_contents(__DIR__ . "/../fixtures/" . $filename);
 		$this->getResponse()->getBody()->rewind();
@@ -3982,7 +3803,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @Given user :user has downloaded the preview of :path with width :width and height :height
 	 *
 	 * @param string $user
 	 * @param string $path
@@ -3991,6 +3811,7 @@ trait WebDav {
 	 *
 	 * @return void
 	 */
+	#[Given('user :user has downloaded the preview of :path with width :width and height :height')]
 	public function userDownloadsThePreviewOfWithWidthAndHeight(
 		string $user,
 		string $path,
@@ -4012,7 +3833,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then as user :user the preview of :path with width :width and height :height should have been changed
 	 *
 	 * @param string $user
 	 * @param string $path
@@ -4021,6 +3841,7 @@ trait WebDav {
 	 *
 	 * @return void
 	 */
+	#[Then('as user :user the preview of :path with width :width and height :height should have been changed')]
 	public function asUserThePreviewOfPathWithHeightAndWidthShouldHaveBeenChanged(
 		string $user,
 		string $path,
@@ -4072,19 +3893,18 @@ trait WebDav {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" has stored id of (?:file|folder) "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $path
 	 *
 	 * @return void
 	 */
+	#[Given('/^user "([^"]*)" has stored id of (?:file|folder) "([^"]*)"$/')]
 	public function userStoresFileIdForPath(string $user, string $path): void {
 		$this->storedFileID = $this->getFileIdForPath($user, $path);
 	}
 
 	/**
-	 * @Then /^user "([^"]*)" (file|folder) "([^"]*)" should have the previously stored id$/
 	 *
 	 * @param string370 $user
 	 * @param string $fileOrFolder
@@ -4092,6 +3912,7 @@ trait WebDav {
 	 *
 	 * @return void
 	 */
+	#[Then('/^user "([^"]*)" (file|folder) "([^"]*)" should have the previously stored id$/')]
 	public function userFileShouldHaveStoredId(string $user, string $fileOrFolder, string $path): void {
 		$user = $this->getActualUsername($user);
 		$currentFileID = $this->getFileIdForPath($user, $path);
@@ -4105,7 +3926,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then /^the (?:Cal|Card)?DAV (exception|message|reason) should be "([^"]*)"$/
 	 *
 	 * @param string $element exception|message|reason
 	 * @param string $message
@@ -4113,6 +3933,7 @@ trait WebDav {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('/^the (?:Cal|Card)?DAV (exception|message|reason) should be "([^"]*)"$/')]
 	public function theDavElementShouldBe(string $element, string $message): void {
 		$responseXmlArray = HttpRequestHelper::parseResponseAsXml($this->getResponse());
 		WebDavAssert::assertDavResponseElementIs(
@@ -4185,7 +4006,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then /^the (?:propfind|search) result of user "([^"]*)" should (not|)\s?contain these (?:files|entries):$/
 	 *
 	 * @param string $user
 	 * @param string $shouldOrNot (not|)
@@ -4194,6 +4014,7 @@ trait WebDav {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('/^the (?:propfind|search) result of user "([^"]*)" should (not|)\\s?contain these (?:files|entries):$/')]
 	public function thePropfindResultShouldContainEntries(
 		string $user,
 		string $shouldOrNot,
@@ -4208,7 +4029,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then /^the (?:propfind|search) result of user "([^"]*)" should contain only these (?:files|entries):$/
 	 *
 	 * @param string $user
 	 * @param TableNode $expectedFiles
@@ -4216,6 +4036,7 @@ trait WebDav {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('/^the (?:propfind|search) result of user "([^"]*)" should contain only these (?:files|entries):$/')]
 	public function thePropfindResultShouldContainOnlyEntries(
 		string $user,
 		TableNode $expectedFiles
@@ -4237,12 +4058,12 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then the propfind/search result should contain :numFiles files/entries
 	 *
 	 * @param int $numFiles
 	 *
 	 * @return void
 	 */
+	#[Then('the propfind/search result should contain :numFiles files/entries')]
 	public function propfindResultShouldContainNumEntries(int $numFiles): void {
 		$this->checkIFResponseContainsNumberEntries($numFiles);
 	}
@@ -4281,27 +4102,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then the propfind/search result should contain any :expectedNumber of these files/entries:
-	 *
-	 * @param integer $expectedNumber
-	 * @param TableNode $expectedFiles
-	 *
-	 * @return void
-	 * @throws Exception
-	 */
-	public function theSearchResultShouldContainAnyOfTheseEntries(
-		int $expectedNumber,
-		TableNode $expectedFiles
-	): void {
-		$this->checkIfSearchResultContainsFiles(
-			$this->getCurrentUser(),
-			$expectedNumber,
-			$expectedFiles
-		);
-	}
-
-	/**
-	 * @Then the propfind/search result of user :user should contain any :expectedNumber of these files/entries:
 	 *
 	 * @param string $user
 	 * @param integer $expectedNumber
@@ -4310,6 +4110,7 @@ trait WebDav {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('the propfind/search result of user :user should contain any :expectedNumber of these files/entries:')]
 	public function theSearchResultOfUserShouldContainAnyOfTheseEntries(
 		string $user,
 		int $expectedNumber,
@@ -4354,7 +4155,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @When user :arg1 lists the resources in :path with depth :depth using the WebDAV API
 	 *
 	 * @param string $user
 	 * @param string $path
@@ -4363,6 +4163,7 @@ trait WebDav {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('user :arg1 lists the resources in :path with depth :depth using the WebDAV API')]
 	public function userListsTheResourcesInPathWithDepthUsingTheWebdavApi(
 		string $user,
 		string $path,
@@ -4377,7 +4178,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then the last DAV response for user :user should contain these nodes/elements
 	 *
 	 * @param string $user
 	 * @param TableNode $table
@@ -4385,6 +4185,7 @@ trait WebDav {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('the last DAV response for user :user should contain these nodes/elements')]
 	public function theLastDavResponseShouldContainTheseNodes(string $user, TableNode $table): void {
 		$this->verifyTableNodeColumns($table, ["name"]);
 		foreach ($table->getHash() as $row) {
@@ -4395,7 +4196,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then the last DAV response for user :user should not contain these nodes/elements
 	 *
 	 * @param string $user
 	 * @param TableNode $table
@@ -4403,6 +4203,7 @@ trait WebDav {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('the last DAV response for user :user should not contain these nodes/elements')]
 	public function theLastDavResponseShouldNotContainTheseNodes(string $user, TableNode $table): void {
 		$this->verifyTableNodeColumns($table, ["name"]);
 		foreach ($table->getHash() as $row) {
@@ -4413,13 +4214,13 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then the last public link DAV response should contain these nodes/elements
 	 *
 	 * @param TableNode $table
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('the last public link DAV response should contain these nodes/elements')]
 	public function theLastPublicDavResponseShouldContainTheseNodes(TableNode $table): void {
 		$token = ($this->isUsingSharingNG())
 		? $this->shareNgGetLastCreatedLinkShareToken() : $this->getLastCreatedPublicShareToken();
@@ -4433,13 +4234,13 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then the last public link DAV response should not contain these nodes/elements
 	 *
 	 * @param TableNode $table
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('the last public link DAV response should not contain these nodes/elements')]
 	public function theLastPublicDavResponseShouldNotContainTheseNodes(TableNode $table): void {
 		$token = ($this->isUsingSharingNG())
 		? $this->shareNgGetLastCreatedLinkShareToken() : $this->getLastCreatedPublicShareToken();
@@ -4453,13 +4254,13 @@ trait WebDav {
 	}
 
 	/**
-	 * @When the public lists the resources in the last created public link with depth :depth using the WebDAV API
 	 *
 	 * @param string $depth
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('the public lists the resources in the last created public link with depth :depth using the WebDAV API')]
 	public function thePublicListsTheResourcesInTheLastCreatedPublicLinkWithDepthUsingTheWebdavApi(
 		string $depth
 	): void {
@@ -4754,7 +4555,7 @@ trait WebDav {
 		if (!isset($authors[$index - 1])) {
 			Assert::fail(
 				'could not find version with index "' . $index
-				. '" for oc:meta-version-edited-by property in response to user "' . $this->responseUser . '"'
+				. ' " for oc:meta-version-edited-by property in response to user "' . $this->responseUser . '"'
 			);
 		}
 		$actualUser = $authors[$index - 1];
@@ -4778,7 +4579,7 @@ trait WebDav {
 		if (!isset($displaynames[$index - 1])) {
 			Assert::fail(
 				'could not find version with index "' . $index
-				. '" for oc:meta-version-edited-by-name property in response to user "' . $this->responseUser . '"'
+				. ' " for oc:meta-version-edited-by-name property in response to user "' . $this->responseUser . '"'
 			);
 		}
 		$actualUserDisplayName = $displaynames[$index - 1];
@@ -4791,7 +4592,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @When user :user downloads the content of GDPR report :pathToFile
 	 *
 	 * @param string $user
 	 * @param string $pathToFile
@@ -4799,6 +4599,7 @@ trait WebDav {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('user :user downloads the content of GDPR report :pathToFile')]
 	public function userGetsTheContentOfGeneratedJsonReport(string $user, string $pathToFile): void {
 		$password = $this->getPasswordForUser($user);
 		$response = $this->downloadFileAsUserUsingPassword($user, $pathToFile, $password);

--- a/tests/acceptance/bootstrap/WebDavLockingContext.php
+++ b/tests/acceptance/bootstrap/WebDavLockingContext.php
@@ -28,6 +28,9 @@ use TestHelpers\HttpRequestHelper;
 use TestHelpers\WebDavHelper;
 use TestHelpers\OcHelper;
 use TestHelpers\BehatHelper;
+use Behat\Step\Given;
+use Behat\Step\Then;
+use Behat\Step\When;
 
 require_once 'bootstrap.php';
 
@@ -134,7 +137,6 @@ class WebDavLockingContext implements Context {
 	}
 
 	/**
-	 * @When user :user locks file :file using the WebDAV API setting the following properties
 	 *
 	 * @param string $user
 	 * @param string $file
@@ -142,6 +144,7 @@ class WebDavLockingContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[When('user :user locks file :file using the WebDAV API setting the following properties')]
 	public function userLocksFileSettingPropertiesUsingWebDavAPI(string $user, string $file, TableNode $properties) {
 		$spaceId = null;
 		if (\str_starts_with($file, "Shares/")
@@ -155,7 +158,6 @@ class WebDavLockingContext implements Context {
 	}
 
 	/**
-	 * @When user :user tries to lock file/folder :file using the WebDAV API setting the following properties
 	 *
 	 * @param string $user
 	 * @param string $file
@@ -163,6 +165,7 @@ class WebDavLockingContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[When('user :user tries to lock file/folder :file using the WebDAV API setting the following properties')]
 	public function userTriesToLockFileSettingPropertiesUsingWebDavAPI(
 		string $user,
 		string $file,
@@ -173,7 +176,6 @@ class WebDavLockingContext implements Context {
 	}
 
 	/**
-	 * @When user :user locks file :file inside the space :space using the WebDAV API setting the following properties
 	 *
 	 * @param string $user
 	 * @param string $file
@@ -183,6 +185,7 @@ class WebDavLockingContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[When('user :user locks file :file inside the space :space using the WebDAV API setting the following properties')]
 	public function userLocksFileInProjectSpaceUsingWebDavAPI(
 		string $user,
 		string $file,
@@ -222,7 +225,6 @@ class WebDavLockingContext implements Context {
 	}
 
 	/**
-	 * @Given user :user has locked file :file inside the space :space setting the following properties
 	 *
 	 * @param string $user
 	 * @param string $file
@@ -232,6 +234,7 @@ class WebDavLockingContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[Given('user :user has locked file :file inside the space :space setting the following properties')]
 	public function userHasLockedFileInProjectSpaceUsingWebDavAPI(
 		string $user,
 		string $file,
@@ -243,7 +246,6 @@ class WebDavLockingContext implements Context {
 	}
 
 	/**
-	 * @When user :user tries to lock file :file inside the space :space using the WebDAV API setting the following properties
 	 *
 	 * @param string $user
 	 * @param string $file
@@ -252,6 +254,7 @@ class WebDavLockingContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[When('user :user tries to lock file :file inside the space :space using the WebDAV API setting the following properties')]
 	public function userTriesToLockFileInProjectSpaceUsingWebDavAPI(
 		string $user,
 		string $file,
@@ -272,7 +275,6 @@ class WebDavLockingContext implements Context {
 	}
 
 	/**
-	 * @When user :user locks file :file using file-id :fileId using the WebDAV API setting the following properties
 	 *
 	 * @param string $user
 	 * @param string $file
@@ -281,6 +283,7 @@ class WebDavLockingContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[When('user :user locks file :file using file-id :fileId using the WebDAV API setting the following properties')]
 	public function userLocksFileUsingFileIdUsingWebDavAPISettingFollowingProperties(
 		string $user,
 		string $file,
@@ -295,7 +298,6 @@ class WebDavLockingContext implements Context {
 	}
 
 	/**
-	 * @When user :user tries to lock file :file using file-id :fileId using the WebDAV API setting the following properties
 	 *
 	 * @param string $user
 	 * @param string $file
@@ -304,6 +306,7 @@ class WebDavLockingContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[When('user :user tries to lock file :file using file-id :fileId using the WebDAV API setting the following properties')]
 	public function userTriesToLockFileUsingFileIdUsingWebDavAPI(
 		string $user,
 		string $file,
@@ -318,7 +321,6 @@ class WebDavLockingContext implements Context {
 	}
 
 	/**
-	 * @Given user :user has locked file :file setting the following properties
 	 *
 	 * @param string $user
 	 * @param string $file
@@ -326,13 +328,13 @@ class WebDavLockingContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[Given('user :user has locked file :file setting the following properties')]
 	public function userHasLockedFile(string $user, string $file, TableNode $properties) {
 		$response = $this->lockFile($user, $file, $properties);
 		$this->featureContext->theHTTPStatusCodeShouldBe(200, '', $response);
 	}
 
 	/**
-	 * @Given user :user has locked file :file inside space :spaceName setting the following properties
 	 *
 	 * @param string $user
 	 * @param string $file
@@ -341,6 +343,7 @@ class WebDavLockingContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[Given('user :user has locked file :file inside space :spaceName setting the following properties')]
 	public function userHasLockedFileInsideSpaceSettingTheFollowingProperties(
 		string $user,
 		string $file,
@@ -353,7 +356,6 @@ class WebDavLockingContext implements Context {
 	}
 
 	/**
-	 * @Given user :user has locked file :file using file-id :fileId setting the following properties
 	 *
 	 * @param string $user
 	 * @param string $file
@@ -362,6 +364,7 @@ class WebDavLockingContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[Given('user :user has locked file :file using file-id :fileId setting the following properties')]
 	public function userHasLockedFileUsingFileId(string $user, string $file, string $fileId, TableNode $properties) {
 		$davPath = WebdavHelper::getDavPath($this->featureContext->getDavPathVersion());
 		$davPath = \rtrim($davPath, '/');
@@ -371,31 +374,13 @@ class WebDavLockingContext implements Context {
 	}
 
 	/**
-	 * @Given the public has locked the last public link shared file/folder setting the following properties
 	 *
 	 * @param TableNode $properties
 	 *
 	 * @return void
 	 */
-	public function publicHasLockedLastSharedFile(TableNode $properties) {
-		$response = $this->lockFile(
-			$this->featureContext->getLastCreatedPublicShareToken(),
-			"/",
-			$properties,
-			null,
-			true
-		);
-		$this->featureContext->theHTTPStatusCodeShouldBe(200, '', $response);
-	}
-
-	/**
-	 * @When the public locks the last public link shared file using the WebDAV API setting the following properties
-	 * @When the public tries to lock the last public link shared file using the WebDAV API setting the following properties
-	 *
-	 * @param TableNode $properties
-	 *
-	 * @return void
-	 */
+	#[When('the public locks the last public link shared file using the WebDAV API setting the following properties')]
+	#[When('the public tries to lock the last public link shared file using the WebDAV API setting the following properties')]
 	public function publicLocksLastSharedFile(TableNode $properties) {
 		$token = ($this->featureContext->isUsingSharingNG())
 		? $this->featureContext->shareNgGetLastCreatedLinkShareToken()
@@ -412,13 +397,13 @@ class WebDavLockingContext implements Context {
 	}
 
 	/**
-	 * @Given the public has locked :file in the last public link shared folder setting the following properties
 	 *
 	 * @param string $file
 	 * @param TableNode $properties
 	 *
 	 * @return void
 	 */
+	#[Given('the public has locked :file in the last public link shared folder setting the following properties')]
 	public function publicHasLockedFileLastSharedFolder(
 		string    $file,
 		TableNode $properties
@@ -437,14 +422,14 @@ class WebDavLockingContext implements Context {
 	}
 
 	/**
-	 * @When /^the public locks "([^"]*)" in the last public link shared folder using the public WebDAV API setting the following properties$/
-	 * @When /^the public tries to lock "([^"]*)" in the last public link shared folder using the public WebDAV API setting the following properties$/
 	 *
 	 * @param string $file
 	 * @param TableNode $properties
 	 *
 	 * @return void
 	 */
+	#[When('the public locks :file in the last public link shared folder using the public WebDAV API setting the following properties')]
+	#[When('the public tries to lock :file in the last public link shared folder using the public WebDAV API setting the following properties')]
 	public function publicLocksFileLastSharedFolder(
 		string $file,
 		TableNode $properties
@@ -464,13 +449,13 @@ class WebDavLockingContext implements Context {
 	}
 
 	/**
-	 * @When user :user unlocks the last created lock of file :file using the WebDAV API
 	 *
 	 * @param string $user
 	 * @param string $file
 	 *
 	 * @return void
 	 */
+	#[When('user :user unlocks the last created lock of file :file using the WebDAV API')]
 	public function unlockLastLockUsingWebDavAPI(string $user, string $file) {
 		$response = $this->unlockItemWithLastLockOfUserAndItemUsingWebDavAPI(
 			$user,
@@ -482,7 +467,6 @@ class WebDavLockingContext implements Context {
 	}
 
 	/**
-	 * @When user :user unlocks the last created lock of file :file inside space :spaceName using the WebDAV API
 	 *
 	 * @param string $user
 	 * @param string $spaceName
@@ -490,6 +474,7 @@ class WebDavLockingContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[When('user :user unlocks the last created lock of file :file inside space :spaceName using the WebDAV API')]
 	public function userUnlocksTheLastCreatedLockOfFileInsideSpaceUsingTheWebdavApi(
 		string $user,
 		string $spaceName,
@@ -509,7 +494,6 @@ class WebDavLockingContext implements Context {
 	}
 
 	/**
-	 * @When user :user unlocks the last created lock of file :itemToUnlock using file-id :fileId using the WebDAV API
 	 *
 	 * @param string $user
 	 * @param string $itemToUnlock
@@ -517,6 +501,7 @@ class WebDavLockingContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[When('user :user unlocks the last created lock of file :itemToUnlock using file-id :fileId using the WebDAV API')]
 	public function userUnlocksTheLastCreatedLockOfFileWithFileIdPathUsingTheWebdavApi(
 		string $user,
 		string $itemToUnlock,
@@ -532,53 +517,6 @@ class WebDavLockingContext implements Context {
 			$itemToUnlock,
 			false,
 			$fullUrl
-		);
-		$this->featureContext->setResponse($response);
-	}
-
-	/**
-	 * @When user :user unlocks file :itemToUnlock with the last created lock of file :itemToUseLockOf using the WebDAV API
-	 *
-	 * @param string $user
-	 * @param string $itemToUnlock
-	 * @param string $itemToUseLockOf
-	 *
-	 * @return void
-	 */
-	public function unlockItemWithLastLockOfOtherItemUsingWebDavAPI(
-		string $user,
-		string $itemToUnlock,
-		string $itemToUseLockOf
-	) {
-		$response = $this->unlockItemWithLastLockOfUserAndItemUsingWebDavAPI(
-			$user,
-			$itemToUnlock,
-			$user,
-			$itemToUseLockOf
-		);
-		$this->featureContext->setResponse($response);
-	}
-
-	/**
-	 * @When user :user unlocks file :itemToUnlock with the last created public lock of file :itemToUseLockOf using the WebDAV API
-	 *
-	 * @param string $user
-	 * @param string $itemToUnlock
-	 * @param string $itemToUseLockOf
-	 *
-	 * @return void
-	 */
-	public function unlockItemWithLastPublicLockOfOtherItemUsingWebDavAPI(
-		string $user,
-		string $itemToUnlock,
-		string $itemToUseLockOf
-	) {
-		$lockOwner = $this->featureContext->getLastCreatedPublicShareToken();
-		$response = $this->unlockItemWithLastLockOfUserAndItemUsingWebDavAPI(
-			$user,
-			$itemToUnlock,
-			$lockOwner,
-			$itemToUseLockOf
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -623,45 +561,6 @@ class WebDavLockingContext implements Context {
 		} else {
 			throw new Exception("xmlPart for 'd:activelock' was expected to be array but found: $xmlPart");
 		}
-	}
-
-	/**
-	 * @Given user :user has unlocked file :itemToUnlock with the last created lock of file :itemToUseLockOf of user :lockOwner using the WebDAV API
-	 *
-	 * @param string $user
-	 * @param string $itemToUnlock
-	 * @param string $lockOwner
-	 * @param string $itemToUseLockOf
-	 * @param boolean $public
-	 *
-	 * @return void
-	 * @throws Exception|GuzzleException
-	 */
-	public function hasUnlockItemWithTheLastCreatedLock(
-		string $user,
-		string $itemToUnlock,
-		string $lockOwner,
-		string $itemToUseLockOf,
-		bool $public = false
-	) {
-		$lockCount = $this->countLockOfResources($user, $itemToUnlock);
-
-		$response = $this->unlockItemWithLastLockOfUserAndItemUsingWebDavAPI(
-			$user,
-			$itemToUnlock,
-			$lockOwner,
-			$itemToUseLockOf,
-			$public
-		);
-		$this->featureContext->theHTTPStatusCodeShouldBe(204, "", $response);
-
-		$lockCountAfterUnlock = $this->countLockOfResources($user, $itemToUnlock);
-
-		Assert::assertEquals(
-			$lockCount - 1,
-			$lockCountAfterUnlock,
-			"Expected $lockCount lock(s) for '$itemToUnlock' but found '$lockCount'"
-		);
 	}
 
 	/**
@@ -733,7 +632,6 @@ class WebDavLockingContext implements Context {
 	}
 
 	/**
-	 * @When user :user unlocks file :itemToUnlock with the last created lock of file :itemToUseLockOf of user :lockOwner using the WebDAV API
 	 *
 	 * @param string $user
 	 * @param string $itemToUnlock
@@ -742,6 +640,7 @@ class WebDavLockingContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[When('user :user unlocks file :itemToUnlock with the last created lock of file :itemToUseLockOf of user :lockOwner using the WebDAV API')]
 	public function userUnlocksItemWithLastLockOfUserAndItemUsingWebDavAPI(
 		string $user,
 		string $itemToUnlock,
@@ -758,7 +657,6 @@ class WebDavLockingContext implements Context {
 	}
 
 	/**
-	 * @When the public unlocks file :itemToUnlock with the last created lock of file :itemToUseLockOf of user :lockOwner using the WebDAV API
 	 *
 	 * @param string $itemToUnlock
 	 * @param string $lockOwner
@@ -766,6 +664,7 @@ class WebDavLockingContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[When('the public unlocks file :itemToUnlock with the last created lock of file :itemToUseLockOf of user :lockOwner using the WebDAV API')]
 	public function unlockItemAsPublicWithLastLockOfUserAndItemUsingWebDavAPI(
 		string $itemToUnlock,
 		string $lockOwner,
@@ -785,12 +684,12 @@ class WebDavLockingContext implements Context {
 	}
 
 	/**
-	 * @When the public unlocks file :itemToUnlock using the WebDAV API
 	 *
 	 * @param string $itemToUnlock
 	 *
 	 * @return void
 	 */
+	#[When('the public unlocks file :itemToUnlock using the WebDAV API')]
 	public function unlockItemAsPublicUsingWebDavAPI(string $itemToUnlock) {
 		$token = ($this->featureContext->isUsingSharingNG())
 		? $this->featureContext->shareNgGetLastCreatedLinkShareToken()
@@ -806,96 +705,6 @@ class WebDavLockingContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" moves (?:file|folder|entry) "([^"]*)" to "([^"]*)" sending the locktoken of (?:file|folder|entry) "([^"]*)" using the WebDAV API$/
-	 *
-	 * @param string $user
-	 * @param string $fileSource
-	 * @param string $fileDestination
-	 * @param string $itemToUseLockOf
-	 *
-	 * @return void
-	 */
-	public function moveItemSendingLockToken(
-		string $user,
-		string $fileSource,
-		string $fileDestination,
-		string $itemToUseLockOf
-	) {
-		$response = $this->moveItemSendingLockTokenOfUser(
-			$user,
-			$fileSource,
-			$fileDestination,
-			$itemToUseLockOf,
-			$user
-		);
-		$this->featureContext->setResponse($response);
-	}
-
-	/**
-	 * @param string $user
-	 * @param string $fileSource
-	 * @param string $fileDestination
-	 * @param string $itemToUseLockOf
-	 * @param string $lockOwner
-	 *
-	 * @return ResponseInterface
-	 */
-	public function moveItemSendingLockTokenOfUser(
-		string $user,
-		string $fileSource,
-		string $fileDestination,
-		string $itemToUseLockOf,
-		string $lockOwner
-	): ResponseInterface {
-		$user = $this->featureContext->getActualUsername($user);
-		$lockOwner = $this->featureContext->getActualUsername($lockOwner);
-		$destination = $this->featureContext->destinationHeaderValue(
-			$user,
-			$fileDestination
-		);
-		$token = $this->tokenOfLastLock[$lockOwner][$itemToUseLockOf];
-		$headers = [
-			"Destination" => $destination,
-			"If" => "(<$token>)"
-		];
-		return $this->featureContext->makeDavRequest(
-			$user,
-			"MOVE",
-			$fileSource,
-			$headers
-		);
-	}
-
-	/**
-	 * @When /^user "([^"]*)" moves (?:file|folder|entry) "([^"]*)" to "([^"]*)" sending the locktoken of (?:file|folder|entry) "([^"]*)" of user "([^"]*)" using the WebDAV API$/
-	 *
-	 * @param string $user
-	 * @param string $fileSource
-	 * @param string $fileDestination
-	 * @param string $itemToUseLockOf
-	 * @param string $lockOwner
-	 *
-	 * @return void
-	 */
-	public function userMovesItemSendingLockTokenOfUser(
-		string $user,
-		string $fileSource,
-		string $fileDestination,
-		string $itemToUseLockOf,
-		string $lockOwner
-	) {
-		$response = $this->moveItemSendingLockTokenOfUser(
-			$user,
-			$fileSource,
-			$fileDestination,
-			$itemToUseLockOf,
-			$lockOwner
-		);
-		$this->featureContext->setResponse($response);
-	}
-
-	/**
-	 * @When /^user "([^"]*)" uploads file with content "([^"]*)" to "([^"]*)" sending the locktoken of (?:file|folder|entry) "([^"]*)" using the WebDAV API$/
 	 *
 	 * @param string $user
 	 * @param string $content
@@ -904,6 +713,7 @@ class WebDavLockingContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[When('/^user "([^"]*)" uploads file with content "([^"]*)" to "([^"]*)" sending the locktoken of (?:file|folder|entry) "([^"]*)" using the WebDAV API$/')]
 	public function userUploadsAFileWithContentTo(
 		string $user,
 		string $content,
@@ -925,7 +735,6 @@ class WebDavLockingContext implements Context {
 	}
 
 	/**
-	 * @Then :count locks should be reported for file :file of user :user by the WebDAV API
 	 *
 	 * @param int $count
 	 * @param string $file
@@ -934,6 +743,7 @@ class WebDavLockingContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[Then(':count locks should be reported for file :file of user :user by the WebDAV API')]
 	public function numberOfLockShouldBeReported(int $count, string $file, string $user) {
 		$lockCount = $this->countLockOfResources($user, $file);
 		Assert::assertEquals(
@@ -944,18 +754,17 @@ class WebDavLockingContext implements Context {
 	}
 
 	/**
-	 * @When the user waits for :time seconds to expire the lock
 	 *
 	 * @param int $time
 	 *
 	 * @return void
 	 */
+	#[When('the user waits for :time seconds to expire the lock')]
 	public function waitForCertainSecondsToExpireTheLock(int $time): void {
 		\sleep($time);
 	}
 
 	/**
-	 * @Then :count locks should be reported for file :file inside the space :space of user :user
 	 *
 	 * @param int $count
 	 * @param string $file
@@ -965,6 +774,7 @@ class WebDavLockingContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
+	#[Then(':count locks should be reported for file :file inside the space :space of user :user')]
 	public function numberOfLockShouldBeReportedInProjectSpace(
 		int $count,
 		string $file,

--- a/tests/acceptance/bootstrap/WebDavPropertiesContext.php
+++ b/tests/acceptance/bootstrap/WebDavPropertiesContext.php
@@ -27,6 +27,9 @@ use TestHelpers\Asserts\WebDav as WebDavTest;
 use TestHelpers\WebDavHelper;
 use TestHelpers\BehatHelper;
 use TestHelpers\HttpRequestHelper;
+use Behat\Step\Given;
+use Behat\Step\Then;
+use Behat\Step\When;
 
 require_once 'bootstrap.php';
 
@@ -43,7 +46,6 @@ class WebDavPropertiesContext implements Context {
 	private array $storedETAG = [];
 
 	/**
-	 * @When /^user "([^"]*)" gets the properties of (?:file|folder|entry) "([^"]*)" using the WebDAV API$/
 	 *
 	 * @param string $user
 	 * @param string $path
@@ -51,6 +53,7 @@ class WebDavPropertiesContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('/^user "([^"]*)" gets the properties of (?:file|folder|entry) "([^"]*)" using the WebDAV API$/')]
 	public function userGetsThePropertiesOfFolder(
 		string $user,
 		string $path
@@ -64,7 +67,6 @@ class WebDavPropertiesContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" gets the properties of (?:file|folder|entry) "([^"]*)" with depth (\d+) using the WebDAV API$/
 	 *
 	 * @param string $user
 	 * @param string $path
@@ -73,6 +75,7 @@ class WebDavPropertiesContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('/^user "([^"]*)" gets the properties of (?:file|folder|entry) "([^"]*)" with depth (\\d+) using the WebDAV API$/')]
 	public function userGetsThePropertiesOfFolderWithDepth(
 		string $user,
 		string $path,
@@ -118,7 +121,6 @@ class WebDavPropertiesContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" gets the following properties of (?:file|folder|entry) "([^"]*)" using the WebDAV API$/
 	 *
 	 * @param string $user
 	 * @param string $path
@@ -127,6 +129,7 @@ class WebDavPropertiesContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('/^user "([^"]*)" gets the following properties of (?:file|folder|entry) "([^"]*)" using the WebDAV API$/')]
 	public function userGetsFollowingPropertiesOfEntryUsingWebDavApi(
 		string $user,
 		string $path,
@@ -138,26 +141,6 @@ class WebDavPropertiesContext implements Context {
 	}
 
 	/**
-	 * @When /^the user gets the following properties of (?:file|folder|entry) "([^"]*)" using the WebDAV API$/
-	 *
-	 * @param string $path
-	 * @param TableNode|null $propertiesTable
-	 *
-	 * @return void
-	 * @throws Exception
-	 */
-	public function theUserGetsPropertiesOfFolder(string $path, TableNode $propertiesTable) {
-		$response = $this->getPropertiesOfFolder(
-			$this->featureContext->getCurrentUser(),
-			$path,
-			null,
-			$propertiesTable
-		);
-		$this->featureContext->setResponse($response);
-	}
-
-	/**
-	 * @Given /^user "([^"]*)" has set the following properties to (?:file|folder|entry) "([^"]*)" using the WebDav API$/
 	 *
 	 * @param string $username
 	 * @param string $path
@@ -168,6 +151,7 @@ class WebDavPropertiesContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Given('/^user "([^"]*)" has set the following properties to (?:file|folder|entry) "([^"]*)" using the WebDav API$/')]
 	public function userHasSetFollowingPropertiesUsingProppatch(
 		string $username,
 		string $path,
@@ -189,7 +173,6 @@ class WebDavPropertiesContext implements Context {
 	}
 
 	/**
-	 * @When user :user gets a custom property :propertyName of file :path
 	 *
 	 * @param string $user
 	 * @param string $propertyName
@@ -198,6 +181,7 @@ class WebDavPropertiesContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('user :user gets a custom property :propertyName of file :path')]
 	public function userGetsCustomPropertyOfFile(
 		string $user,
 		string $propertyName,
@@ -221,7 +205,6 @@ class WebDavPropertiesContext implements Context {
 	}
 
 	/**
-	 * @When user :user gets a custom property :propertyName with namespace :namespace of file :path
 	 *
 	 * @param string $user
 	 * @param string $propertyName
@@ -231,6 +214,7 @@ class WebDavPropertiesContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('user :user gets a custom property :propertyName with namespace :namespace of file :path')]
 	public function userGetsPropertiesWithNamespaceOfFile(
 		string $user,
 		string $propertyName,
@@ -282,7 +266,6 @@ class WebDavPropertiesContext implements Context {
 	}
 
 	/**
-	 * @When /^the public gets the following properties of (?:file|folder|entry) "([^"]*)" in the last created public link using the WebDAV API$/
 	 *
 	 * @param string $path
 	 * @param TableNode $propertiesTable
@@ -290,6 +273,7 @@ class WebDavPropertiesContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('/^the public gets the following properties of (?:file|folder|entry) "([^"]*)" in the last created public link using the WebDAV API$/')]
 	public function thePublicGetsFollowingPropertiesOfEntryFromLastLinkShare(
 		string $path,
 		TableNode $propertiesTable
@@ -330,7 +314,6 @@ class WebDavPropertiesContext implements Context {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" sets property "([^"]*)" of (?:file|folder|entry) "([^"]*)" to "([^"]*)"$/
 	 *
 	 * @param string $user user id who sets the property
 	 * @param string $propertyName name of property in Clark notation
@@ -340,6 +323,7 @@ class WebDavPropertiesContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Given('/^user "([^"]*)" sets property "([^"]*)" of (?:file|folder|entry) "([^"]*)" to "([^"]*)"$/')]
 	public function userSetsPropertyOfEntryTo(
 		string $user,
 		string $propertyName,
@@ -356,7 +340,6 @@ class WebDavPropertiesContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" sets property "([^"]*)" with namespace "([^"]*)" of (?:file|folder|entry) "([^"]*)" to "([^"]*)" using the WebDAV API$/
 	 *
 	 * @param string $user user id who sets the property
 	 * @param string $propertyName name of property in Clark notation
@@ -367,6 +350,7 @@ class WebDavPropertiesContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[When('/^user "([^"]*)" sets property "([^"]*)" with namespace "([^"]*)" of (?:file|folder|entry) "([^"]*)" to "([^"]*)" using the WebDAV API$/')]
 	public function userSetsPropertyWithNamespaceOfEntryTo(
 		string $user,
 		string $propertyName,
@@ -385,7 +369,6 @@ class WebDavPropertiesContext implements Context {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" has set property "([^"]*)" of (?:file|folder|entry) "([^"]*)" to "([^"]*)"$/
 	 *
 	 * @param string $user user id who sets the property
 	 * @param string $propertyName name of property in Clark notation
@@ -395,6 +378,7 @@ class WebDavPropertiesContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Given('/^user "([^"]*)" has set property "([^"]*)" of (?:file|folder|entry) "([^"]*)" to "([^"]*)"$/')]
 	public function userHasSetPropertyOfEntryTo(
 		string $user,
 		string $propertyName,
@@ -411,36 +395,6 @@ class WebDavPropertiesContext implements Context {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" has set property "([^"]*)" with namespace "([^"]*)" of (?:file|folder|entry) "([^"]*)" to "([^"]*)"$/
-	 *
-	 * @param string $user user id who sets the property
-	 * @param string $propertyName name of property in Clark notation
-	 * @param string $namespace namespace in the form of "x1='http://whatever.org/ns'"
-	 * @param string $path path on which to set properties to
-	 * @param string $propertyValue property value
-	 *
-	 * @return void
-	 * @throws Exception
-	 */
-	public function userHasSetPropertyWithNamespaceOfEntryTo(
-		string $user,
-		string $propertyName,
-		string $namespace,
-		string $path,
-		string $propertyValue
-	): void {
-		$response = $this->setResourceProperty(
-			$user,
-			$propertyName,
-			$path,
-			$propertyValue,
-			$namespace
-		);
-		$this->featureContext->theHTTPStatusCodeShouldBe(207, "", $response);
-	}
-
-	/**
-	 * @Then /^the response should contain a custom "([^"]*)" property with value "(([^"\\]|\\.)*)"$/
 	 *
 	 * @param string $propertyName
 	 * @param string $propertyValue
@@ -448,6 +402,7 @@ class WebDavPropertiesContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('/^the response should contain a custom "([^"]*)" property with value "(([^"\\\\]|\\\\.)*)"$/')]
 	public function theResponseShouldContainCustomPropertyWithValue(string $propertyName, string $propertyValue): void {
 		$propertyValue = \str_replace('\"', '"', $propertyValue);
 		$responseXmlObject = HttpRequestHelper::getResponseXml(
@@ -471,7 +426,6 @@ class WebDavPropertiesContext implements Context {
 	}
 
 	/**
-	 * @Then /^the response should contain a custom "([^"]*)" property with namespace "([^"]*)" and value "([^"]*)"$/
 	 *
 	 * @param string $propertyName
 	 * @param string $namespaceString
@@ -480,6 +434,7 @@ class WebDavPropertiesContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('the response should contain a custom :propertyName property with namespace :namespaceString and value :propertyValue')]
 	public function theResponseShouldContainACustomPropertyWithNamespaceAndValue(
 		string $propertyName,
 		string $namespaceString,
@@ -513,7 +468,6 @@ class WebDavPropertiesContext implements Context {
 	}
 
 	/**
-	 * @Then the single response should contain a property :property with a child property :childProperty
 	 *
 	 * @param string $property
 	 * @param string $childProperty
@@ -522,6 +476,7 @@ class WebDavPropertiesContext implements Context {
 	 *
 	 * @throws Exception
 	 */
+	#[Then('the single response should contain a property :property with a child property :childProperty')]
 	public function theSingleResponseShouldContainAPropertyWithChildProperty(
 		string $property,
 		string $childProperty
@@ -536,13 +491,13 @@ class WebDavPropertiesContext implements Context {
 	}
 
 	/**
-	 * @Then the xml response should contain a property :key
 	 *
 	 * @param string $key
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('the xml response should contain a property :key')]
 	public function theResponseShouldContainProperty(string $key): void {
 		$this->checkResponseContainsProperty(
 			$this->featureContext->getResponse(),
@@ -551,7 +506,6 @@ class WebDavPropertiesContext implements Context {
 	}
 
 	/**
-	 * @Then the xml response should contain a property :key with namespace :namespace
 	 *
 	 * @param string $key
 	 * @param string $namespace
@@ -559,6 +513,7 @@ class WebDavPropertiesContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('the xml response should contain a property :key with namespace :namespace')]
 	public function theResponseShouldContainPropertyWithNamespace(string $key, string $namespace): void {
 		$this->checkResponseContainsProperty(
 			$this->featureContext->getResponse(),
@@ -568,7 +523,6 @@ class WebDavPropertiesContext implements Context {
 	}
 
 	/**
-	 * @Then the single response should contain a property :key with value :value
 	 *
 	 * @param string $key
 	 * @param string $expectedValue
@@ -576,6 +530,7 @@ class WebDavPropertiesContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('the single response should contain a property :key with value :value')]
 	public function theSingleResponseShouldContainAPropertyWithValue(
 		string $key,
 		string $expectedValue
@@ -589,7 +544,6 @@ class WebDavPropertiesContext implements Context {
 	}
 
 	/**
-	 * @Then the single response about the file owned by :user should contain a property :key with value :value
 	 *
 	 * @param string $user
 	 * @param string $key
@@ -598,6 +552,7 @@ class WebDavPropertiesContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('the single response about the file owned by :user should contain a property :key with value :value')]
 	public function theSingleResponseAboutTheFileOwnedByShouldContainAPropertyWithValue(
 		string $user,
 		string $key,
@@ -609,29 +564,6 @@ class WebDavPropertiesContext implements Context {
 			$expectedValue,
 			$expectedValue,
 			$user
-		);
-	}
-
-	/**
-	 * @Then the single response should contain a property :key with value :value or with value :altValue
-	 *
-	 * @param string $key
-	 * @param string $expectedValue
-	 * @param string $altExpectedValue
-	 *
-	 * @return void
-	 * @throws Exception
-	 */
-	public function theSingleResponseShouldContainAPropertyWithValueAndAlternative(
-		string $key,
-		string $expectedValue,
-		string $altExpectedValue
-	): void {
-		$this->checkResponseContainsAPropertyWithValue(
-			$this->featureContext->getResponse(),
-			$key,
-			$expectedValue,
-			$altExpectedValue
 		);
 	}
 
@@ -711,7 +643,6 @@ class WebDavPropertiesContext implements Context {
 	}
 
 	/**
-	 * @Then the value of the item :xpath in the response should be :value
 	 *
 	 * @param string $xpath
 	 * @param string $expectedValue
@@ -719,6 +650,7 @@ class WebDavPropertiesContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('the value of the item :xpath in the response should be :value')]
 	public function assertValueOfItemInResponseIs(string $xpath, string $expectedValue): void {
 		$this->assertValueOfItemInResponseAboutUserIs(
 			$xpath,
@@ -728,7 +660,6 @@ class WebDavPropertiesContext implements Context {
 	}
 
 	/**
-	 * @Then as user :user the value of the item :xpath of path :path in the response should be :value
 	 *
 	 * @param string $user
 	 * @param string $xpath
@@ -738,6 +669,7 @@ class WebDavPropertiesContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('as user :user the value of the item :xpath of path :path in the response should be :value')]
 	public function valueOfItemOfPathShouldBe(string $user, string $xpath, string $path, string $expectedValue): void {
 		$path = $this->featureContext->substituteInLineCodes($path, $user);
 		$path = \ltrim($path, '/');
@@ -751,7 +683,6 @@ class WebDavPropertiesContext implements Context {
 	}
 
 	/**
-	 * @Then the value of the item :xpath in the response about user :user should be :value
 	 *
 	 * @param string $xpath
 	 * @param string $user
@@ -760,6 +691,7 @@ class WebDavPropertiesContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('the value of the item :xpath in the response about user :user should be :value')]
 	public function theValueOfTheItemInTheResponseAboutUserShouldBe(
 		string $xpath,
 		string $user,
@@ -799,7 +731,6 @@ class WebDavPropertiesContext implements Context {
 	}
 
 	/**
-	 * @Then the value of the item :xpath in the response about user :user should be :value1 or :value2
 	 *
 	 * @param string $xpath
 	 * @param string|null $user
@@ -809,6 +740,7 @@ class WebDavPropertiesContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('the value of the item :xpath in the response about user :user should be :value1 or :value2')]
 	public function assertValueOfItemInResponseAboutUserIsEitherOr(
 		string $xpath,
 		?string $user,
@@ -865,7 +797,6 @@ class WebDavPropertiesContext implements Context {
 	}
 
 	/**
-	 * @Then the value of the item :xpath in the response should match :value
 	 *
 	 * @param string $xpath
 	 * @param string $pattern
@@ -873,6 +804,7 @@ class WebDavPropertiesContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('the value of the item :xpath in the response should match :value')]
 	public function assertValueOfItemInResponseRegExp(string $xpath, string $pattern): void {
 		$this->assertXpathValueMatchesPattern(
 			HttpRequestHelper::getResponseXml($this->featureContext->getResponse()),
@@ -882,32 +814,6 @@ class WebDavPropertiesContext implements Context {
 	}
 
 	/**
-	 * @Then /^as a public the lock discovery property "([^"]*)" of the (?:file|folder|entry) "([^"]*)" should match "([^"]*)"$/
-	 *
-	 * @param string $xpath
-	 * @param string $path
-	 * @param string $pattern
-	 *
-	 * @return void
-	 * @throws Exception
-	 */
-	public function publicGetsThePropertiesOfFolderAndAssertValueOfItemInResponseRegExp(
-		string $xpath,
-		string $path,
-		string $pattern
-	): void {
-		$propertiesTable = new TableNode([['propertyName'],['d:lockdiscovery']]);
-		$response = $this->getPropertiesOfEntryFromLastLinkShare($path, $propertiesTable);
-		$this->featureContext->theHTTPStatusCodeShouldBe('207', "", $response);
-		$this->assertXpathValueMatchesPattern(
-			HttpRequestHelper::getResponseXml($response, __METHOD__),
-			$xpath,
-			$pattern
-		);
-	}
-
-	/**
-	 * @Then there should be an entry with href containing :expectedHref in the response to user :user
 	 *
 	 * @param string $expectedHref
 	 * @param string $user
@@ -915,6 +821,7 @@ class WebDavPropertiesContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('there should be an entry with href containing :expectedHref in the response to user :user')]
 	public function assertEntryWithHrefMatchingRegExpInResponseToUser(string $expectedHref, string $user): void {
 		$responseXmlObject = HttpRequestHelper::getResponseXml(
 			$this->featureContext->getResponse(),
@@ -1019,57 +926,6 @@ class WebDavPropertiesContext implements Context {
 	}
 
 	/**
-	 * @Then /^as user "([^"]*)" the lock discovery property "([^"]*)" of the (?:file|folder|entry) "([^"]*)" should match "([^"]*)"$/
-	 *
-	 * @param string|null $user
-	 * @param string $xpath
-	 * @param string $path
-	 * @param string $pattern
-	 *
-	 * @return void
-	 * @throws Exception
-	 */
-	public function userGetsPropertiesOfFolderAndAssertValueOfItemInResponseToUserRegExp(
-		string $user,
-		string $xpath,
-		string $path,
-		string $pattern
-	): void {
-		$propertiesTable = new TableNode([['propertyName'],['d:lockdiscovery']]);
-		$response = $this->getPropertiesOfFolder(
-			$user,
-			$path,
-			null,
-			$propertiesTable
-		);
-		$this->featureContext->theHTTPStatusCodeShouldBe('207', '', $response);
-		$this->assertXpathValueMatchesPattern(
-			HttpRequestHelper::getResponseXml($response, __METHOD__),
-			$xpath,
-			$pattern,
-			$user
-		);
-	}
-
-	/**
-	 * @Then the item :xpath in the response should not exist
-	 *
-	 * @param string $xpath
-	 *
-	 * @return void
-	 * @throws Exception
-	 */
-	public function assertItemInResponseDoesNotExist(string $xpath): void {
-		$xmlPart = HttpRequestHelper::getResponseXml($this->featureContext->getResponse())->xpath($xpath);
-		Assert::assertFalse(
-			isset($xmlPart[0]),
-			"Found item with xpath \"$xpath\" but it should not exist"
-		);
-	}
-
-	/**
-	 * @Then /^as user "([^"]*)" (?:file|folder|entry) "([^"]*)" should contain a property "([^"]*)" with value "([^"]*)" or with value "([^"]*)"$/
-	 * @Then /^as user "([^"]*)" (?:file|folder|entry) "([^"]*)" should contain a property "([^"]*)" with value "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $path
@@ -1079,6 +935,8 @@ class WebDavPropertiesContext implements Context {
 	 *
 	 * @return void
 	 */
+	#[Then('/^as user "([^"]*)" (?:file|folder|entry) "([^"]*)" should contain a property "([^"]*)" with value "([^"]*)" or with value "([^"]*)"$/')]
+	#[Then('/^as user "([^"]*)" (?:file|folder|entry) "([^"]*)" should contain a property "([^"]*)" with value "([^"]*)"$/')]
 	public function asUserFolderShouldContainAPropertyWithValueOrWithValue(
 		string $user,
 		string $path,
@@ -1126,7 +984,6 @@ class WebDavPropertiesContext implements Context {
 	}
 
 	/**
-	 * @Then the single response should contain a property :key with value like :regex
 	 *
 	 * @param string $key
 	 * @param string $regex
@@ -1134,6 +991,7 @@ class WebDavPropertiesContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('the single response should contain a property :key with value like :regex')]
 	public function theSingleResponseShouldContainAPropertyWithValueLike(
 		string $key,
 		string $regex
@@ -1154,13 +1012,13 @@ class WebDavPropertiesContext implements Context {
 	}
 
 	/**
-	 * @Then the response should contain a share-types property with
 	 *
 	 * @param TableNode $table
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('the response should contain a share-types property with')]
 	public function theResponseShouldContainAShareTypesPropertyWith(TableNode $table): void {
 		$this->featureContext->verifyTableNodeColumnsCount($table, 1);
 		WebdavTest::assertResponseContainsShareTypes(
@@ -1170,13 +1028,13 @@ class WebDavPropertiesContext implements Context {
 	}
 
 	/**
-	 * @Then the response should contain an empty property :property
 	 *
 	 * @param string $property
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('the response should contain an empty property :property')]
 	public function theResponseShouldContainAnEmptyProperty(string $property): void {
 		$xmlPart = HttpRequestHelper::getResponseXml($this->featureContext->getResponse())->xpath(
 			"//d:prop/$property"
@@ -1225,23 +1083,6 @@ class WebDavPropertiesContext implements Context {
 	}
 
 	/**
-	 * @When user :user stores etag of element :path using the WebDAV API
-	 *
-	 * @param string $user
-	 * @param string $path
-	 *
-	 * @return void
-	 * @throws Exception
-	 */
-	public function userStoresEtagOfElement(string $user, string $path): void {
-		$this->storeEtagOfElement(
-			$user,
-			$path
-		);
-	}
-
-	/**
-	 * @Given user :user has stored etag of element :path on path :storePath
 	 *
 	 * @param string $user
 	 * @param string $path
@@ -1250,6 +1091,7 @@ class WebDavPropertiesContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Given('user :user has stored etag of element :path on path :storePath')]
 	public function userStoresEtagOfElementOnPath(string $user, string $path, string $storePath): void {
 		$user = $this->featureContext->getActualUsername($user);
 		$this->storeEtagOfElement(
@@ -1266,7 +1108,6 @@ class WebDavPropertiesContext implements Context {
 	}
 
 	/**
-	 * @Given user :user has stored etag of element :path
 	 *
 	 * @param string $user
 	 * @param string $path
@@ -1274,6 +1115,7 @@ class WebDavPropertiesContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Given('user :user has stored etag of element :path')]
 	public function userHasStoredEtagOfElement(string $user, string $path): void {
 		$user = $this->featureContext->getActualUsername($user);
 		$this->storeEtagOfElement(
@@ -1286,11 +1128,11 @@ class WebDavPropertiesContext implements Context {
 	}
 
 	/**
-	 * @Then /^the properties response should contain an etag$/
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('the properties response should contain an etag')]
 	public function thePropertiesResponseShouldContainAnEtag(): void {
 		Assert::assertTrue(
 			$this->featureContext->isEtagValid($this->featureContext->getEtagFromResponseXmlObject()),
@@ -1317,8 +1159,6 @@ class WebDavPropertiesContext implements Context {
 	}
 
 	/**
-	 * @Then as user :username the last response should have the following properties
-	 *
 	 * only supports new DAV version
 	 *
 	 * @param string $username
@@ -1330,6 +1170,7 @@ class WebDavPropertiesContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('as user :username the last response should have the following properties')]
 	public function theResponseShouldHavePropertyWithValue(string $username, TableNode $expectedPropTable): void {
 		$this->featureContext->verifyTableNodeColumns(
 			$expectedPropTable,
@@ -1403,13 +1244,13 @@ class WebDavPropertiesContext implements Context {
 	}
 
 	/**
-	 * @Then these etags should not have changed:
 	 *
 	 * @param TableNode $etagTable
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('these etags should not have changed:')]
 	public function theseEtagsShouldNotHaveChanged(TableNode $etagTable): void {
 		$this->featureContext->verifyTableNodeColumns($etagTable, ["user", "path"]);
 		$this->featureContext->verifyTableNodeColumnsCount($etagTable, 2);
@@ -1431,13 +1272,13 @@ class WebDavPropertiesContext implements Context {
 	}
 
 	/**
-	 * @Then these etags should have changed:
 	 *
 	 * @param TableNode $etagTable
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('these etags should have changed:')]
 	public function theseEtagsShouldHaveChanged(TableNode $etagTable): void {
 		$this->featureContext->verifyTableNodeColumns($etagTable, ["user", "path"]);
 		$this->featureContext->verifyTableNodeColumnsCount($etagTable, 2);
@@ -1459,7 +1300,6 @@ class WebDavPropertiesContext implements Context {
 	}
 
 	/**
-	 * @Then /^the etag of element "([^"]*)" of user "([^"]*)" (should|should not) have changed$/
 	 *
 	 * @param string $path
 	 * @param string $user
@@ -1468,6 +1308,7 @@ class WebDavPropertiesContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	#[Then('/^the etag of element "([^"]*)" of user "([^"]*)" (should|should not) have changed$/')]
 	public function etagOfElementOfUserShouldOrShouldNotHaveChanged(
 		string $path,
 		string $user,

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -108,6 +108,8 @@ default:
         - OcConfigContext:
         - TrashbinContext:
         - SharingNgContext:
+        - FavoritesContext:
+        - WebDavPropertiesContext:
 
     apiGraphUserGroup:
       paths:

--- a/tests/acceptance/expected-failures-decomposed-storage.md
+++ b/tests/acceptance/expected-failures-decomposed-storage.md
@@ -49,16 +49,16 @@
 
 #### [Same users can be added in a group multiple time](https://github.com/owncloud/ocis/issues/5702)
 
-- [apiGraphUserGroup/addUserToGroup.feature:295](https://github.com/opencloud-eu/opencloud/blob/main/tests/acceptance/features/apiGraphUserGroup/addUserToGroup.feature#L295)
+- [apiGraphUserGroup/addUserToGroup.feature:294](https://github.com/opencloud-eu/opencloud/blob/main/tests/acceptance/features/apiGraphUserGroup/addUserToGroup.feature#L294)
 
 #### [Users are added in a group with wrong host in host-part of user](https://github.com/owncloud/ocis/issues/5871)
 
-- [apiGraphUserGroup/addUserToGroup.feature:379](https://github.com/opencloud-eu/opencloud/blob/main/tests/acceptance/features/apiGraphUserGroup/addUserToGroup.feature#L379)
-- [apiGraphUserGroup/addUserToGroup.feature:393](https://github.com/opencloud-eu/opencloud/blob/main/tests/acceptance/features/apiGraphUserGroup/addUserToGroup.feature#L393)
+- [apiGraphUserGroup/addUserToGroup.feature:378](https://github.com/opencloud-eu/opencloud/blob/main/tests/acceptance/features/apiGraphUserGroup/addUserToGroup.feature#L378)
+- [apiGraphUserGroup/addUserToGroup.feature:392](https://github.com/opencloud-eu/opencloud/blob/main/tests/acceptance/features/apiGraphUserGroup/addUserToGroup.feature#L392)
 
 #### [Adding the same user as multiple members in a single request results in listing the same user twice in the group](https://github.com/owncloud/ocis/issues/5855)
 
-- [apiGraphUserGroup/addUserToGroup.feature:430](https://github.com/opencloud-eu/opencloud/blob/main/tests/acceptance/features/apiGraphUserGroup/addUserToGroup.feature#L430)
+- [apiGraphUserGroup/addUserToGroup.feature:429](https://github.com/opencloud-eu/opencloud/blob/main/tests/acceptance/features/apiGraphUserGroup/addUserToGroup.feature#L429)
 
 #### [Shared file locking is not possible using different path](https://github.com/owncloud/ocis/issues/7599)
 

--- a/tests/acceptance/expected-failures-posix-storage.md
+++ b/tests/acceptance/expected-failures-posix-storage.md
@@ -49,16 +49,17 @@
 
 #### [Same users can be added in a group multiple time](https://github.com/owncloud/ocis/issues/5702)
 
-- [apiGraphUserGroup/addUserToGroup.feature:295](https://github.com/opencloud-eu/opencloud/blob/main/tests/acceptance/features/apiGraphUserGroup/addUserToGroup.feature#L295)
+- [apiGraphUserGroup/addUserToGroup.feature:294](https://github.com/opencloud-eu/opencloud/blob/main/tests/acceptance/features/apiGraphUserGroup/addUserToGroup.feature#L294)
 
 #### [Users are added in a group with wrong host in host-part of user](https://github.com/owncloud/ocis/issues/5871)
 
-- [apiGraphUserGroup/addUserToGroup.feature:379](https://github.com/opencloud-eu/opencloud/blob/main/tests/acceptance/features/apiGraphUserGroup/addUserToGroup.feature#L379)
-- [apiGraphUserGroup/addUserToGroup.feature:393](https://github.com/opencloud-eu/opencloud/blob/main/tests/acceptance/features/apiGraphUserGroup/addUserToGroup.feature#L393)
+- [apiGraphUserGroup/addUserToGroup.feature:378](https://github.com/opencloud-eu/opencloud/blob/main/tests/acceptance/features/apiGraphUserGroup/addUserToGroup.feature#L378)
+- [apiGraphUserGroup/addUserToGroup.feature:392](https://github.com/opencloud-eu/opencloud/blob/main/tests/acceptance/features/apiGraphUserGroup/addUserToGroup.feature#L392)
 
 #### [Adding the same user as multiple members in a single request results in listing the same user twice in the group](https://github.com/owncloud/ocis/issues/5855)
 
-- [apiGraphUserGroup/addUserToGroup.feature:430](https://github.com/opencloud-eu/opencloud/blob/main/tests/acceptance/features/apiGraphUserGroup/addUserToGroup.feature#L430)
+
+- [apiGraphUserGroup/addUserToGroup.feature:429](https://github.com/opencloud-eu/opencloud/blob/main/tests/acceptance/features/apiGraphUserGroup/addUserToGroup.feature#L429)
 
 #### [Shared file locking is not possible using different path](https://github.com/owncloud/ocis/issues/7599)
 

--- a/tests/acceptance/features/apiGraphUserGroup/addUserToGroup.feature
+++ b/tests/acceptance/features/apiGraphUserGroup/addUserToGroup.feature
@@ -225,16 +225,15 @@ Feature: add users to group
 
 
   Scenario: add multiple users to a group at once
-    Given the administrator has assigned the role "Admin" to user "Alice" using the Graph API
-    And these users have been created with default attributes:
+    Given these users have been created with default attributes:
       | username |
       | Brian    |
       | Carol    |
-    And user "Alice" has created a group "grp1" using the Graph API
-    When the administrator "Alice" adds the following users to a group "grp1" at once using the Graph API
-      | username |
-      | Brian    |
-      | Carol    |
+    And the administrator has created a group "grp1" using the Graph API
+    When the administrator adds the following users to the following groups using the Graph API
+      | username | groupname |
+      | Brian    | grp1      |
+      | Carol    | grp1      |
     Then the HTTP status code should be "204"
     And the following users should be listed in the following groups
       | username | groupname |

--- a/tests/acceptance/features/apiSharingNg1/sharedWithMe.feature
+++ b/tests/acceptance/features/apiSharingNg1/sharedWithMe.feature
@@ -681,9 +681,8 @@ Feature: an user gets the resources shared to them
 
 
   Scenario: sharee lists the file share received via group invitation (Personal space)
-    Given the administrator has assigned the role "Admin" to user "Alice" using the Graph API
+    Given the administrator has created a group "grp1" using the Graph API
     And user "Alice" has uploaded file with content "hello" to "textfile0.txt"
-    And user "Alice" has created a group "grp1" using the Graph API
     And user "Brian" has been added to group "grp1"
     And user "Alice" has sent the following resource share invitation:
       | resource        | textfile0.txt |
@@ -974,9 +973,8 @@ Feature: an user gets the resources shared to them
 
   Scenario: sharee lists the folder share received via group invitation (Personal space)
     Given using spaces DAV path
-    And the administrator has assigned the role "Admin" to user "Alice" using the Graph API
-    And  user "Alice" has created folder "folder"
-    And user "Alice" has created a group "grp1" using the Graph API
+    And the administrator has created a group "grp1" using the Graph API
+    And user "Alice" has created folder "folder"
     And user "Brian" has been added to group "grp1"
     And user "Alice" has sent the following resource share invitation:
       | resource        | folder   |
@@ -1214,9 +1212,8 @@ Feature: an user gets the resources shared to them
 
 
   Scenario: sharee list the same file shares received via user and group invitation (Personal space)
-    Given the administrator has assigned the role "Admin" to user "Alice" using the Graph API
+    Given the administrator has created a group "grp1" using the Graph API
     And user "Alice" has uploaded file with content "hello" to "textfile0.txt"
-    And user "Alice" has created a group "grp1" using the Graph API
     And user "Brian" has been added to group "grp1"
     And user "Alice" has sent the following resource share invitation:
       | resource        | textfile0.txt |
@@ -1585,9 +1582,8 @@ Feature: an user gets the resources shared to them
 
 
   Scenario: sharee list the same folder shares received via user and group invitation (Personal space)
-    Given the administrator has assigned the role "Admin" to user "Alice" using the Graph API
+    Given the administrator has created a group "grp1" using the Graph API
     And  user "Alice" has created folder "folder"
-    And user "Alice" has created a group "grp1" using the Graph API
     And user "Brian" has been added to group "grp1"
     And user "Alice" has sent the following resource share invitation:
       | resource        | folder   |
@@ -3027,10 +3023,10 @@ Feature: an user gets the resources shared to them
 
   Scenario: sharee lists the file share received via group invitation (Project space)
     Given using spaces DAV path
-    And the administrator has assigned the role "Admin" to user "Alice" using the Graph API
+    And the administrator has created a group "grp1" using the Graph API
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "new-space" with the default quota using the Graph API
     And user "Alice" has uploaded a file inside space "new-space" with content "hello world" to "textfile0.txt"
-    And user "Alice" has created a group "grp1" using the Graph API
     And user "Brian" has been added to group "grp1"
     And user "Alice" has sent the following resource share invitation:
       | resource        | textfile0.txt |
@@ -3242,9 +3238,9 @@ Feature: an user gets the resources shared to them
 
   Scenario: sharee lists the folder share received via group invitation (Project space)
     Given using spaces DAV path
-    And the administrator has assigned the role "Admin" to user "Alice" using the Graph API
+    And the administrator has created a group "grp1" using the Graph API
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "new-space" with the default quota using the Graph API
-    And user "Alice" has created a group "grp1" using the Graph API
     And user "Alice" has created a folder "folder" in space "new-space"
     And user "Brian" has been added to group "grp1"
     And user "Alice" has sent the following resource share invitation:
@@ -3435,10 +3431,10 @@ Feature: an user gets the resources shared to them
 
   Scenario: sharee list the same file shares received via user and group invitation (Project space)
     Given using spaces DAV path
-    And the administrator has assigned the role "Admin" to user "Alice" using the Graph API
+    And the administrator has created a group "grp1" using the Graph API
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "new-space" with the default quota using the Graph API
     And user "Alice" has uploaded a file inside space "new-space" with content "hello world" to "textfile0.txt"
-    And user "Alice" has created a group "grp1" using the Graph API
     And user "Brian" has been added to group "grp1"
     And user "Alice" has sent the following resource share invitation:
       | resource        | textfile0.txt |
@@ -3727,9 +3723,9 @@ Feature: an user gets the resources shared to them
 
   Scenario: sharee list the same folder shares received via user and group invitation (Project space)
     Given using spaces DAV path
-    And the administrator has assigned the role "Admin" to user "Alice" using the Graph API
+    And the administrator has created a group "grp1" using the Graph API
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "new-space" with the default quota using the Graph API
-    And user "Alice" has created a group "grp1" using the Graph API
     And user "Alice" has created a folder "folder" in space "new-space"
     And user "Brian" has been added to group "grp1"
     And user "Alice" has sent the following resource share invitation:

--- a/tests/acceptance/features/apiSpacesDavOperation/getFileByFileId.feature
+++ b/tests/acceptance/features/apiSpacesDavOperation/getFileByFileId.feature
@@ -157,8 +157,7 @@ Feature: accessing files using file id
     And user "Brian" has disabled the auto-sync share
     And user "Alice" has uploaded file with content "some data" to "/textfile.txt"
     And we save it into "FILEID"
-    And the administrator has assigned the role "Admin" to user "Alice" using the Graph API
-    And user "Alice" has created a group "grp1" using the Graph API
+    And the administrator has created a group "grp1" using the Graph API
     And user "Brian" has been added to group "grp1"
     And user "Alice" has sent the following resource share invitation:
       | resource        | textfile.txt |
@@ -180,8 +179,7 @@ Feature: accessing files using file id
     And user "Alice" has created folder "uploadFolder"
     And user "Alice" has uploaded file with content "some data" to "uploadFolder/textfile.txt"
     And we save it into "FILEID"
-    And the administrator has assigned the role "Admin" to user "Alice" using the Graph API
-    And user "Alice" has created a group "grp1" using the Graph API
+    And the administrator has created a group "grp1" using the Graph API
     And user "Brian" has been added to group "grp1"
     And user "Alice" has sent the following resource share invitation:
       | resource        | uploadFolder |
@@ -244,13 +242,13 @@ Feature: accessing files using file id
 
   Scenario Outline: user who is member of group gets content of a shared file in project space when sync is disabled
     Given using spaces DAV path
+    And the administrator has created a group "grp1" using the Graph API
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "new-space" with the default quota using the Graph API
     And user "Brian" has been created with default attributes
     And user "Brian" has disabled the auto-sync share
     And user "Alice" has uploaded a file inside space "new-space" with content "some content" to "textfile.txt"
     And we save it into "FILEID"
-    And user "Admin" has created a group "grp1" using the Graph API
     And user "Brian" has been added to group "grp1"
     And user "Alice" has sent the following resource share invitation:
       | resource        | textfile.txt |
@@ -275,7 +273,7 @@ Feature: accessing files using file id
     And user "Alice" has created a folder "uploadFolder" in space "new-space"
     And user "Alice" has uploaded a file inside space "new-space" with content "some content" to "uploadFolder/textfile.txt"
     And we save it into "FILEID"
-    And user "Admin" has created a group "grp1" using the Graph API
+    And the administrator has created a group "grp1" using the Graph API
     And user "Brian" has been added to group "grp1"
     And user "Alice" has sent the following resource share invitation:
       | resource        | uploadFolder |

--- a/tests/acceptance/scripts/find-unused-steps.sh
+++ b/tests/acceptance/scripts/find-unused-steps.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+
+# Finds Behat step definitions (in tests/acceptance/bootstrap/*.php) that are never
+# used by any scenario in tests/acceptance/features/**/*.feature.
+#
+# Uses Behat's own RegexPatternPolicy/TurnipPatternPolicy to compile each step
+# definition pattern into the exact same regex Behat itself uses for matching,
+# so results are accurate (no custom regex re-implementation).
+#
+# This is a reporting tool, not a hard gate: some flagged steps may still be in
+# use if they are called programmatically from other PHP context code rather
+# than from a .feature file, which this script cannot detect.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+
+php -d error_reporting=E_ALL -- "${ROOT_DIR}" <<'PHP'
+<?php
+
+$rootDir = $argv[1];
+require $rootDir . '/vendor-bin/behat/vendor/autoload.php';
+
+use Behat\Behat\Definition\Pattern\Policy\RegexPatternPolicy;
+use Behat\Behat\Definition\Pattern\Policy\TurnipPatternPolicy;
+
+$bootstrapDir = $rootDir . '/tests/acceptance/bootstrap';
+$featuresDir = $rootDir . '/tests/acceptance/features';
+
+$attrRegex = "/^\s*#\[(Given|When|Then)\('(.*)'\)\]\s*$/";
+
+$definitions = [];
+foreach (glob($bootstrapDir . '/*.php') as $file) {
+    $lines = file($file);
+    foreach ($lines as $lineNo => $line) {
+        if (preg_match($attrRegex, rtrim($line, "\n"), $m)) {
+            $pattern = str_replace(["\\'", '\\\\'], ["'", '\\'], $m[2]);
+            $definitions[] = [
+                'file' => basename($file),
+                'line' => $lineNo + 1,
+                'keyword' => $m[1],
+                'pattern' => $pattern,
+            ];
+        }
+    }
+}
+
+$stepLineRegex = '/^\s*(Given|When|Then|And|But)\s+(.*)$/';
+$tableRowRegex = '/^\s*\|(.*)\|\s*$/';
+
+/**
+ * Splits a Gherkin table row into trimmed cell values.
+ *
+ * @param string $row
+ *
+ * @return string[]
+ */
+function splitTableRow(string $row): array {
+    return array_map('trim', explode('|', trim($row, "| \t")));
+}
+
+$uniqueTexts = [];
+$featureFiles = new RecursiveIteratorIterator(
+    new RecursiveDirectoryIterator($featuresDir, FilesystemIterator::SKIP_DOTS)
+);
+foreach ($featureFiles as $fileInfo) {
+    if ($fileInfo->getExtension() !== 'feature') {
+        continue;
+    }
+    $lines = file($fileInfo->getPathname());
+
+    // pendingOutlineSteps holds raw "<placeholder>" step texts belonging to the
+    // Scenario Outline currently being parsed, waiting to be substituted once
+    // their Examples: table(s) are found.
+    $pendingOutlineSteps = [];
+    $inOutline = false;
+
+    $i = 0;
+    $count = count($lines);
+    while ($i < $count) {
+        $line = rtrim($lines[$i], "\n");
+
+        if (preg_match('/^\s*Scenario Outline\s*:/i', $line)) {
+            $inOutline = true;
+            $pendingOutlineSteps = [];
+            $i++;
+            continue;
+        }
+
+        if (preg_match('/^\s*(Scenario\s*:|Scenario Outline\s*:|Feature\s*:)/i', $line) && !preg_match('/^\s*Scenario Outline\s*:/i', $line)) {
+            // A plain Scenario (or a new Feature) ends the current outline context.
+            $inOutline = false;
+            $pendingOutlineSteps = [];
+        }
+
+        if (preg_match($stepLineRegex, $line, $m)) {
+            $text = rtrim($m[2]);
+            if ($inOutline && strpos($text, '<') !== false) {
+                $pendingOutlineSteps[] = $text;
+            } else {
+                $uniqueTexts[$text] = true;
+            }
+            $i++;
+            continue;
+        }
+
+        if ($inOutline && preg_match('/^\s*Examples\s*:/i', $line)) {
+            $i++;
+            // skip blank/tag lines before the header row
+            while ($i < $count && trim($lines[$i]) === '') {
+                $i++;
+            }
+            if ($i >= $count || !preg_match($tableRowRegex, rtrim($lines[$i], "\n"), $hm)) {
+                continue;
+            }
+            $header = splitTableRow($hm[1]);
+            $i++;
+            while ($i < $count && preg_match($tableRowRegex, rtrim($lines[$i], "\n"), $rm)) {
+                $row = splitTableRow($rm[1]);
+                $values = count($header) === count($row) ? array_combine($header, $row) : false;
+                if ($values !== false) {
+                    foreach ($pendingOutlineSteps as $template) {
+                        $substituted = preg_replace_callback(
+                            '/<([^>]+)>/',
+                            function ($mm) use ($values) {
+                                return $values[$mm[1]] ?? $mm[0];
+                            },
+                            $template
+                        );
+                        $uniqueTexts[$substituted] = true;
+                    }
+                }
+                $i++;
+            }
+            continue;
+        }
+
+        $i++;
+    }
+}
+$uniqueTexts = array_keys($uniqueTexts);
+
+$regexPolicy = new RegexPatternPolicy();
+$turnipPolicy = new TurnipPatternPolicy();
+
+$unused = [];
+foreach ($definitions as $def) {
+    try {
+        $regex = $regexPolicy->supportsPattern($def['pattern'])
+            ? $regexPolicy->transformPatternToRegex($def['pattern'])
+            : $turnipPolicy->transformPatternToRegex($def['pattern']);
+    } catch (\Throwable $e) {
+        fwrite(STDERR, "Skipping invalid pattern in {$def['file']}:{$def['line']}: {$e->getMessage()}\n");
+        continue;
+    }
+
+    $matched = false;
+    foreach ($uniqueTexts as $text) {
+        if (@preg_match($regex, $text) === 1) {
+            $matched = true;
+            break;
+        }
+    }
+    if (!$matched) {
+        $unused[] = $def;
+    }
+}
+
+echo "Checked " . count($definitions) . " step definitions against " . count($uniqueTexts) . " unique feature step texts.\n";
+echo "Found " . count($unused) . " potentially unused step definitions:\n\n";
+foreach ($unused as $u) {
+    echo "{$u['file']}:{$u['line']} [{$u['keyword']}] {$u['pattern']}\n";
+}
+PHP


### PR DESCRIPTION

- Converted step definitions from docblock annotations `( @Given / @When / @Then )` to PHP  attributes `( #[Given(...)] / #[When(...)`  https://docs.behat.org/en/latest/user_guide/context.html. This lets the vscode resolve step usages properly. click by step-> go to step definition.
-  added  `.vscode/settings.json`  and  `.vscode/extensions.json ` configuring the cucumberautocomplete extension (recommended in  extensions.json ) 
- added checking unused steps and removed 63 unused step definitions
example: 
```
 make find-unused-steps
Checked 901 step definitions against 5849 unique feature step texts.
Found 31 potentially unused step definitions:

GraphContext.php:889 [Given] the administrator has created a group :group using the Graph API
GraphContext.php:2615 [When] user :user switches the system language to :language using the Graph API
Provisioning.php:898 [When] user :user gets the list of all users using the provisioning API
.....
```

