### PR TITLE
fix(proxy): make OCS capabilities endpoint unprotected

### DIFF
--- a/services/proxy/pkg/config/defaults/defaultconfig.go
+++ b/services/proxy/pkg/config/defaults/defaultconfig.go
@@ -172,6 +172,18 @@ func DefaultPolicies() []config.Policy {
 					Service:     "eu.opencloud.web.frontend",
 					Unprotected: true,
 				},
+				{
+					// Capabilities must be readable by anonymous/unauthenticated
+					// clients: it's how a client discovers server capabilities
+					// (including auth-related ones) before it has ever
+					// authenticated. Without this, the general /ocs/ route below
+					// requires auth, and anonymous capabilities requests 401
+					// instead of returning the (public-safe) capabilities payload.
+					Type:        config.RegexRoute,
+					Endpoint:    "/ocs/v[12].php/cloud/capabilities",
+					Service:     "eu.opencloud.web.frontend",
+					Unprotected: true,
+				},
 				// OCM WAYF public endpoints
 				{
 					Endpoint:    "/sciencemesh/federations",


### PR DESCRIPTION
Anonymous/unauthenticated clients need to read /ocs/v[12].php/cloud/ capabilities before they've ever authenticated - it's how a client discovers server capabilities, including auth-related ones, in the first place. It fell through to the general /ocs/ policy route, which requires auth, so anonymous requests got a 401 instead of the (public-safe) capabilities payload.

Mirrors the existing precedent for /ocs/v[12].php/config a few lines above, which already carries Unprotected: true for the same reason.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)
