### PR TITLE
add header to release pr. remove 📦️ Dependencies from release descrip…

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -15,6 +15,7 @@ exclude_paths:
   - 'idp/src/**'
   - 'devtools/**'
   - 'deployments/**'
+  - "release-config.ts"
   - 'tests/acceptance/expected-failures-*.md'
   - 'tests/acceptance/bootstrap/**'
   - 'tests/acceptance/TestHelpers/**'

--- a/release-config.ts
+++ b/release-config.ts
@@ -73,6 +73,38 @@ export default {
     const latestTag = tags.pop() || "v0.0.0";
     return compareVersions(latestTag, nextVersion) === -1;
   },
+  getReleaseDescription: async ({ nextVersion }) => {
+    const note =
+      "> [!IMPORTANT]\n" +
+      "> This is a rolling release. Learn here about the [release types and lifecycle](https://docs.opencloud.eu/docs/admin/resources/lifecycle#release-types).\n\n";
+
+    // Exclude the "📦️ Dependencies" section from the release description
+    const section = removeChangelogSubsection(
+      await getChangelogSection(nextVersion),
+      "📦️ Dependencies"
+    );
+
+    return `${note}${section}`;
+  },
+};
+// helper functions
+const getChangelogSection = async (nextVersion: string) => {
+  const { promises: fs } = await import("fs");
+  const changelog = await fs.readFile("CHANGELOG.md", "utf-8").catch(() => "");
+
+  const section = changelog
+    .split(/\n(?=## \[)/)
+    .find((s) => s.startsWith(`## [${nextVersion}]`));
+
+  return section?.trim() ?? "";
+};
+
+const removeChangelogSubsection = (section: string, heading: string) => {
+  return section
+    .split(/\n(?=### )/)
+    .filter((s) => !s.startsWith(`### ${heading}`))
+    .join("\n")
+    .trim();
 };
 
 const parseVersion = (tag: string) => {


### PR DESCRIPTION
- [x] added header: `This is a rolling release. Learn here about the`
tested here: https://github.com/v-scharf/rrg-test/pull/2

  
  
  - Now we have header in PR, in release description- ✅️

<img width="720" height="361" alt="image" src="https://github.com/user-attachments/assets/6fd0e508-6e16-4bef-adbc-cf8bab205449" />


  -  but not in changelog - ✅️:
<img width="413" height="337" alt="image" src="https://github.com/user-attachments/assets/79038cca-3a0f-46c4-b181-e2feb04d5f27" />


- [x] excluded `📦️ Dependencies` from release pr and release description  -> but stills in changelog ✅️