### PR TITLE
Reindex spaces concurrently

### DIFF
--- a/services/search/pkg/config/config.go
+++ b/services/search/pkg/config/config.go
@@ -28,7 +28,7 @@ type Config struct {
 	Extractor                  Extractor             `yaml:"extractor"`
 	ContentExtractionSizeLimit uint64                `yaml:"content_extraction_size_limit" env:"SEARCH_CONTENT_EXTRACTION_SIZE_LIMIT" desc:"Maximum file size in bytes that is allowed for content extraction." introductionVersion:"1.0.0"`
 	BatchSize                  int                   `yaml:"batch_size" env:"SEARCH_BATCH_SIZE" desc:"The number of documents to process in a single batch. Defaults to 500." introductionVersion:"1.0.0"`
-	ReindexConcurrency         int                   `yaml:"reindex_concurrency" env:"SEARCH_REINDEX_CONCURRENCY" desc:"The maximum number of spaces that are reindexed concurrently when reindexing all spaces." introductionVersion:"%%NEXT%%"`
+	ReindexMaxConcurrency      int                   `yaml:"reindex_concurrency" env:"SEARCH_REINDEX_MAX_CONCURRENCY" desc:"The maximum number of spaces that are reindexed concurrently when reindexing all spaces." introductionVersion:"%%NEXT%%"`
 
 	ServiceAccount ServiceAccount `yaml:"service_account"`
 

--- a/services/search/pkg/config/config.go
+++ b/services/search/pkg/config/config.go
@@ -28,6 +28,7 @@ type Config struct {
 	Extractor                  Extractor             `yaml:"extractor"`
 	ContentExtractionSizeLimit uint64                `yaml:"content_extraction_size_limit" env:"SEARCH_CONTENT_EXTRACTION_SIZE_LIMIT" desc:"Maximum file size in bytes that is allowed for content extraction." introductionVersion:"1.0.0"`
 	BatchSize                  int                   `yaml:"batch_size" env:"SEARCH_BATCH_SIZE" desc:"The number of documents to process in a single batch. Defaults to 500." introductionVersion:"1.0.0"`
+	ReindexConcurrency         int                   `yaml:"reindex_concurrency" env:"SEARCH_REINDEX_CONCURRENCY" desc:"The maximum number of spaces that are reindexed concurrently when reindexing all spaces." introductionVersion:"%%NEXT%%"`
 
 	ServiceAccount ServiceAccount `yaml:"service_account"`
 

--- a/services/search/pkg/config/defaults/defaultconfig.go
+++ b/services/search/pkg/config/defaults/defaultconfig.go
@@ -65,6 +65,7 @@ func DefaultConfig() *config.Config {
 		},
 		ContentExtractionSizeLimit: 20 * 1024 * 1024, // Limit content extraction to <20MB files by default
 		BatchSize:                  50,
+		ReindexConcurrency:         3,
 	}
 }
 

--- a/services/search/pkg/config/defaults/defaultconfig.go
+++ b/services/search/pkg/config/defaults/defaultconfig.go
@@ -65,7 +65,7 @@ func DefaultConfig() *config.Config {
 		},
 		ContentExtractionSizeLimit: 20 * 1024 * 1024, // Limit content extraction to <20MB files by default
 		BatchSize:                  50,
-		ReindexConcurrency:         3,
+		ReindexMaxConcurrency:      3,
 	}
 }
 

--- a/services/search/pkg/service/grpc/v0/service.go
+++ b/services/search/pkg/service/grpc/v0/service.go
@@ -148,25 +148,21 @@ func (s Service) IndexSpace(_ context.Context, in *searchsvc.IndexSpaceRequest, 
 	// Index all spaces concurrently, limited to a configurable number of spaces
 	// being reindexed at the same time.
 	concurrency := max(s.cfg.ReindexConcurrency, 1)
-
-	g, gctx := errgroup.WithContext(ctx)
+	var g errgroup.Group
 	g.SetLimit(concurrency)
 
 	for _, space := range resp.GetStorageSpaces() {
-		// stop scheduling new work once one of the goroutines failed
-		if gctx.Err() != nil {
-			break
-		}
-
 		g.Go(func() error {
 			s.log.Info().Str("space_id", space.GetId().GetOpaqueId()).Msg("indexing space")
+
 			err := s.searcher.IndexSpace(space.GetId(), in.GetForceReindex())
 			if err != nil {
 				s.log.Error().Err(err).Str("space_id", space.GetId().GetOpaqueId()).Msg("failed to index space")
 			} else {
 				s.log.Info().Str("space_id", space.GetId().GetOpaqueId()).Msg("finished indexing space")
 			}
-			return err
+
+			return nil
 		})
 	}
 

--- a/services/search/pkg/service/grpc/v0/service.go
+++ b/services/search/pkg/service/grpc/v0/service.go
@@ -147,7 +147,7 @@ func (s Service) IndexSpace(_ context.Context, in *searchsvc.IndexSpaceRequest, 
 
 	// Index all spaces concurrently, limited to a configurable number of spaces
 	// being reindexed at the same time.
-	concurrency := max(s.cfg.ReindexConcurrency, 1)
+	concurrency := max(s.cfg.ReindexMaxConcurrency, 1)
 	var g errgroup.Group
 	g.SetLimit(concurrency)
 

--- a/services/search/pkg/service/grpc/v0/service.go
+++ b/services/search/pkg/service/grpc/v0/service.go
@@ -19,6 +19,7 @@ import (
 	"github.com/opencloud-eu/reva/v2/pkg/utils"
 	merrors "go-micro.dev/v4/errors"
 	"go-micro.dev/v4/metadata"
+	"golang.org/x/sync/errgroup"
 	grpcmetadata "google.golang.org/grpc/metadata"
 
 	"github.com/opencloud-eu/opencloud/pkg/log"
@@ -144,13 +145,32 @@ func (s Service) IndexSpace(_ context.Context, in *searchsvc.IndexSpaceRequest, 
 		return errors.New(resp.GetStatus().GetMessage())
 	}
 
+	// Index all spaces concurrently, limited to a configurable number of spaces
+	// being reindexed at the same time.
+	concurrency := max(s.cfg.ReindexConcurrency, 1)
+
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(concurrency)
+
 	for _, space := range resp.GetStorageSpaces() {
-		if err := s.searcher.IndexSpace(space.GetId(), in.GetForceReindex()); err != nil {
-			return err
+		// stop scheduling new work once one of the goroutines failed
+		if gctx.Err() != nil {
+			break
 		}
+
+		g.Go(func() error {
+			s.log.Info().Str("space_id", space.GetId().GetOpaqueId()).Msg("indexing space")
+			err := s.searcher.IndexSpace(space.GetId(), in.GetForceReindex())
+			if err != nil {
+				s.log.Error().Err(err).Str("space_id", space.GetId().GetOpaqueId()).Msg("failed to index space")
+			} else {
+				s.log.Info().Str("space_id", space.GetId().GetOpaqueId()).Msg("finished indexing space")
+			}
+			return err
+		})
 	}
 
-	return nil
+	return g.Wait()
 }
 
 // FromCache pulls a search result from cache


### PR DESCRIPTION
This speeds up reindexing all spaces which happend sequentially space after space until now. The level of concurrency can be configured using the SEARCH_REINDEX_CONCURRENCY env var (3 by default).