### PR TITLE
fix: oidcHTTPClient now use proxy from environment

### DIFF
--- a/services/proxy/pkg/command/server.go
+++ b/services/proxy/pkg/command/server.go
@@ -104,6 +104,7 @@ func Server(cfg *config.Config) *cobra.Command {
 						InsecureSkipVerify: cfg.OIDC.Insecure, //nolint:gosec
 					},
 					DisableKeepAlives: true,
+					Proxy: http.ProxyFromEnvironment,
 				},
 				Timeout: time.Second * 10,
 			}
@@ -279,6 +280,7 @@ func loadMiddlewares(logger log.Logger, cfg *config.Config,
 				InsecureSkipVerify: cfg.OIDC.Insecure, //nolint:gosec
 			},
 			DisableKeepAlives: true,
+			Proxy: http.ProxyFromEnvironment,
 		},
 		Timeout: time.Second * 10,
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a change to OpenCloud!

For fixing potential security issues please see https://opencloud.eu/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the main branch which holds the next version of OpenCloud.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Update transport setting for oidcHTTPClient so it can use proxy setting from the environment. This can be required for systems with limited firewall access, so that oidc issuer can be reached via a proxy.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/opencloud-eu/opencloud/issues/3114

## Motivation and Context
Makes it possible to authenticate using external IdP when OpenCloud system needs to use a http proxy for outoing http requests.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Needed firewall rule for authentication with external IdP even though OpenCloud system was configured to use http proxy. Verified Firewall rule was no longer needed after applying patch.    

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added
