### PR TITLE
feat(posixfs): #3182 add basepath option in the "posixfs scan" command

### DIFF
--- a/opencloud/pkg/command/posixfs.go
+++ b/opencloud/pkg/command/posixfs.go
@@ -13,6 +13,7 @@ import (
 	"github.com/opencloud-eu/opencloud/pkg/config/configlog"
 	"github.com/opencloud-eu/opencloud/pkg/config/parser"
 	oclog "github.com/opencloud-eu/opencloud/pkg/log"
+	"github.com/opencloud-eu/opencloud/pkg/x/path/filepathx"
 	storageUsersParser "github.com/opencloud-eu/opencloud/services/storage-users/pkg/config/parser"
 	"github.com/opencloud-eu/opencloud/services/storage-users/pkg/event"
 	"github.com/opencloud-eu/opencloud/services/storage-users/pkg/revaconfig"
@@ -95,6 +96,39 @@ func scanCmd(ocCfg *config.Config) *cobra.Command {
 				os.Exit(1)
 			}
 
+			storageRoot := cfg.Drivers.Posix.Root
+			root := storageRoot
+			defaultRoot := true
+			if v, err := cmd.Flags().GetString("basepath"); err != nil {
+				fmt.Fprintf(os.Stderr, "Failed to parse command-line parameter '--basepath': %v\n", err)
+				os.Exit(1)
+			} else if v != "" {
+				root = v
+				if !filepath.IsAbs(v) {
+					if v, err = filepath.Abs(v); err != nil {
+						fmt.Fprintf(os.Stderr, "Failed to make the basepath mentioned using '--basepath' absolute: %v\n", err)
+						os.Exit(1)
+					} else {
+						root = v
+					}
+				} else {
+					root = v
+				}
+				root = filepath.Clean(root)
+				defaultRoot = false
+			}
+
+			// ensure that, if a basepath has been indicated, it is under the storage root
+			if !defaultRoot {
+				if contained, err := filepathx.IsSameOrContainedBy(storageRoot, root); err != nil {
+					fmt.Fprintf(os.Stderr, "Failed to determine whether the specified basepath %q is contained by the storage root %q: %v\n", root, storageRoot, err)
+					os.Exit(1)
+				} else if !contained {
+					fmt.Fprintf(os.Stderr, "The specified basepath %q is neither the storage root %q, nor a subdirectory thereof, nor a file underneath it\n", root, storageRoot)
+					os.Exit(1)
+				}
+			}
+
 			// We want to initialize the driver but disable scanfs on boot, so we can trigger it manually afterwards
 			drivers := revaconfig.StorageProviderDrivers(cfg)
 			drivers["posix"] = revaconfig.Posix(cfg, false, false)
@@ -111,6 +145,10 @@ func scanCmd(ocCfg *config.Config) *cobra.Command {
 				oclog.Level("error"),
 				oclog.Pretty(true),
 				oclog.Color(false)).Logger
+
+			if !defaultRoot {
+				log = log.With().Str("basepath", root).Logger()
+			}
 
 			f, ok := registry.NewFuncs["posix"]
 			if !ok {
@@ -130,8 +168,12 @@ func scanCmd(ocCfg *config.Config) *cobra.Command {
 				os.Exit(1)
 			}
 
-			fmt.Println("Starting posixfs scan...")
-			err = cacher.WarmupIDCache(cfg.Drivers.Posix.Root, true, false)
+			if defaultRoot {
+				fmt.Println("Starting posixfs scan...")
+			} else {
+				fmt.Printf("Starting posixfs scan at '%s'...\n", root)
+			}
+			err = cacher.WarmupIDCache(root, true, false)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Scan failed: %v\n", err)
 				return err
@@ -141,6 +183,7 @@ func scanCmd(ocCfg *config.Config) *cobra.Command {
 			return nil
 		},
 	}
+	cmd.Flags().StringP("basepath", "p", "", "the root under which to scan files, which may be a directory or a file (when omitted, detaults to using the storage root)")
 	return cmd
 }
 

--- a/pkg/x/path/filepathx/path.go
+++ b/pkg/x/path/filepathx/path.go
@@ -1,7 +1,9 @@
 package filepathx
 
 import (
+	"fmt"
 	"path/filepath"
+	"strings"
 )
 
 // JailJoin joins any number of path elements into a single path,
@@ -9,4 +11,28 @@ import (
 // and ensuring that the path is always under the jail.
 func JailJoin(jail string, elem ...string) string {
 	return filepath.Join(jail, filepath.Join(append([]string{"/"}, elem...)...))
+}
+
+// Determines whether the file or directory 'child' is same as or underneath the directory 'parent'.
+//
+// Note that 'parent' is expected to be a directory.
+func IsSameOrContainedBy(parent string, child string) (bool, error) {
+	absParent, err := filepath.Abs(parent)
+	if err != nil {
+		return false, fmt.Errorf("failed to make parent directory absolute: %q: %w", parent, err)
+	}
+
+	absChild, err := filepath.Abs(child)
+	if err != nil {
+		return false, fmt.Errorf("failed to make child file/directory absolute: %q: %w", child, err)
+	}
+
+	rel, err := filepath.Rel(absParent, absChild)
+	if err != nil {
+		return false, fmt.Errorf("failed to determine the relative path between the parent directory %q and the child file/directory: %q: %w", absParent, absChild, err)
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return false, nil
+	}
+	return true, nil
 }

--- a/pkg/x/path/filepathx/path_test.go
+++ b/pkg/x/path/filepathx/path_test.go
@@ -1,9 +1,12 @@
 package filepathx_test
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/opencloud-eu/opencloud/pkg/x/path/filepathx"
+	"github.com/stretchr/testify/require"
 )
 
 func TestJailJoin(t *testing.T) {
@@ -58,6 +61,26 @@ func TestJailJoin(t *testing.T) {
 			if got := filepathx.JailJoin(tt.args.jail, tt.args.elem...); got != tt.want {
 				t.Errorf("JailJoin() = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+func TestIsSameOrContainedBy(t *testing.T) {
+	for _, tt := range []struct {
+		parent   string
+		child    string
+		expected bool
+	}{
+		{"foo", "foo", true},
+		{"/foo", "/foo", true},
+		{"foo", "foo/bar", true},
+		{"foo", "bar", false},
+	} {
+		t.Run(fmt.Sprintf("%s: %s vs %s", t.Name(), strings.ReplaceAll(tt.parent, "/", "."), strings.ReplaceAll(tt.child, "/", ".")), func(t *testing.T) {
+			require := require.New(t)
+			b, err := filepathx.IsSameOrContainedBy(tt.parent, tt.child)
+			require.NoError(err)
+			require.Equal(tt.expected, b)
 		})
 	}
 }


### PR DESCRIPTION
<!--
Thanks for submitting a change to OpenCloud!

For fixing potential security issues please see https://opencloud.eu/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the main branch which holds the next version of OpenCloud.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Adds support for specifying a basepath using `-p` when running the `posixfs scan` command, to indicate a directory under which to start scanning, or a singular file to scan, as opposed to scanning from the storage root directory as is the default behaviour

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- implements https://github.com/opencloud-eu/opencloud/issues/3182

## Motivation and Context
In some scenarios, a system administrator might want to run the `posixfs scan` command under a specific subdirectory of the storage root instead of the whole tree under the storage root. This is made possible by specifying the basepath introduced with this change.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually in a local environment, by disabling posixfs watching (with `STORAGE_USERS_POSIX_WATCH_FS` set to `false`) and then copying files into the storage, checking that they had no xattrs set on them (using `getfattr -d`), running the `posixfs scan` command on them, both on individual files and on the containing directory, and then checking that OpenCloud posixfs metadata has been set on those files afterwards (again using `getfattr -d`).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added
