### PR TITLE
add fs extra to idp package

### DIFF
--- a/services/idp/package.json
+++ b/services/idp/package.json
@@ -61,6 +61,7 @@
     "css-minimizer-webpack-plugin": "^8.0.0",
     "dotenv": "17.4.2",
     "dotenv-expand": "^13.0.0",
+    "fs-extra": "^11.3.6",
     "gettext-parser": "^9.0.2",
     "html-webpack-plugin": "^5.6.7",
     "i18next-cli": "^1.65.0",

--- a/services/idp/pnpm-lock.yaml
+++ b/services/idp/pnpm-lock.yaml
@@ -108,6 +108,9 @@ importers:
       dotenv-expand:
         specifier: ^13.0.0
         version: 13.0.0
+      fs-extra:
+        specifier: ^11.3.6
+        version: 11.3.6
       gettext-parser:
         specifier: ^9.0.2
         version: 9.0.2
@@ -2769,6 +2772,10 @@ packages:
 
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
+
+  fs-extra@11.3.6:
+    resolution: {integrity: sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA==}
+    engines: {node: '>=14.14'}
 
   fs-extra@9.1.0:
     resolution: {integrity: sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==}
@@ -7973,6 +7980,12 @@ snapshots:
       mime-types: 2.1.35
 
   fraction.js@5.3.4: {}
+
+  fs-extra@11.3.6:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.2.1
+      universalify: 2.0.1
 
   fs-extra@9.1.0:
     dependencies:


### PR DESCRIPTION
I got error when `make generate` on fresh main branch

```
pnpm build
$ node --openssl-legacy-provider scripts/build.js && rm -f build/service-worker.js
◇ injected env (5) from .env // tip: ◈ encrypted .env [www.dotenvx.com]
node:internal/modules/cjs/loader:1404
  throw err;
  ^

Error: Cannot find module 'fs-extra'
Require stack:
- /Users/v.scharf/Work/opencloud/opencloud/services/idp/scripts/build.js
    at Function._resolveFilename (node:internal/modules/cjs/loader:1401:15)
    at defaultResolveImpl (node:internal/modules/cjs/loader:1057:19)
    at resolveForCJSWithHooks (node:internal/modules/cjs/loader:1062:22)
    at Function._load (node:internal/modules/cjs/loader:1211:37)
    at TracingChannel.traceSync (node:diagnostics_channel:322:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:235:24)
    at Module.require (node:internal/modules/cjs/loader:1487:12)
    at require (node:internal/modules/helpers:135:16)
    at Object.<anonymous> (/Users/v.scharf/Work/opencloud/opencloud/services/idp/scripts/build.js:20:12)
    at Module._compile (node:internal/modules/cjs/loader:1730:14) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/Users/v.scharf/Work/opencloud/opencloud/services/idp/scripts/build.js'
  ]
}

Node.js v22.15.0
[ELIFECYCLE] Command failed with exit code 1.
make[1]: *** [pnpm-build] Error 1
make: *** [generate-prod] Error 1
```

fixed it