### PR TITLE
fix(idp): serve the real identifier app for welcome/goodbye/consent/chooseaccount

### DIFF
--- a/services/idp/pkg/service/v0/service.go
+++ b/services/idp/pkg/service/v0/service.go
@@ -292,10 +292,24 @@ func (idp *IDP) initMux(ctx context.Context, r []server.WithRoutes, h http.Handl
 		),
 	)
 
-	// handle / | index.html with a template that needs to have the BASE_PREFIX replaced
-	idp.mux.Get("/signin/v1/identifier", idp.Index())
-	idp.mux.Get("/signin/v1/identifier/", idp.Index())
-	idp.mux.Get("/signin/v1/identifier/index.html", idp.Index())
+	// handle / | index.html with a template that needs to have the BASE_PREFIX replaced.
+	//
+	// This covers every route the vendored lico library registers for its own
+	// built-in identifier webapp (vendor/github.com/libregraph/lico/identifier/identifier.go's
+	// `r.Handle("/<path>", i)` calls), not just "identifier" -- lico's own
+	// webappIndexHTML is only ever populated when IdentifierClientDisabled is
+	// false, which it never is here (that's the whole point of running our own,
+	// correctly-templated identifier app instead). Without an override, hitting
+	// any of these directly (e.g. after a SAML logout redirect, or a bookmarked
+	// URL) reached lico's handler, which serves that permanently-empty template:
+	// HTTP 200 with a literally empty body. All five are routes the identifier
+	// app's own client-side router (services/idp/src/Routes.jsx) recognizes, so
+	// serving our real index.html for them is all that's needed.
+	for _, path := range []string{"identifier", "chooseaccount", "consent", "welcome", "goodbye"} {
+		idp.mux.Get("/signin/v1/"+path, idp.Index())
+		idp.mux.Get("/signin/v1/"+path+"/", idp.Index())
+		idp.mux.Get("/signin/v1/"+path+"/index.html", idp.Index())
+	}
 
 	idp.mux.Mount("/", gm)
 


### PR DESCRIPTION
fix(idp): serve the real identifier app for welcome/goodbye/consent/chooseaccount

The vendored lico library registers /welcome, /goodbye, /consent, and /chooseaccount (alongside /identifier) as routes served by its own built-in identifier webapp
(vendor/github.com/libregraph/lico/identifier/identifier.go). That built-in webapp's index.html is only ever read from disk when IdentifierClientDisabled is false - but OpenCloud always runs with it true, since services/idp/pkg/service/v0/service.go's Index() serves our own, correctly-templated identifier app instead. Previously only /signin/v1/identifier (and its trailing-slash/index.html variants) was overridden this way; hitting any of the other four directly - a bookmarked URL, or a SAML logout redirect via
absoluteURLForRoute("goodbye") - reached lico's handler instead, which writes a permanently-empty webappIndexHTML: HTTP 200 with a literally empty body, and nothing rendered.

All five are routes the identifier app's own client-side router (services/idp/src/Routes.jsx) already recognizes, so serving our real index.html for all of them is enough to fix this.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)