### PR TITLE
Fix proxy middleware race

### DIFF
--- a/services/proxy/pkg/middleware/oidc_auth.go
+++ b/services/proxy/pkg/middleware/oidc_auth.go
@@ -104,13 +104,15 @@ func (m *OIDCAuthenticator) getClaims(token string, req *http.Request) (map[stri
 	expiration := m.extractExpiration(aClaims)
 	// always set an exp claim
 	claims["exp"] = expiration.Unix()
-	go func() {
-		d, err := msgpack.Marshal(claims)
-		if err != nil {
-			m.Logger.Error().Err(err).Msg("failed to marshal claims for userinfo cache")
-			return
-		}
 
+	d, err := msgpack.Marshal(claims)
+	if err != nil {
+		m.Logger.Error().Err(err).Msg("failed to marshal claims for userinfo cache")
+
+		return claims, true, nil
+	}
+
+	go func() {
 		err = m.userInfoCache.Write(&store.Record{
 			Key:    encodedHash,
 			Value:  d,


### PR DESCRIPTION
## Description
```bash
go test -race ./services/proxy/pkg/middleware/

Will run 22 of 22 specs
•••••==================
WARNING: DATA RACE
Write at 0x00c000401740 by goroutine 123:
  runtime.mapaccess2_faststr()
      /Users/fschade/.local/share/mise/installs/go/1.26.5/src/internal/runtime/maps/runtime_faststr.go:161 +0x2ac
  github.com/opencloud-eu/opencloud/services/proxy/pkg/middleware.(*OIDCAuthenticator).getClaims()
      /Users/fschade/Developer/fschade/opencloud/services/proxy/pkg/middleware/oidc_auth.go:105 +0x7ac
  github.com/opencloud-eu/opencloud/services/proxy/pkg/middleware.(*OIDCAuthenticator).Authenticate()
      /Users/fschade/Developer/fschade/opencloud/services/proxy/pkg/middleware/oidc_auth.go:209 +0xf4
  github.com/opencloud-eu/opencloud/services/proxy/pkg/middleware.init.func5.2.2()
      /Users/fschade/Developer/fschade/opencloud/services/proxy/pkg/middleware/oidc_auth_test.go:70 +0x168
  github.com/onsi/ginkgo/v2/internal.extractBodyFunction.func3()
      /Users/fschade/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.32.0/internal/node.go:585 +0x30
  github.com/onsi/ginkgo/v2/internal.(*Suite).runNode.func3()
      /Users/fschade/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.32.0/internal/suite.go:946 +0x4ac

Previous read at 0x00c000401740 by goroutine 120:
  github.com/vmihailenco/msgpack/v5.(*Encoder).EncodeMap()
      /Users/fschade/go/pkg/mod/github.com/vmihailenco/msgpack/v5@v5.4.1/encode_map.go:100 +0x38
  github.com/vmihailenco/msgpack/v5.encodeMapStringInterfaceValue()
      /Users/fschade/go/pkg/mod/github.com/vmihailenco/msgpack/v5@v5.4.1/encode_map.go:93 +0x1a8
  github.com/vmihailenco/msgpack/v5.(*Encoder).EncodeValue()
      /Users/fschade/go/pkg/mod/github.com/vmihailenco/msgpack/v5@v5.4.1/encode.go:240 +0xa0
  github.com/vmihailenco/msgpack/v5.(*Encoder).Encode()
      /Users/fschade/go/pkg/mod/github.com/vmihailenco/msgpack/v5@v5.4.1/encode.go:226 +0x414
  github.com/vmihailenco/msgpack/v5.Marshal()
      /Users/fschade/go/pkg/mod/github.com/vmihailenco/msgpack/v5@v5.4.1/encode.go:66 +0x254
  github.com/opencloud-eu/opencloud/services/proxy/pkg/middleware.(*OIDCAuthenticator).getClaims.func1()
      /Users/fschade/Developer/fschade/opencloud/services/proxy/pkg/middleware/oidc_auth.go:107 +0x70

Goroutine 123 (running) created at:
  github.com/onsi/ginkgo/v2/internal.(*Suite).runNode()
      /Users/fschade/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.32.0/internal/suite.go:911 +0xce4
  github.com/onsi/ginkgo/v2/internal.(*group).attemptSpec()
      /Users/fschade/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.32.0/internal/group.go:234 +0xe3c
  github.com/onsi/ginkgo/v2/internal.(*group).run()
      /Users/fschade/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.32.0/internal/group.go:384 +0xca8
  github.com/onsi/ginkgo/v2/internal.(*Suite).runSpecs()
      /Users/fschade/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.32.0/internal/suite.go:519 +0xca8
  github.com/onsi/ginkgo/v2/internal.(*Suite).Run()
      /Users/fschade/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.32.0/internal/suite.go:136 +0x490
  github.com/onsi/ginkgo/v2.RunSpecs()
      /Users/fschade/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.32.0/core_dsl.go:314 +0xbe4
  github.com/opencloud-eu/opencloud/services/proxy/pkg/middleware_test.TestMiddleware()
      /Users/fschade/Developer/fschade/opencloud/services/proxy/pkg/middleware/middleware_suite_test.go:12 +0x54
  testing.tRunner()
      /Users/fschade/.local/share/mise/installs/go/1.26.5/src/testing/testing.go:2036 +0x164
  testing.(*T).Run.gowrap1()
      /Users/fschade/.local/share/mise/installs/go/1.26.5/src/testing/testing.go:2101 +0x34

Goroutine 120 (finished) created at:
  github.com/opencloud-eu/opencloud/services/proxy/pkg/middleware.(*OIDCAuthenticator).getClaims()
      /Users/fschade/Developer/fschade/opencloud/services/proxy/pkg/middleware/oidc_auth.go:106 +0x964
  github.com/opencloud-eu/opencloud/services/proxy/pkg/middleware.(*OIDCAuthenticator).Authenticate()
      /Users/fschade/Developer/fschade/opencloud/services/proxy/pkg/middleware/oidc_auth.go:209 +0xf4
  github.com/opencloud-eu/opencloud/services/proxy/pkg/middleware.init.func5.2.1()
      /Users/fschade/Developer/fschade/opencloud/services/proxy/pkg/middleware/oidc_auth_test.go:61 +0x168
  github.com/onsi/ginkgo/v2/internal.extractBodyFunction.func3()
      /Users/fschade/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.32.0/internal/node.go:585 +0x30
  github.com/onsi/ginkgo/v2/internal.(*Suite).runNode.func3()
      /Users/fschade/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.32.0/internal/suite.go:946 +0x4ac
==================
==================
WARNING: DATA RACE
Write at 0x00c0003ae278 by goroutine 123:
  github.com/opencloud-eu/opencloud/services/proxy/pkg/middleware.(*OIDCAuthenticator).getClaims()
      /Users/fschade/Developer/fschade/opencloud/services/proxy/pkg/middleware/oidc_auth.go:105 +0x7b8
  github.com/opencloud-eu/opencloud/services/proxy/pkg/middleware.(*OIDCAuthenticator).Authenticate()
      /Users/fschade/Developer/fschade/opencloud/services/proxy/pkg/middleware/oidc_auth.go:209 +0xf4
  github.com/opencloud-eu/opencloud/services/proxy/pkg/middleware.init.func5.2.2()
      /Users/fschade/Developer/fschade/opencloud/services/proxy/pkg/middleware/oidc_auth_test.go:70 +0x168
  github.com/onsi/ginkgo/v2/internal.extractBodyFunction.func3()
      /Users/fschade/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.32.0/internal/node.go:585 +0x30
  github.com/onsi/ginkgo/v2/internal.(*Suite).runNode.func3()
      /Users/fschade/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.32.0/internal/suite.go:946 +0x4ac

Previous read at 0x00c0003ae278 by goroutine 120:
  github.com/vmihailenco/msgpack/v5.(*Encoder).EncodeMap()
      /Users/fschade/go/pkg/mod/github.com/vmihailenco/msgpack/v5@v5.4.1/encode_map.go:103 +0x158
  github.com/vmihailenco/msgpack/v5.encodeMapStringInterfaceValue()
      /Users/fschade/go/pkg/mod/github.com/vmihailenco/msgpack/v5@v5.4.1/encode_map.go:93 +0x1a8
  github.com/vmihailenco/msgpack/v5.(*Encoder).EncodeValue()
      /Users/fschade/go/pkg/mod/github.com/vmihailenco/msgpack/v5@v5.4.1/encode.go:240 +0xa0
  github.com/vmihailenco/msgpack/v5.(*Encoder).Encode()
      /Users/fschade/go/pkg/mod/github.com/vmihailenco/msgpack/v5@v5.4.1/encode.go:226 +0x414
  github.com/vmihailenco/msgpack/v5.Marshal()
      /Users/fschade/go/pkg/mod/github.com/vmihailenco/msgpack/v5@v5.4.1/encode.go:66 +0x254
  github.com/opencloud-eu/opencloud/services/proxy/pkg/middleware.(*OIDCAuthenticator).getClaims.func1()
      /Users/fschade/Developer/fschade/opencloud/services/proxy/pkg/middleware/oidc_auth.go:107 +0x70

Goroutine 123 (running) created at:
  github.com/onsi/ginkgo/v2/internal.(*Suite).runNode()
      /Users/fschade/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.32.0/internal/suite.go:911 +0xce4
  github.com/onsi/ginkgo/v2/internal.(*group).attemptSpec()
      /Users/fschade/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.32.0/internal/group.go:234 +0xe3c
  github.com/onsi/ginkgo/v2/internal.(*group).run()
      /Users/fschade/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.32.0/internal/group.go:384 +0xca8
  github.com/onsi/ginkgo/v2/internal.(*Suite).runSpecs()
      /Users/fschade/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.32.0/internal/suite.go:519 +0xca8
  github.com/onsi/ginkgo/v2/internal.(*Suite).Run()
      /Users/fschade/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.32.0/internal/suite.go:136 +0x490
  github.com/onsi/ginkgo/v2.RunSpecs()
      /Users/fschade/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.32.0/core_dsl.go:314 +0xbe4
  github.com/opencloud-eu/opencloud/services/proxy/pkg/middleware_test.TestMiddleware()
      /Users/fschade/Developer/fschade/opencloud/services/proxy/pkg/middleware/middleware_suite_test.go:12 +0x54
  testing.tRunner()
      /Users/fschade/.local/share/mise/installs/go/1.26.5/src/testing/testing.go:2036 +0x164
  testing.(*T).Run.gowrap1()
      /Users/fschade/.local/share/mise/installs/go/1.26.5/src/testing/testing.go:2101 +0x34

Goroutine 120 (finished) created at:
  github.com/opencloud-eu/opencloud/services/proxy/pkg/middleware.(*OIDCAuthenticator).getClaims()
      /Users/fschade/Developer/fschade/opencloud/services/proxy/pkg/middleware/oidc_auth.go:106 +0x964
  github.com/opencloud-eu/opencloud/services/proxy/pkg/middleware.(*OIDCAuthenticator).Authenticate()
      /Users/fschade/Developer/fschade/opencloud/services/proxy/pkg/middleware/oidc_auth.go:209 +0xf4
  github.com/opencloud-eu/opencloud/services/proxy/pkg/middleware.init.func5.2.1()
      /Users/fschade/Developer/fschade/opencloud/services/proxy/pkg/middleware/oidc_auth_test.go:61 +0x168
  github.com/onsi/ginkgo/v2/internal.extractBodyFunction.func3()
      /Users/fschade/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.32.0/internal/node.go:585 +0x30
  github.com/onsi/ginkgo/v2/internal.(*Suite).runNode.func3()
      /Users/fschade/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.32.0/internal/suite.go:946 +0x4ac
==================
•==================
WARNING: DATA RACE
Write at 0x00c000401740 by goroutine 127:
  runtime.mapaccess2_faststr()
      /Users/fschade/.local/share/mise/installs/go/1.26.5/src/internal/runtime/maps/runtime_faststr.go:161 +0x2ac
  github.com/opencloud-eu/opencloud/services/proxy/pkg/middleware.(*OIDCAuthenticator).getClaims()
      /Users/fschade/Developer/fschade/opencloud/services/proxy/pkg/middleware/oidc_auth.go:105 +0x7ac
  github.com/opencloud-eu/opencloud/services/proxy/pkg/middleware.(*OIDCAuthenticator).Authenticate()
      /Users/fschade/Developer/fschade/opencloud/services/proxy/pkg/middleware/oidc_auth.go:209 +0xf4
  github.com/opencloud-eu/opencloud/services/proxy/pkg/middleware.init.func5.2.3()
      /Users/fschade/Developer/fschade/opencloud/services/proxy/pkg/middleware/oidc_auth_test.go:80 +0x238
  github.com/onsi/ginkgo/v2/internal.extractBodyFunction.func3()
      /Users/fschade/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.32.0/internal/node.go:585 +0x30
  github.com/onsi/ginkgo/v2/internal.(*Suite).runNode.func3()
      /Users/fschade/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.32.0/internal/suite.go:946 +0x4ac

Previous read at 0x00c000401740 by goroutine 124:
  github.com/vmihailenco/msgpack/v5.(*Encoder).EncodeMap()
      /Users/fschade/go/pkg/mod/github.com/vmihailenco/msgpack/v5@v5.4.1/encode_map.go:100 +0x38
  github.com/vmihailenco/msgpack/v5.encodeMapStringInterfaceValue()
      /Users/fschade/go/pkg/mod/github.com/vmihailenco/msgpack/v5@v5.4.1/encode_map.go:93 +0x1a8
  github.com/vmihailenco/msgpack/v5.(*Encoder).EncodeValue()
      /Users/fschade/go/pkg/mod/github.com/vmihailenco/msgpack/v5@v5.4.1/encode.go:240 +0xa0
  github.com/vmihailenco/msgpack/v5.(*Encoder).Encode()
      /Users/fschade/go/pkg/mod/github.com/vmihailenco/msgpack/v5@v5.4.1/encode.go:226 +0x414
  github.com/vmihailenco/msgpack/v5.Marshal()
      /Users/fschade/go/pkg/mod/github.com/vmihailenco/msgpack/v5@v5.4.1/encode.go:66 +0x254
  github.com/opencloud-eu/opencloud/services/proxy/pkg/middleware.(*OIDCAuthenticator).getClaims.func1()
      /Users/fschade/Developer/fschade/opencloud/services/proxy/pkg/middleware/oidc_auth.go:107 +0x70

Goroutine 127 (running) created at:
  github.com/onsi/ginkgo/v2/internal.(*Suite).runNode()
      /Users/fschade/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.32.0/internal/suite.go:911 +0xce4
  github.com/onsi/ginkgo/v2/internal.(*group).attemptSpec()
      /Users/fschade/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.32.0/internal/group.go:234 +0xe3c
  github.com/onsi/ginkgo/v2/internal.(*group).run()
      /Users/fschade/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.32.0/internal/group.go:384 +0xca8
  github.com/onsi/ginkgo/v2/internal.(*Suite).runSpecs()
      /Users/fschade/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.32.0/internal/suite.go:519 +0xca8
  github.com/onsi/ginkgo/v2/internal.(*Suite).Run()
      /Users/fschade/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.32.0/internal/suite.go:136 +0x490
  github.com/onsi/ginkgo/v2.RunSpecs()
      /Users/fschade/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.32.0/core_dsl.go:314 +0xbe4
  github.com/opencloud-eu/opencloud/services/proxy/pkg/middleware_test.TestMiddleware()
      /Users/fschade/Developer/fschade/opencloud/services/proxy/pkg/middleware/middleware_suite_test.go:12 +0x54
  testing.tRunner()
      /Users/fschade/.local/share/mise/installs/go/1.26.5/src/testing/testing.go:2036 +0x164
  testing.(*T).Run.gowrap1()
      /Users/fschade/.local/share/mise/installs/go/1.26.5/src/testing/testing.go:2101 +0x34

Goroutine 124 (finished) created at:
  github.com/opencloud-eu/opencloud/services/proxy/pkg/middleware.(*OIDCAuthenticator).getClaims()
      /Users/fschade/Developer/fschade/opencloud/services/proxy/pkg/middleware/oidc_auth.go:106 +0x964
  github.com/opencloud-eu/opencloud/services/proxy/pkg/middleware.(*OIDCAuthenticator).Authenticate()
      /Users/fschade/Developer/fschade/opencloud/services/proxy/pkg/middleware/oidc_auth.go:209 +0xf4
  github.com/opencloud-eu/opencloud/services/proxy/pkg/middleware.init.func5.2.2()
      /Users/fschade/Developer/fschade/opencloud/services/proxy/pkg/middleware/oidc_auth_test.go:70 +0x168
  github.com/onsi/ginkgo/v2/internal.extractBodyFunction.func3()
      /Users/fschade/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.32.0/internal/node.go:585 +0x30
  github.com/onsi/ginkgo/v2/internal.(*Suite).runNode.func3()
      /Users/fschade/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.32.0/internal/suite.go:946 +0x4ac
==================
==================
WARNING: DATA RACE
Write at 0x00c0003ae278 by goroutine 127:
  github.com/opencloud-eu/opencloud/services/proxy/pkg/middleware.(*OIDCAuthenticator).getClaims()
      /Users/fschade/Developer/fschade/opencloud/services/proxy/pkg/middleware/oidc_auth.go:105 +0x7b8
  github.com/opencloud-eu/opencloud/services/proxy/pkg/middleware.(*OIDCAuthenticator).Authenticate()
      /Users/fschade/Developer/fschade/opencloud/services/proxy/pkg/middleware/oidc_auth.go:209 +0xf4
  github.com/opencloud-eu/opencloud/services/proxy/pkg/middleware.init.func5.2.3()
      /Users/fschade/Developer/fschade/opencloud/services/proxy/pkg/middleware/oidc_auth_test.go:80 +0x238
  github.com/onsi/ginkgo/v2/internal.extractBodyFunction.func3()
      /Users/fschade/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.32.0/internal/node.go:585 +0x30
  github.com/onsi/ginkgo/v2/internal.(*Suite).runNode.func3()
      /Users/fschade/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.32.0/internal/suite.go:946 +0x4ac

Previous read at 0x00c0003ae278 by goroutine 124:
  github.com/vmihailenco/msgpack/v5.(*Encoder).EncodeMap()
      /Users/fschade/go/pkg/mod/github.com/vmihailenco/msgpack/v5@v5.4.1/encode_map.go:103 +0x158
  github.com/vmihailenco/msgpack/v5.encodeMapStringInterfaceValue()
      /Users/fschade/go/pkg/mod/github.com/vmihailenco/msgpack/v5@v5.4.1/encode_map.go:93 +0x1a8
  github.com/vmihailenco/msgpack/v5.(*Encoder).EncodeValue()
      /Users/fschade/go/pkg/mod/github.com/vmihailenco/msgpack/v5@v5.4.1/encode.go:240 +0xa0
  github.com/vmihailenco/msgpack/v5.(*Encoder).Encode()
      /Users/fschade/go/pkg/mod/github.com/vmihailenco/msgpack/v5@v5.4.1/encode.go:226 +0x414
  github.com/vmihailenco/msgpack/v5.Marshal()
      /Users/fschade/go/pkg/mod/github.com/vmihailenco/msgpack/v5@v5.4.1/encode.go:66 +0x254
  github.com/opencloud-eu/opencloud/services/proxy/pkg/middleware.(*OIDCAuthenticator).getClaims.func1()
      /Users/fschade/Developer/fschade/opencloud/services/proxy/pkg/middleware/oidc_auth.go:107 +0x70

Goroutine 127 (running) created at:
  github.com/onsi/ginkgo/v2/internal.(*Suite).runNode()
      /Users/fschade/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.32.0/internal/suite.go:911 +0xce4
  github.com/onsi/ginkgo/v2/internal.(*group).attemptSpec()
      /Users/fschade/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.32.0/internal/group.go:234 +0xe3c
  github.com/onsi/ginkgo/v2/internal.(*group).run()
      /Users/fschade/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.32.0/internal/group.go:384 +0xca8
  github.com/onsi/ginkgo/v2/internal.(*Suite).runSpecs()
      /Users/fschade/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.32.0/internal/suite.go:519 +0xca8
  github.com/onsi/ginkgo/v2/internal.(*Suite).Run()
      /Users/fschade/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.32.0/internal/suite.go:136 +0x490
  github.com/onsi/ginkgo/v2.RunSpecs()
      /Users/fschade/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.32.0/core_dsl.go:314 +0xbe4
  github.com/opencloud-eu/opencloud/services/proxy/pkg/middleware_test.TestMiddleware()
      /Users/fschade/Developer/fschade/opencloud/services/proxy/pkg/middleware/middleware_suite_test.go:12 +0x54
  testing.tRunner()
      /Users/fschade/.local/share/mise/installs/go/1.26.5/src/testing/testing.go:2036 +0x164
  testing.(*T).Run.gowrap1()
      /Users/fschade/.local/share/mise/installs/go/1.26.5/src/testing/testing.go:2101 +0x34

Goroutine 124 (finished) created at:
  github.com/opencloud-eu/opencloud/services/proxy/pkg/middleware.(*OIDCAuthenticator).getClaims()
      /Users/fschade/Developer/fschade/opencloud/services/proxy/pkg/middleware/oidc_auth.go:106 +0x964
  github.com/opencloud-eu/opencloud/services/proxy/pkg/middleware.(*OIDCAuthenticator).Authenticate()
      /Users/fschade/Developer/fschade/opencloud/services/proxy/pkg/middleware/oidc_auth.go:209 +0xf4
  github.com/opencloud-eu/opencloud/services/proxy/pkg/middleware.init.func5.2.2()
      /Users/fschade/Developer/fschade/opencloud/services/proxy/pkg/middleware/oidc_auth_test.go:70 +0x168
  github.com/onsi/ginkgo/v2/internal.extractBodyFunction.func3()
      /Users/fschade/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.32.0/internal/node.go:585 +0x30
  github.com/onsi/ginkgo/v2/internal.(*Suite).runNode.func3()
      /Users/fschade/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.32.0/internal/suite.go:946 +0x4ac
==================
•==================
WARNING: DATA RACE
Write at 0x00c000401740 by goroutine 131:
  runtime.mapaccess2_faststr()
      /Users/fschade/.local/share/mise/installs/go/1.26.5/src/internal/runtime/maps/runtime_faststr.go:161 +0x2ac
  github.com/opencloud-eu/opencloud/services/proxy/pkg/middleware.(*OIDCAuthenticator).getClaims()
      /Users/fschade/Developer/fschade/opencloud/services/proxy/pkg/middleware/oidc_auth.go:105 +0x7ac
  github.com/opencloud-eu/opencloud/services/proxy/pkg/middleware.(*OIDCAuthenticator).Authenticate()
      /Users/fschade/Developer/fschade/opencloud/services/proxy/pkg/middleware/oidc_auth.go:209 +0xf4
  github.com/opencloud-eu/opencloud/services/proxy/pkg/middleware.init.func5.2.4()
      /Users/fschade/Developer/fschade/opencloud/services/proxy/pkg/middleware/oidc_auth_test.go:92 +0x168
  github.com/onsi/ginkgo/v2/internal.extractBodyFunction.func3()
      /Users/fschade/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.32.0/internal/node.go:585 +0x30
  github.com/onsi/ginkgo/v2/internal.(*Suite).runNode.func3()
      /Users/fschade/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.32.0/internal/suite.go:946 +0x4ac

Previous read at 0x00c000401740 by goroutine 128:
  github.com/vmihailenco/msgpack/v5.(*Encoder).EncodeMap()
      /Users/fschade/go/pkg/mod/github.com/vmihailenco/msgpack/v5@v5.4.1/encode_map.go:100 +0x38
  github.com/vmihailenco/msgpack/v5.encodeMapStringInterfaceValue()
      /Users/fschade/go/pkg/mod/github.com/vmihailenco/msgpack/v5@v5.4.1/encode_map.go:93 +0x1a8
  github.com/vmihailenco/msgpack/v5.(*Encoder).EncodeValue()
      /Users/fschade/go/pkg/mod/github.com/vmihailenco/msgpack/v5@v5.4.1/encode.go:240 +0xa0
  github.com/vmihailenco/msgpack/v5.(*Encoder).Encode()
      /Users/fschade/go/pkg/mod/github.com/vmihailenco/msgpack/v5@v5.4.1/encode.go:226 +0x414
  github.com/vmihailenco/msgpack/v5.Marshal()
      /Users/fschade/go/pkg/mod/github.com/vmihailenco/msgpack/v5@v5.4.1/encode.go:66 +0x254
  github.com/opencloud-eu/opencloud/services/proxy/pkg/middleware.(*OIDCAuthenticator).getClaims.func1()
      /Users/fschade/Developer/fschade/opencloud/services/proxy/pkg/middleware/oidc_auth.go:107 +0x70

Goroutine 131 (running) created at:
  github.com/onsi/ginkgo/v2/internal.(*Suite).runNode()
      /Users/fschade/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.32.0/internal/suite.go:911 +0xce4
  github.com/onsi/ginkgo/v2/internal.(*group).attemptSpec()
      /Users/fschade/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.32.0/internal/group.go:234 +0xe3c
  github.com/onsi/ginkgo/v2/internal.(*group).run()
      /Users/fschade/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.32.0/internal/group.go:384 +0xca8
  github.com/onsi/ginkgo/v2/internal.(*Suite).runSpecs()
      /Users/fschade/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.32.0/internal/suite.go:519 +0xca8
  github.com/onsi/ginkgo/v2/internal.(*Suite).Run()
      /Users/fschade/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.32.0/internal/suite.go:136 +0x490
  github.com/onsi/ginkgo/v2.RunSpecs()
      /Users/fschade/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.32.0/core_dsl.go:314 +0xbe4
  github.com/opencloud-eu/opencloud/services/proxy/pkg/middleware_test.TestMiddleware()
      /Users/fschade/Developer/fschade/opencloud/services/proxy/pkg/middleware/middleware_suite_test.go:12 +0x54
  testing.tRunner()
      /Users/fschade/.local/share/mise/installs/go/1.26.5/src/testing/testing.go:2036 +0x164
  testing.(*T).Run.gowrap1()
      /Users/fschade/.local/share/mise/installs/go/1.26.5/src/testing/testing.go:2101 +0x34

Goroutine 128 (finished) created at:
  github.com/opencloud-eu/opencloud/services/proxy/pkg/middleware.(*OIDCAuthenticator).getClaims()
      /Users/fschade/Developer/fschade/opencloud/services/proxy/pkg/middleware/oidc_auth.go:106 +0x964
  github.com/opencloud-eu/opencloud/services/proxy/pkg/middleware.(*OIDCAuthenticator).Authenticate()
      /Users/fschade/Developer/fschade/opencloud/services/proxy/pkg/middleware/oidc_auth.go:209 +0xf4
  github.com/opencloud-eu/opencloud/services/proxy/pkg/middleware.init.func5.2.3()
      /Users/fschade/Developer/fschade/opencloud/services/proxy/pkg/middleware/oidc_auth_test.go:80 +0x238
  github.com/onsi/ginkgo/v2/internal.extractBodyFunction.func3()
      /Users/fschade/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.32.0/internal/node.go:585 +0x30
  github.com/onsi/ginkgo/v2/internal.(*Suite).runNode.func3()
      /Users/fschade/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.32.0/internal/suite.go:946 +0x4ac
==================
==================
WARNING: DATA RACE
Write at 0x00c0003ae278 by goroutine 131:
  github.com/opencloud-eu/opencloud/services/proxy/pkg/middleware.(*OIDCAuthenticator).getClaims()
      /Users/fschade/Developer/fschade/opencloud/services/proxy/pkg/middleware/oidc_auth.go:105 +0x7b8
  github.com/opencloud-eu/opencloud/services/proxy/pkg/middleware.(*OIDCAuthenticator).Authenticate()
      /Users/fschade/Developer/fschade/opencloud/services/proxy/pkg/middleware/oidc_auth.go:209 +0xf4
  github.com/opencloud-eu/opencloud/services/proxy/pkg/middleware.init.func5.2.4()
      /Users/fschade/Developer/fschade/opencloud/services/proxy/pkg/middleware/oidc_auth_test.go:92 +0x168
  github.com/onsi/ginkgo/v2/internal.extractBodyFunction.func3()
      /Users/fschade/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.32.0/internal/node.go:585 +0x30
  github.com/onsi/ginkgo/v2/internal.(*Suite).runNode.func3()
      /Users/fschade/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.32.0/internal/suite.go:946 +0x4ac

Previous read at 0x00c0003ae278 by goroutine 128:
  github.com/vmihailenco/msgpack/v5.(*Encoder).EncodeMap()
      /Users/fschade/go/pkg/mod/github.com/vmihailenco/msgpack/v5@v5.4.1/encode_map.go:103 +0x158
  github.com/vmihailenco/msgpack/v5.encodeMapStringInterfaceValue()
      /Users/fschade/go/pkg/mod/github.com/vmihailenco/msgpack/v5@v5.4.1/encode_map.go:93 +0x1a8
  github.com/vmihailenco/msgpack/v5.(*Encoder).EncodeValue()
      /Users/fschade/go/pkg/mod/github.com/vmihailenco/msgpack/v5@v5.4.1/encode.go:240 +0xa0
  github.com/vmihailenco/msgpack/v5.(*Encoder).Encode()
      /Users/fschade/go/pkg/mod/github.com/vmihailenco/msgpack/v5@v5.4.1/encode.go:226 +0x414
  github.com/vmihailenco/msgpack/v5.Marshal()
      /Users/fschade/go/pkg/mod/github.com/vmihailenco/msgpack/v5@v5.4.1/encode.go:66 +0x254
  github.com/opencloud-eu/opencloud/services/proxy/pkg/middleware.(*OIDCAuthenticator).getClaims.func1()
      /Users/fschade/Developer/fschade/opencloud/services/proxy/pkg/middleware/oidc_auth.go:107 +0x70

Goroutine 131 (running) created at:
  github.com/onsi/ginkgo/v2/internal.(*Suite).runNode()
      /Users/fschade/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.32.0/internal/suite.go:911 +0xce4
  github.com/onsi/ginkgo/v2/internal.(*group).attemptSpec()
      /Users/fschade/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.32.0/internal/group.go:234 +0xe3c
  github.com/onsi/ginkgo/v2/internal.(*group).run()
      /Users/fschade/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.32.0/internal/group.go:384 +0xca8
  github.com/onsi/ginkgo/v2/internal.(*Suite).runSpecs()
      /Users/fschade/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.32.0/internal/suite.go:519 +0xca8
  github.com/onsi/ginkgo/v2/internal.(*Suite).Run()
      /Users/fschade/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.32.0/internal/suite.go:136 +0x490
  github.com/onsi/ginkgo/v2.RunSpecs()
      /Users/fschade/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.32.0/core_dsl.go:314 +0xbe4
  github.com/opencloud-eu/opencloud/services/proxy/pkg/middleware_test.TestMiddleware()
      /Users/fschade/Developer/fschade/opencloud/services/proxy/pkg/middleware/middleware_suite_test.go:12 +0x54
  testing.tRunner()
      /Users/fschade/.local/share/mise/installs/go/1.26.5/src/testing/testing.go:2036 +0x164
  testing.(*T).Run.gowrap1()
      /Users/fschade/.local/share/mise/installs/go/1.26.5/src/testing/testing.go:2101 +0x34

Goroutine 128 (finished) created at:
  github.com/opencloud-eu/opencloud/services/proxy/pkg/middleware.(*OIDCAuthenticator).getClaims()
      /Users/fschade/Developer/fschade/opencloud/services/proxy/pkg/middleware/oidc_auth.go:106 +0x964
  github.com/opencloud-eu/opencloud/services/proxy/pkg/middleware.(*OIDCAuthenticator).Authenticate()
      /Users/fschade/Developer/fschade/opencloud/services/proxy/pkg/middleware/oidc_auth.go:209 +0xf4
  github.com/opencloud-eu/opencloud/services/proxy/pkg/middleware.init.func5.2.3()
      /Users/fschade/Developer/fschade/opencloud/services/proxy/pkg/middleware/oidc_auth_test.go:80 +0x238
  github.com/onsi/ginkgo/v2/internal.extractBodyFunction.func3()
      /Users/fschade/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.32.0/internal/node.go:585 +0x30
  github.com/onsi/ginkgo/v2/internal.(*Suite).runNode.func3()
      /Users/fschade/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.32.0/internal/suite.go:946 +0x4ac
==================
•••••••••••••••

Ran 22 of 22 Specs in 0.014 seconds
SUCCESS! -- 22 Passed | 0 Failed | 0 Pending | 0 Skipped
--- FAIL: TestMiddleware (0.02s)
    testing.go:1712: race detected during execution of test
FAIL
FAIL    github.com/opencloud-eu/opencloud/services/proxy/pkg/middleware 0.816s
FAIL
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
- [X] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added
