### PR TITLE
api-test: mark group last-manager removal scenario as flaky

### DIFF
--- a/tests/acceptance/bootstrap/SharingNgContext.php
+++ b/tests/acceptance/bootstrap/SharingNgContext.php
@@ -1031,19 +1031,7 @@ class SharingNgContext implements Context {
 			$this->featureContext->shareNgAddToCreatedUserGroupShares($this->getDrivePermissionsList($sharer, $space));
 			$permissionID = $this->featureContext->shareNgGetLastCreatedUserGroupShareID();
 		} elseif ($shareType == 'group' && !isset($recipient)) {
-			// https://github.com/opencloud-eu/opencloud/pull/3179#issuecomment-5103212045
-			$retried = 0;
-			do {
-				$response = $this->getDrivePermissionsList($sharer, $space);
-				$tryAgain = $response->getStatusCode() === 404
-				&& $retried < HttpRequestHelper::numRetriesOnHttpTooEarly();
-				if ($tryAgain) {
-					$retried += 1;
-					echo "Drive permissions of space '$space' not available for user '$sharer' yet, retrying ($retried)...\n";
-					// wait 500ms and try again
-					\usleep(500 * 1000);
-				}
-			} while ($tryAgain);
+			$response = $this->getDrivePermissionsList($sharer, $space);
 			$permissionID = $this->featureContext->getJsonDecodedResponse($response)['value'][0]['id'];
 		} else {
 			$permissionID = match ($shareType) {

--- a/tests/acceptance/features/apiSharingNg1/removeAccessToDrive.feature
+++ b/tests/acceptance/features/apiSharingNg1/removeAccessToDrive.feature
@@ -141,7 +141,7 @@ Feature: Remove access to a drive
     Then the HTTP status code should be "403"
     And the user "Alice" should have a space called "NewSpace"
 
-
+  @flaky @issue-3193
   Scenario: user of a group cannot remove own group from project space if it is the last manager using root endpoint
     Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And group "group1" has been created


### PR DESCRIPTION
related: #3193 and https://github.com/opencloud-eu/opencloud/pull/3179#issuecomment-5103212045
you can find fail here https://ci.opencloud.rocks/repos/3/pipeline/932/242 

retrying doesn't help -> create issue, mark test as flaky