### PR TITLE
fix(Dockerfile): run node-generate-prod from the repo root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ FROM quay.io/opencloudeu/nodejs-ci:24 AS generate
 
 COPY ./ /opencloud/
 
-WORKDIR /opencloud/opencloud
+WORKDIR /opencloud
 RUN make node-generate-prod
 
 FROM quay.io/opencloudeu/golang-ci:1.25 AS build


### PR DESCRIPTION
WORKDIR was set to /opencloud/opencloud before this RUN step, but node-generate-prod is only a real target in the repo-root Makefile (it fans out to every service's own node-generate-prod via $(MAKE) -C $$mod node-generate-prod). The nested opencloud/Makefile has no such target, so running from there does nothing - silently, because it's mistaken for an already-satisfied file target rather than erroring - and the resulting image ships without the web/idp frontend assets it was supposed to generate (services/idp/assets/ identifier/index.html in particular, which makes the idp service crash-loop with "Could not open index template").

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)