### PR TITLE
refactor(config): extract BindSourcesToStructs into pkg/config/binder

### DIFF
--- a/pkg/config/binder/binder.go
+++ b/pkg/config/binder/binder.go
@@ -1,0 +1,53 @@
+// Package binder binds OpenCloud yaml config files to config structs, as a leaf
+// package that avoids importing the aggregate service config in pkg/config.
+package binder
+
+import (
+	"io/fs"
+	"os"
+	"path"
+	"strings"
+
+	gofig "github.com/gookit/config/v2"
+	gooyaml "github.com/gookit/config/v2/yaml"
+	"github.com/opencloud-eu/opencloud/pkg/config/defaults"
+)
+
+// decoderConfigTagName sets the tag name to be used from the config structs
+// currently we only support "yaml" because we only support config loading
+// from yaml files and the yaml parser has no simple way to set a custom tag name to use
+var decoderConfigTagName = "yaml"
+
+// BindSourcesToStructs assigns any config value from a config file / env variable to struct `dst`.
+func BindSourcesToStructs(service string, dst any) error {
+	fileSystem := os.DirFS("/")
+	filePath := strings.TrimLeft(path.Join(defaults.BaseConfigPath(), service+".yaml"), "/")
+	return BindSourcesToStructsFS(fileSystem, filePath, service, dst)
+}
+
+// BindSourcesToStructsFS is like BindSourcesToStructs but reads from the given fs.FS and path.
+func BindSourcesToStructsFS(fileSystem fs.FS, filePath, service string, dst any) error {
+	cnf := gofig.NewWithOptions(service)
+	cnf.WithOptions(func(options *gofig.Options) {
+		options.ParseEnv = true
+		options.DecoderConfig.TagName = decoderConfigTagName
+	})
+	cnf.AddDriver(gooyaml.Driver)
+
+	yamlContent, err := fs.ReadFile(fileSystem, filePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+
+		return err
+	}
+	_ = cnf.LoadSources("yaml", yamlContent)
+
+	err = cnf.BindStruct("", &dst)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/config/binder/binder.go
+++ b/pkg/config/binder/binder.go
@@ -16,7 +16,7 @@ import (
 // decoderConfigTagName sets the tag name to be used from the config structs
 // currently we only support "yaml" because we only support config loading
 // from yaml files and the yaml parser has no simple way to set a custom tag name to use
-var decoderConfigTagName = "yaml"
+const decoderConfigTagName = "yaml"
 
 // BindSourcesToStructs assigns any config value from a config file / env variable to struct `dst`.
 func BindSourcesToStructs(service string, dst any) error {
@@ -42,6 +42,8 @@ func BindSourcesToStructsFS(fileSystem fs.FS, filePath, service string, dst any)
 
 		return err
 	}
+	// the error is ignored on purpose, matching the pre-extraction behavior:
+	// an unparseable yaml file binds nothing instead of failing the startup
 	_ = cnf.LoadSources("yaml", yamlContent)
 
 	err = cnf.BindStruct("", &dst)

--- a/pkg/config/binder/binder_test.go
+++ b/pkg/config/binder/binder_test.go
@@ -14,11 +14,13 @@ type TestConfig struct {
 }
 
 func TestBindSourcesToStructs(t *testing.T) {
-	// setup test env
+	// setup test env: one var set to pin env expansion, two deliberately
+	// unset to pin the defaults
+	t.Setenv("BINDER_TEST_SET_VAR", "from-env")
 	yaml := `
-a: "${FOO_VAR|no-foo}"
-b: "${BAR_VAR|no-bar}"
-c: "${CODE_VAR|code}"
+a: "${BINDER_TEST_SET_VAR|no-foo}"
+b: "${BINDER_TEST_UNSET_VAR|no-bar}"
+c: "${BINDER_TEST_OTHER_UNSET_VAR|code}"
 `
 	filePath := "etc/opencloud/foo.yaml"
 	fs := fstest.MapFS{
@@ -31,7 +33,7 @@ c: "${CODE_VAR|code}"
 		t.Error(err)
 	}
 
-	assert.Equal(t, c.A, "no-foo")
+	assert.Equal(t, c.A, "from-env")
 	assert.Equal(t, c.B, "no-bar")
 	assert.Equal(t, c.C, "code")
 }

--- a/pkg/config/binder/binder_test.go
+++ b/pkg/config/binder/binder_test.go
@@ -1,0 +1,53 @@
+package binder
+
+import (
+	"testing"
+	"testing/fstest"
+
+	"gotest.tools/v3/assert"
+)
+
+type TestConfig struct {
+	A string `yaml:"a"`
+	B string `yaml:"b"`
+	C string `yaml:"c"`
+}
+
+func TestBindSourcesToStructs(t *testing.T) {
+	// setup test env
+	yaml := `
+a: "${FOO_VAR|no-foo}"
+b: "${BAR_VAR|no-bar}"
+c: "${CODE_VAR|code}"
+`
+	filePath := "etc/opencloud/foo.yaml"
+	fs := fstest.MapFS{
+		filePath: {Data: []byte(yaml)},
+	}
+	// perform test
+	c := TestConfig{}
+	err := BindSourcesToStructsFS(fs, filePath, "foo", &c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	assert.Equal(t, c.A, "no-foo")
+	assert.Equal(t, c.B, "no-bar")
+	assert.Equal(t, c.C, "code")
+}
+
+func TestBindSourcesToStructs_UnknownFile(t *testing.T) {
+	// setup test env
+	filePath := "etc/opencloud/foo.yaml"
+	fs := fstest.MapFS{}
+	// perform test
+	c := TestConfig{}
+	err := BindSourcesToStructsFS(fs, filePath, "foo", &c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	assert.Equal(t, c.A, "")
+	assert.Equal(t, c.B, "")
+	assert.Equal(t, c.C, "")
+}

--- a/pkg/config/helpers.go
+++ b/pkg/config/helpers.go
@@ -1,55 +1,14 @@
 package config
 
 import (
-	"io/fs"
-	"os"
-	"path"
 	"strings"
 
-	gofig "github.com/gookit/config/v2"
-	gooyaml "github.com/gookit/config/v2/yaml"
-	"github.com/opencloud-eu/opencloud/pkg/config/defaults"
-)
-
-var (
-	// decoderConfigTagName sets the tag name to be used from the config structs
-	// currently we only support "yaml" because we only support config loading
-	// from yaml files and the yaml parser has no simple way to set a custom tag name to use
-	decoderConfigTagName = "yaml"
+	"github.com/opencloud-eu/opencloud/pkg/config/binder"
 )
 
 // BindSourcesToStructs assigns any config value from a config file / env variable to struct `dst`.
-func BindSourcesToStructs(service string, dst any) error {
-	fileSystem := os.DirFS("/")
-	filePath := strings.TrimLeft(path.Join(defaults.BaseConfigPath(), service+".yaml"), "/")
-	return bindSourcesToStructs(fileSystem, filePath, service, dst)
-}
-
-func bindSourcesToStructs(fileSystem fs.FS, filePath, service string, dst any) error {
-	cnf := gofig.NewWithOptions(service)
-	cnf.WithOptions(func(options *gofig.Options) {
-		options.ParseEnv = true
-		options.DecoderConfig.TagName = decoderConfigTagName
-	})
-	cnf.AddDriver(gooyaml.Driver)
-
-	yamlContent, err := fs.ReadFile(fileSystem, filePath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-
-		return err
-	}
-	_ = cnf.LoadSources("yaml", yamlContent)
-
-	err = cnf.BindStruct("", &dst)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
+// Backward-compatible re-export; the implementation lives in pkg/config/binder.
+var BindSourcesToStructs = binder.BindSourcesToStructs
 
 // LocalEndpoint returns the local endpoint for a given protocol and address.
 // Use it when configuring the reva runtime to get a service endpoint in the same

--- a/pkg/config/helpers.go
+++ b/pkg/config/helpers.go
@@ -7,8 +7,10 @@ import (
 )
 
 // BindSourcesToStructs assigns any config value from a config file / env variable to struct `dst`.
-// Backward-compatible re-export; the implementation lives in pkg/config/binder.
-var BindSourcesToStructs = binder.BindSourcesToStructs
+// The implementation lives in pkg/config/binder.
+func BindSourcesToStructs(service string, dst any) error {
+	return binder.BindSourcesToStructs(service, dst)
+}
 
 // LocalEndpoint returns the local endpoint for a given protocol and address.
 // Use it when configuring the reva runtime to get a service endpoint in the same

--- a/pkg/config/helpers_test.go
+++ b/pkg/config/helpers_test.go
@@ -4,53 +4,9 @@ import (
 	"testing"
 	"testing/fstest"
 
+	"github.com/opencloud-eu/opencloud/pkg/config/binder"
 	"gotest.tools/v3/assert"
 )
-
-type TestConfig struct {
-	A string `yaml:"a"`
-	B string `yaml:"b"`
-	C string `yaml:"c"`
-}
-
-func TestBindSourcesToStructs(t *testing.T) {
-	// setup test env
-	yaml := `
-a: "${FOO_VAR|no-foo}"
-b: "${BAR_VAR|no-bar}"
-c: "${CODE_VAR|code}"
-`
-	filePath := "etc/opencloud/foo.yaml"
-	fs := fstest.MapFS{
-		filePath: {Data: []byte(yaml)},
-	}
-	// perform test
-	c := TestConfig{}
-	err := bindSourcesToStructs(fs, filePath, "foo", &c)
-	if err != nil {
-		t.Error(err)
-	}
-
-	assert.Equal(t, c.A, "no-foo")
-	assert.Equal(t, c.B, "no-bar")
-	assert.Equal(t, c.C, "code")
-}
-
-func TestBindSourcesToStructs_UnknownFile(t *testing.T) {
-	// setup test env
-	filePath := "etc/opencloud/foo.yaml"
-	fs := fstest.MapFS{}
-	// perform test
-	c := TestConfig{}
-	err := bindSourcesToStructs(fs, filePath, "foo", &c)
-	if err != nil {
-		t.Error(err)
-	}
-
-	assert.Equal(t, c.A, "")
-	assert.Equal(t, c.B, "")
-	assert.Equal(t, c.C, "")
-}
 
 func TestBindSourcesToStructs_NoEnvVar(t *testing.T) {
 	// setup test env
@@ -180,7 +136,7 @@ clientlog:
 	}
 	// perform test
 	c := Config{}
-	err := bindSourcesToStructs(fs, filePath, "foo", &c)
+	err := binder.BindSourcesToStructsFS(fs, filePath, "foo", &c)
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
Move `BindSourcesToStructs` into a new leaf package `pkg/config/binder` (depends only on gookit + `pkg/config/defaults`), so code that only needs to bind a yaml config file can import it without pulling in the aggregate service config in `pkg/config`.

`pkg/config` keeps a backward-compatible re-export, so existing callers are unchanged.

### Why

This lets third-party services, like my [opencloud-music](https://github.com/dschmidt/opencloud-music), adopt the exact same config pattern as OpenCloud itself (config structs + yaml/env binding) without pulling in the whole OpenCloud dependency tree.

For comparison you can look at https://github.com/dragotin/opencloud-immichframe/pull/1
All the deps in go.mod/sum are added just to use BindSourcesToStructs from OpenCloud. With this go.mod becomes a two line change (or so)