### PR TITLE
allow tuning the proxies http client

### DIFF
--- a/services/proxy/pkg/config/defaults/defaultconfig.go
+++ b/services/proxy/pkg/config/defaults/defaultconfig.go
@@ -35,6 +35,16 @@ func DefaultConfig() *config.Config {
 			TLSCert:   path.Join(defaults.BaseDataPath(), "proxy", "server.crt"),
 			TLSKey:    path.Join(defaults.BaseDataPath(), "proxy", "server.key"),
 			TLS:       true,
+			Client: config.Client{
+				ForceAttemptHTTP2:     false,
+				DialTimeout:           30 * time.Second,
+				DialKeepAlive:         30 * time.Second,
+				MaxIdleConns:          100,
+				MaxIdleConnsPerHost:   100,
+				IdleConnTimeout:       90 * time.Second,
+				TLSHandshakeTimeout:   10 * time.Second,
+				ExpectContinueTimeout: 1 * time.Second,
+			},
 		},
 		Service: config.Service{
 			Name: "proxy",

--- a/services/proxy/pkg/config/http.go
+++ b/services/proxy/pkg/config/http.go
@@ -1,5 +1,7 @@
 package config
 
+import "time"
+
 // HTTP defines the available http configuration.
 type HTTP struct {
 	Addr      string `yaml:"addr" env:"PROXY_HTTP_ADDR" desc:"The bind address of the HTTP service." introductionVersion:"1.0.0"`
@@ -8,4 +10,16 @@ type HTTP struct {
 	TLSCert   string `yaml:"tls_cert" env:"PROXY_TRANSPORT_TLS_CERT" desc:"Path/File name of the TLS server certificate (in PEM format) for the external http services. If not defined, the root directory derives from $OC_BASE_DATA_PATH/proxy." introductionVersion:"1.0.0"`
 	TLSKey    string `yaml:"tls_key" env:"PROXY_TRANSPORT_TLS_KEY" desc:"Path/File name for the TLS certificate key (in PEM format) for the server certificate to use for the external http services. If not defined, the root directory derives from $OC_BASE_DATA_PATH/proxy." introductionVersion:"1.0.0"`
 	TLS       bool   `yaml:"tls" env:"PROXY_TLS" desc:"Enable/Disable HTTPS for external HTTP services. Must be set to 'true' if the built-in IDP service and no reverse proxy is used. See the text description for details." introductionVersion:"1.0.0"`
+	Client    Client `yaml:"client"`
+}
+
+type Client struct {
+	DialTimeout           time.Duration `yaml:"dial_timeout" env:"PROXY_TRANSPORT_CLIENT_DIAL_TIMEOUT" desc:"Dial timeout for the HTTP client." introductionVersion:"%NEXT%"`
+	DialKeepAlive         time.Duration `yaml:"dial_keep_alive" env:"PROXY_TRANSPORT_CLIENT_DIAL_KEEP_ALIVE" desc:"Dial keep alive for the HTTP client." introductionVersion:"%NEXT%"`
+	ForceAttemptHTTP2     bool          `yaml:"force_attempt_http2" env:"PROXY_TRANSPORT_CLIENT_FORCE_ATTEMPT_HTTP2" desc:"Force attempt HTTP/2 for the HTTP client. Set to true if backend communication is encrypted and HTTP/2 is desired." introductionVersion:"%NEXT%"`
+	MaxIdleConns          int           `yaml:"max_idle_conns" env:"PROXY_TRANSPORT_CLIENT_MAX_IDLE_CONNS" desc:"Maximum idle connections for the HTTP client." introductionVersion:"%NEXT%"`
+	MaxIdleConnsPerHost   int           `yaml:"max_idle_conns_per_host" env:"PROXY_TRANSPORT_CLIENT_MAX_IDLE_CONNS_PER_HOST" desc:"Maximum idle connections per host for the HTTP client." introductionVersion:"%NEXT%"`
+	IdleConnTimeout       time.Duration `yaml:"idle_conn_timeout" env:"PROXY_TRANSPORT_CLIENT_IDLE_CONN_TIMEOUT" desc:"Idle connection timeout for the HTTP client." introductionVersion:"%NEXT%"`
+	TLSHandshakeTimeout   time.Duration `yaml:"tls_handshake_timeout" env:"PROXY_TRANSPORT_CLIENT_TLS_HANDSHAKE_TIMEOUT" desc:"TLS handshake timeout for the HTTP client." introductionVersion:"%NEXT%"`
+	ExpectContinueTimeout time.Duration `yaml:"expect_continue_timeout" env:"PROXY_TRANSPORT_CLIENT_EXPECT_CONTINUE_TIMEOUT" desc:"Expect continue timeout for the HTTP client." introductionVersion:"%NEXT%"`
 }

--- a/services/proxy/pkg/proxy/proxy.go
+++ b/services/proxy/pkg/proxy/proxy.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"os"
-	"time"
 
 	"github.com/opencloud-eu/opencloud/pkg/log"
 	"github.com/opencloud-eu/opencloud/services/proxy/pkg/config"
@@ -67,7 +66,7 @@ func NewMultiHostReverseProxy(opts ...Option) (*MultiHostReverseProxy, error) {
 			return nil, err
 		}
 		if !certs.AppendCertsFromPEM(pemData) {
-			return nil, errors.New("Error initializing LDAP Backend. Adding CA cert failed")
+			return nil, errors.New("Error initializing Proxy. Adding CA cert failed")
 		}
 		tlsConf.RootCAs = certs
 	}
@@ -75,15 +74,15 @@ func NewMultiHostReverseProxy(opts ...Option) (*MultiHostReverseProxy, error) {
 	rp.Transport = &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
 		DialContext: (&net.Dialer{
-			Timeout:   30 * time.Second,
-			KeepAlive: 30 * time.Second,
-			DualStack: true,
+			Timeout:   options.Config.HTTP.Client.DialTimeout,
+			KeepAlive: options.Config.HTTP.Client.DialKeepAlive,
 		}).DialContext,
-		ForceAttemptHTTP2:     true,
-		MaxIdleConns:          100,
-		IdleConnTimeout:       90 * time.Second,
-		TLSHandshakeTimeout:   10 * time.Second,
-		ExpectContinueTimeout: 1 * time.Second,
+		ForceAttemptHTTP2:     options.Config.HTTP.Client.ForceAttemptHTTP2,
+		MaxIdleConns:          options.Config.HTTP.Client.MaxIdleConns,
+		MaxIdleConnsPerHost:   options.Config.HTTP.Client.MaxIdleConnsPerHost,
+		IdleConnTimeout:       options.Config.HTTP.Client.IdleConnTimeout,
+		TLSHandshakeTimeout:   options.Config.HTTP.Client.TLSHandshakeTimeout,
+		ExpectContinueTimeout: options.Config.HTTP.Client.ExpectContinueTimeout,
 		TLSClientConfig:       tlsConf,
 	}
 	return rp, nil


### PR DESCRIPTION
Seeing blocking requests under high load we revisited the http client configuration used by our proxy. Currently, our internal connections use http1.1 by default because backend traffic to other services is not encrypted. That is why we change two defaults:
1. `ForceAttemptHTTP2` is now disabled. It just creates connection establishment overhead. When backend traffic to opencloud services is not limited to localhost AND is encrypted this should be enabled.
2. `MaxIdleConnsPerHost`  is now increased from the default 2 to 100 as the proxy otherwise cannot reuse the already established http 1.1 connections.

All other client options that were previously hardcoded can now also be tuned.
