### PR TITLE
fix(runtime): log service startup errors instead of printing them beside the log

### DIFF
--- a/opencloud/pkg/runtime/service/service.go
+++ b/opencloud/pkg/runtime/service/service.go
@@ -389,9 +389,16 @@ func Start(ctx context.Context, o ...Option) error {
 				if ev.Restarting {
 					l = s.Log.Error()
 				}
-				l.Str("event", e.String()).Str("service", ev.ServiceName).Str("supervisor", ev.SupervisorName).
-					Bool("restarting", ev.Restarting).Float64("failures", ev.CurrentFailures).Float64("threshold", ev.FailureThreshold).
-					Interface("error", ev.Err).Msg("service terminated")
+				l = l.Str("event", e.String()).Str("service", ev.ServiceName).Str("supervisor", ev.SupervisorName).
+					Bool("restarting", ev.Restarting).Float64("failures", ev.CurrentFailures).Float64("threshold", ev.FailureThreshold)
+				// ev.Err is an interface{}: marshaling an error yields {} because
+				// its fields are unexported, so the message has to go through Err
+				if err, ok := ev.Err.(error); ok {
+					l = l.Err(err)
+				} else {
+					l = l.Interface("error", ev.Err)
+				}
+				l.Msg("service terminated")
 			case suture.EventBackoff:
 				s.Log.Warn().Str("event", e.String()).Str("supervisor", ev.SupervisorName).Msg("service backoff")
 			case suture.EventResume:

--- a/pkg/clihelper/app.go
+++ b/pkg/clihelper/app.go
@@ -14,11 +14,17 @@ func DefaultApp(app *cobra.Command) *cobra.Command {
 	// version info
 	app.Version = fmt.Sprintf("%s (%s <%s>) (%s)", version.String, "OpenCloud GmbH", "support@opencloud.eu", version.Compiled())
 
-	// a failing RunE is a runtime error, not a usage error: printing it here
-	// would put unstructured text next to the JSON log records, and the usage
-	// block on top of it is noise. main() reports what reaches it.
+	// cobra would print the error on top of what main() already prints
 	app.SilenceErrors = true
-	app.SilenceUsage = true
+
+	// keep the usage block for flag parse errors, drop it once RunE runs.
+	// Traversing runs the hook even below a subcommand that brings its own,
+	// e.g. every service below ServiceCommand.
+	cobra.EnableTraverseRunHooks = true
+	app.PersistentPreRunE = func(cmd *cobra.Command, _ []string) error {
+		cmd.SilenceUsage = true
+		return nil
+	}
 
 	return app
 }

--- a/pkg/clihelper/app.go
+++ b/pkg/clihelper/app.go
@@ -14,5 +14,11 @@ func DefaultApp(app *cobra.Command) *cobra.Command {
 	// version info
 	app.Version = fmt.Sprintf("%s (%s <%s>) (%s)", version.String, "OpenCloud GmbH", "support@opencloud.eu", version.Compiled())
 
+	// a failing RunE is a runtime error, not a usage error: printing it here
+	// would put unstructured text next to the JSON log records, and the usage
+	// block on top of it is noise. main() reports what reaches it.
+	app.SilenceErrors = true
+	app.SilenceUsage = true
+
 	return app
 }


### PR DESCRIPTION
Service startup errors were printed as plain text into the log stream (`SilenceErrors`/`SilenceUsage` unset on the cobra app), and the one record about the failure carried `"error":{}` (suture's `ev.Err` is an `interface{}`, so it got marshaled instead of passed to `Err()`).

The example below is the schema mismatch error from #3098, but this is not specific to it: every startup error of every service has this shape.

before:

```
{"level":"warn","service":"proxy","time":"...","message":"No tls certificate provided, using a generated one"}
Error: manual action required: search index /var/lib/opencloud/search/bleve was built with a different schema:
  - field Deleted is explicitly mapped now, but the index already holds data that was indexed dynamically for it, of an unknown type
  [... 10 more ...]
There is no in-place migration: with the OpenCloud search service stopped, delete the index directory /var/lib/opencloud/search/bleve, then start it again ...
Usage:
  search server [flags]

Flags:
  -h, --help   help for server

{"level":"error","service":"opencloud","event":"opencloud: Failed service 'search' (1.000000 failures of 5.000000), restarting: true, error: manual action required: search index ...","service":"search","supervisor":"opencloud","restarting":true,"failures":1,"threshold":5,"error":{},"time":"...","message":"service terminated"}
```

after:

```
{"level":"error","service":"opencloud","event":"opencloud: Failed service 'search' (1.000000 failures of 5.000000), restarting: true, error: manual action required: search index ...","service":"search","supervisor":"opencloud","restarting":true,"failures":1,"threshold":5,"error":"manual action required: search index /var/lib/opencloud/search/bleve was built with a different schema:\n  - field Deleted is explicitly mapped now, but the index already holds data that was indexed dynamically for it, of an unknown type\n  [... 10 more ...]\nThere is no in-place migration: with the OpenCloud search service stopped, delete the index directory /var/lib/opencloud/search/bleve, then start it again ...","time":"...","message":"service terminated"}
```
