### PR TITLE
feat(web): add yjsServerUrl config

### DIFF
--- a/services/web/pkg/config/options.go
+++ b/services/web/pkg/config/options.go
@@ -22,6 +22,7 @@ type Options struct {
 	ConcurrentRequests     *ConcurrentRequests `json:"concurrentRequests,omitempty" yaml:"concurrentRequests"`
 	DefaultAppID           string              `json:"defaultAppId,omitempty" yaml:"defaultAppId" env:"WEB_OPTION_DEFAULT_APP_ID" desc:"Defines the entrypoint for the web ui." introductionVersion:"4.0.0"`
 	OxAppSuite             *OxAppSuite         `json:"oxAppSuite,omitempty" yaml:"oxAppSuite"`
+	YjsServerUrl           string              `json:"yjsServerUrl,omitempty" yaml:"yjsServerUrl" env:"WEB_OPTION_YJS_SERVER_URL" desc:"The URL of the Yjs server used for collaborative editing. This feature is disabled as long as no URL is given." introductionVersion:"7.5.0"`
 }
 
 // Announcement is a banner message shown above the top bar to all users. It is managed at runtime


### PR DESCRIPTION
This config specifies a URL for a yjs server (e.g. hocuspocus) that is used for document collaboration in web apps (e.g. tiptap editor, excalidraw, ...). It's optional, not setting this disables this feature in Web.

refs https://github.com/opencloud-eu/web/issues/3033, groundwork for https://github.com/opencloud-eu/web/pull/2785