### PR TITLE
enhance: send events for adding/removing favourite items

### DIFF
--- a/services/clientlog/pkg/command/server.go
+++ b/services/clientlog/pkg/command/server.go
@@ -48,6 +48,8 @@ var _registeredEvents = []events.Unmarshaller{
 	events.LinkUpdated{},
 	events.LinkRemoved{},
 	events.BackchannelLogout{},
+	events.LabelAdded{},
+	events.LabelRemoved{},
 }
 
 // Server is the entrypoint for the server command.

--- a/services/clientlog/pkg/service/service.go
+++ b/services/clientlog/pkg/service/service.go
@@ -132,6 +132,11 @@ func (cl *ClientlogService) processEvent(event events.Event) {
 		users, data, err = processShareEvent(ctx, ref, gwc, event.InitiatorID, uid, gid)
 	}
 
+	labelEv := func(typ string, ref *provider.Reference, uid *user.UserId) {
+		evType = typ
+		users, data, err = processLabelEvent(ctx, ref, gwc, event.InitiatorID, uid)
+	}
+
 	spaceEv := func(typ string, id *provider.StorageSpaceId, uids []string) {
 		evType = typ
 		users, data, err = processSpaceEvent(ctx, id, gwc, event.InitiatorID, uids)
@@ -166,6 +171,10 @@ func (cl *ClientlogService) processEvent(event events.Event) {
 		fileEv("file-unlocked", e.Ref)
 	case events.FileTouched:
 		fileEv("file-touched", e.Ref)
+	case events.LabelAdded:
+		labelEv("item-favorite-added", e.Ref, e.UserID)
+	case events.LabelRemoved:
+		labelEv("item-favorite-removed", e.Ref, e.UserID)
 	case events.SpaceCreated:
 		spaceEv("space-created", e.ID, []string{e.Executant.GetOpaqueId()})
 	case events.SpaceDisabled:
@@ -253,6 +262,24 @@ func processFileEvent(ctx context.Context, ref *provider.Reference, gwc gateway.
 
 	users, err := utils.GetSpaceMembers(ctx, info.GetSpace().GetId().GetOpaqueId(), gwc, utils.ViewerRole)
 	return users, data, err
+}
+
+// process label (e.g. favorite) related events, notifying only the user the label belongs to
+func processLabelEvent(ctx context.Context, ref *provider.Reference, gwc gateway.GatewayAPIClient, initiatorid string, uid *user.UserId) ([]string, FileEvent, error) {
+	info, err := utils.GetResource(ctx, ref, gwc)
+	if err != nil {
+		return nil, FileEvent{}, err
+	}
+
+	data := FileEvent{
+		ParentItemID: storagespace.FormatResourceID(info.GetParentId()),
+		ItemID:       storagespace.FormatResourceID(info.GetId()),
+		SpaceID:      storagespace.FormatStorageID(info.GetSpace().GetRoot().GetStorageId(), info.GetSpace().GetRoot().GetSpaceId()),
+		InitiatorID:  initiatorid,
+		Etag:         info.GetEtag(),
+	}
+
+	return []string{uid.GetOpaqueId()}, data, nil
 }
 
 // process share related events


### PR DESCRIPTION
## Description
This PR may fix #2933 and provides the events for web UI being able to react on favourite events (as also reported in opencloud-eu/web#3016

Enhancement: Send SSE events when items are added to or removed from favourites

Currently, marking or unmarking a resource as a favourite does not notify connected web clients, so favourite state changes made in one browser tab or on another device only becomes visible after a manual reload. The graph service already published `LabelAdded`/`LabelRemoved` events on the event bus for this; the clientlog service now also consumes them and forwards `item-favorite-added`/`item-favorite-removed` SSE notifications to the affected user, mirroring how renames and moves are already announced.

## Related Issue
- Fixes or may fix #2933

## Motivation and Context
Making web UI react on favourite changes, backend needs to generate and send events.

## How Has This Been Tested?
- built dev-docker image
- checked `sse` browser connection of a logged-in user and watched for `item-favorite-removed` and `item-favorite-added` events

## Screenshots (if appropriate):
<img width="1894" height="79" alt="Screenshot 2026-08-03 at 15 16 45" src="https://github.com/user-attachments/assets/f5d65747-70fc-4c90-96bb-044d761e1455" />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added
