### PR TITLE
api-test: replace sleeps with WaitHelper poll for async state

### DIFF
--- a/tests/acceptance/TestHelpers/WaitHelper.php
+++ b/tests/acceptance/TestHelpers/WaitHelper.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types=1);
+/**
+ * @author Viktor Scharf OpenCloud GmbH <v.scharf@opencloud.eu>
+ * @copyright Copyright (c) 2026 OpenCloud GmbH <v.scharf@opencloud.eu>
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License,
+ * as published by the Free Software Foundation;
+ * either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace TestHelpers;
+
+/**
+ * Helper for waiting on asynchronous/eventually-consistent server state.
+ * @package TestHelpers
+ */
+class WaitHelper {
+	/**
+	 * Overall time to keep polling before giving up (seconds).
+	 */
+	public const TIMEOUT_SECONDS = 10;
+
+	/**
+	 * Pause between two attempts (milliseconds).
+	 */
+	public const INTERVAL_MS = 500;
+
+	/**
+	 * Repeat $makeAttempt until $shouldStop returns true or the timeout elapses.
+	 *
+	 * @param callable $makeAttempt  makes one attempt (e.g. sends a request) and returns its result
+	 * @param callable $shouldStop   receives that result, returns true to stop polling
+	 *
+	 * @return mixed the last result from $makeAttempt
+	 */
+	public static function waitUntil(callable $makeAttempt, callable $shouldStop): mixed {
+		$deadline = \microtime(true) + self::TIMEOUT_SECONDS;
+		$result = $makeAttempt();
+		while (!$shouldStop($result) && \microtime(true) < $deadline) {
+			\usleep(self::INTERVAL_MS * 1000);
+			$result = $makeAttempt();
+		}
+		return $result;
+	}
+}

--- a/tests/acceptance/TestHelpers/WaitHelper.php
+++ b/tests/acceptance/TestHelpers/WaitHelper.php
@@ -22,6 +22,7 @@ namespace TestHelpers;
 
 /**
  * Helper for waiting on asynchronous/eventually-consistent server state.
+ *
  * @package TestHelpers
  */
 class WaitHelper {

--- a/tests/acceptance/bootstrap/GraphContext.php
+++ b/tests/acceptance/bootstrap/GraphContext.php
@@ -18,6 +18,7 @@ use TestHelpers\WebDavHelper;
 use TestHelpers\HttpRequestHelper;
 use TestHelpers\BehatHelper;
 use TestHelpers\TokenHelper;
+use TestHelpers\WaitHelper;
 use Behat\Step\Given;
 use Behat\Step\Then;
 use Behat\Step\When;
@@ -2650,40 +2651,34 @@ class GraphContext implements Context {
 
 		$credentials = $this->getAdminOrUserCredentials($user);
 
-		// Sometimes listing shares might not return the updated shares list
-		// so try again until @client.synchronize is true for the max. number of retries (i.e. 10)
-		// and do not retry when the share is expected to be not synced
+		// Sometimes listing shares might not return the updated shares list, so poll
+		// until every share reports @client.synchronize (auto-synced). Do not wait
+		// when retry is disabled or when the user has auto-sync turned off, i.e. when
+		// the share is expected to be not synced.
 		$retryEnabled = ($retryOption === '');
-		$tryAgain = false;
-		$retried = 0;
-		do {
-			$response = GraphHelper::getSharesSharedWithMe(
+		$response = WaitHelper::waitUntil(
+			fn() => GraphHelper::getSharesSharedWithMe(
 				$this->featureContext->getBaseUrl(),
 				$this->featureContext->getStepLineRef(),
 				$credentials['username'],
 				$credentials['password']
-			);
-
-			$jsonBody = $this->featureContext->getJsonDecodedResponseBodyContent($response);
-
-			if ($retryEnabled) {
+			),
+			function ($response) use ($retryEnabled, $credentials) {
+				if (!$retryEnabled) {
+					return true;
+				}
+				if (!$this->featureContext->getUserAutoSyncSetting($credentials['username'])) {
+					return true;
+				}
+				$jsonBody = $this->featureContext->getJsonDecodedResponseBodyContent($response);
 				foreach ($jsonBody->value as $share) {
-					$autoSync = $this->featureContext->getUserAutoSyncSetting($credentials['username']);
-					$tryAgain = !$share->{'@client.synchronize'}
-					&& $autoSync
-					&& $retried < HttpRequestHelper::numRetriesOnHttpTooEarly();
-
-					if ($tryAgain) {
-						$retried += 1;
-						echo "auto-sync share for user '$user' is enabled\n";
-						echo "but share '$share->name' was not auto-synced, retrying ($retried)...\n";
-						// wait 500ms and try again
-						\usleep(500 * 1000);
-						break;
+					if (!$share->{'@client.synchronize'}) {
+						return false;
 					}
 				}
+				return true;
 			}
-		} while ($tryAgain);
+		);
 
 		$this->featureContext->setResponse($response);
 		$this->featureContext->pushToLastStatusCodesArrays();

--- a/tests/acceptance/bootstrap/GraphContext.php
+++ b/tests/acceptance/bootstrap/GraphContext.php
@@ -2657,7 +2657,7 @@ class GraphContext implements Context {
 		// the share is expected to be not synced.
 		$retryEnabled = ($retryOption === '');
 		$response = WaitHelper::waitUntil(
-			fn() => GraphHelper::getSharesSharedWithMe(
+			fn () => GraphHelper::getSharesSharedWithMe(
 				$this->featureContext->getBaseUrl(),
 				$this->featureContext->getStepLineRef(),
 				$credentials['username'],

--- a/tests/acceptance/bootstrap/SpacesContext.php
+++ b/tests/acceptance/bootstrap/SpacesContext.php
@@ -32,6 +32,7 @@ use TestHelpers\WebDavHelper;
 use TestHelpers\GraphHelper;
 use TestHelpers\OcHelper;
 use TestHelpers\BehatHelper;
+use TestHelpers\WaitHelper;
 use Behat\Step\Given;
 use Behat\Step\Then;
 use Behat\Step\When;
@@ -3856,15 +3857,26 @@ class SpacesContext implements Context {
 		string $spaceName,
 		TableNode $propertiesTable
 	): void {
-		// NOTE: extracting properties occurs asynchronously
-		// short wait is necessary before getting those properties
-		sleep(2);
+		// NOTE: extracting properties occurs asynchronously after upload, so we need to wait until the properties are available
 		$spaceId = $this->getSpaceIdByName($user, $spaceName);
-		$response = $this->webDavPropertiesContext->getPropertiesOfFolder(
-			$user,
-			$resourceName,
-			$spaceId,
-			$propertiesTable
+		$response = WaitHelper::waitUntil(
+			fn() => $this->webDavPropertiesContext->getPropertiesOfFolder(
+				$user,
+				$resourceName,
+				$spaceId,
+				$propertiesTable
+			),
+			function ($response) {
+				// check if the response body contains any of the extracted-property leaf names
+				$body = (string) $response->getBody();
+				$response->getBody()->rewind();
+				foreach (["camera-make", "latitude", "longitude", "album", "artist", "width", "height"] as $leaf) {
+					if (\str_contains($body, $leaf)) {
+						return true;
+					}
+				}
+				return false;
+			}
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -4544,16 +4556,26 @@ class SpacesContext implements Context {
 			$itemId = $this->getFileId($user, $space, $file);
 		}
 		$url = $this->featureContext->getBaseUrl() . "/graph/v1.0/drives/$spaceId/items/$itemId";
-		// NOTE: extracting properties occurs asynchronously
-		// short wait is necessary before getting those properties
-		sleep(2);
-		$this->featureContext->setResponse(
-			HttpRequestHelper::get(
+
+		// NOTE: extracting properties occurs asynchronously after upload, so we need to wait until the properties are available
+		$extractionFacets = ["image", "photo", "location", "audio", "video"];
+		$response = WaitHelper::waitUntil(
+			fn() => HttpRequestHelper::get(
 				$url,
 				$this->featureContext->getStepLineRef(),
 				$user,
 				$this->featureContext->getPasswordForUser($user),
-			)
+			),
+			function ($response) use ($extractionFacets) {
+				if ($response->getStatusCode() !== 200) {
+					return true;
+				}
+				$body = $this->featureContext->getJsonDecodedResponseBodyContent($response);
+				return \is_object($body)
+					&& !empty(\array_intersect($extractionFacets, \array_keys((array) $body)));
+			}
 		);
+
+		$this->featureContext->setResponse($response);
 	}
 }

--- a/tests/acceptance/bootstrap/SpacesContext.php
+++ b/tests/acceptance/bootstrap/SpacesContext.php
@@ -3860,7 +3860,7 @@ class SpacesContext implements Context {
 		// NOTE: extracting properties occurs asynchronously after upload, so we need to wait until the properties are available
 		$spaceId = $this->getSpaceIdByName($user, $spaceName);
 		$response = WaitHelper::waitUntil(
-			fn() => $this->webDavPropertiesContext->getPropertiesOfFolder(
+			fn () => $this->webDavPropertiesContext->getPropertiesOfFolder(
 				$user,
 				$resourceName,
 				$spaceId,
@@ -4560,7 +4560,7 @@ class SpacesContext implements Context {
 		// NOTE: extracting properties occurs asynchronously after upload, so we need to wait until the properties are available
 		$extractionFacets = ["image", "photo", "location", "audio", "video"];
 		$response = WaitHelper::waitUntil(
-			fn() => HttpRequestHelper::get(
+			fn () => HttpRequestHelper::get(
 				$url,
 				$this->featureContext->getStepLineRef(),
 				$user,

--- a/tests/acceptance/bootstrap/TUSContext.php
+++ b/tests/acceptance/bootstrap/TUSContext.php
@@ -33,6 +33,7 @@ use TestHelpers\HttpRequestHelper;
 use TestHelpers\WebDavHelper;
 use TestHelpers\BehatHelper;
 use TestHelpers\UploadHelper;
+use TestHelpers\WaitHelper;
 use Behat\Step\Given;
 use Behat\Step\When;
 
@@ -238,22 +239,10 @@ class TUSContext implements Context {
 	): void {
 		$resourceLocation = $this->getLastTusResourceLocation();
 
-		$retried = 0;
-		do {
-			$tryAgain = false;
-			$response = $this->uploadChunkToTUSLocation($user, $resourceLocation, $offset, $data);
-			// retry on 409 Conflict (Offset mismatch during TUS upload)
-			if ($response->getStatusCode() === 409) {
-				$tryAgain = true;
-			}
-			$tryAgain = $tryAgain && $retried < HttpRequestHelper::numRetriesOnHttpTooEarly();
-			if ($tryAgain) {
-				$retried += 1;
-				echo "Offset mismatch during TUS upload, retrying ($retried)...\n";
-				// wait 1s and try again
-				\sleep(1);
-			}
-		} while ($tryAgain);
+		$response = WaitHelper::waitUntil(
+			fn() => $this->uploadChunkToTUSLocation($user, $resourceLocation, $offset, $data),
+			fn($response) => $response->getStatusCode() !== 409
+		);
 		$this->featureContext->setResponse($response);
 	}
 

--- a/tests/acceptance/bootstrap/TUSContext.php
+++ b/tests/acceptance/bootstrap/TUSContext.php
@@ -240,8 +240,8 @@ class TUSContext implements Context {
 		$resourceLocation = $this->getLastTusResourceLocation();
 
 		$response = WaitHelper::waitUntil(
-			fn() => $this->uploadChunkToTUSLocation($user, $resourceLocation, $offset, $data),
-			fn($response) => $response->getStatusCode() !== 409
+			fn () => $this->uploadChunkToTUSLocation($user, $resourceLocation, $offset, $data),
+			fn ($response) => $response->getStatusCode() !== 409
 		);
 		$this->featureContext->setResponse($response);
 	}


### PR DESCRIPTION
fixed: 
```
[FAILED] Total unexpected failed scenarios:
- apiSearchContent/extractedProps.feature:298
- apiSearchContent/extractedProps.feature:426
```
Tests were failed because property extraction is asynchronous and `sleep(2)` didn't help

- Replaced to `TestHelpers/WaitHelper::waitUntil($makeAttempt, $shouldStop)` a small poll primitive (the PHP analogue of Playwright's expect.poll/toPass) that retries until the awaited state appears or a timeout elapses, then returns the last result - analog https://playwright.dev/docs/test-assertions#expectpoll and https://playwright.dev/docs/test-assertions#expecttopass

```
Scenario: GET extracted properties of an image file (Shares space)                                             # /woodpecker/src/github.com/opencloud-eu/opencloud/tests/acceptance/features/apiSearchContent/extractedProps.feature:426
    Given user "Brian" has been created with default attributes                                                  # FeatureContext::userHasBeenCreatedWithDefaultAttributes()
    And user "Alice" has uploaded a file "filesForUpload/testavatar.jpg" to "testavatar.jpg" in space "Personal" # SpacesContext::userHasUploadedAFileToInSpaceUsingTheWebdavApi()
    And user "Alice" has sent the following resource share invitation:                                           # SharingNgContext::userHasSentTheFollowingResourceShareInvitation()
      | resource        | testavatar.jpg |
      | space           | Personal       |
      | sharee          | Brian          |
      | shareType       | user           |
      | permissionsRole | Viewer         |
    And user "Brian" has a share "testavatar.jpg" synced                                                         # SharingNgContext::userHasShareSynced()
      │ [INFO] Wait for share sync status...
    When user "Brian" gets the file "testavatar.jpg" from space "Shares" using the Graph API                     # SpacesContext::userGetsTheDriveItemInSpace()
    Then the HTTP status code should be "200"                                                                    # FeatureContext::thenTheHTTPStatusCodeShouldBe()
    And the JSON data of the response should match                                                               # FeatureContext::theJsonDataOfTheResponseShouldMatch()
      """
        {
          "type": "object",
          "required": [
            "image",
            "location",
            "photo"
          ],
          "properties": {
            "image": {
              "type": "object",
              "required": [ "height", "width" ],
              "properties": {
                "height": {
                  "const": 500
                },
                "width": {
                  "const": 1402
                }
              }
            },
            "location": {
              "type": "object",
              "required": [ "latitude", "longitude" ],
              "properties": {
                "latitude": {
                  "const": 52.437804
                },
                "longitude": {
                  "const": 13.341866
                }
              }
            },
            "photo": {
              "type": "object",
              "required": [
                "cameraMake",
                "cameraModel",
                "fNumber",
                "focalLength",
                "orientation"
              ],
              "properties": {
                "cameraMake": {
                  "const": "NIKON"
                },
                "cameraModel": {
                  "const": "COOLPIX P6000"
                },
                "fNumber": {
                  "const": 4.5
                },
                "focalLength": {
                  "const": 6
                },
                "orientation": {
                  "const": 1
                }
              }
            }
          }
        }
      """
      JSON Schema validation failed:
      1. {root}->required:
      	 - Required property missing: id
      	   Received: eTag, file, id, lastModifiedDateTime, name, parentReference, size, webUrl

```