### PR TITLE
fix(ci): stamp version into daily docker images

### DIFF
--- a/.woodpecker.star
+++ b/.woodpecker.star
@@ -1902,10 +1902,12 @@ def checkVersionPlaceholder():
 def dockerRelease(ctx, repo, build_type):
     build_args = {
         "REVISION": "%s" % ctx.build.commit,
-        "STRING": "%s" % ctx.build.commit[:8],
         "VERSION": "%s" % (ctx.build.ref.replace("refs/tags/", "") if ctx.build.event == "tag" else "daily"),
         "EDITION": "stable" if build_type == "production" else "rolling",
     }
+
+    if ctx.build.event != "tag":
+        build_args["STRING"] = ctx.build.commit[:8]
 
     # if no additional tag is given, the build-plugin adds latest
     hard_tag = "daily"

--- a/.woodpecker.star
+++ b/.woodpecker.star
@@ -1902,6 +1902,7 @@ def checkVersionPlaceholder():
 def dockerRelease(ctx, repo, build_type):
     build_args = {
         "REVISION": "%s" % ctx.build.commit,
+        "STRING": "%s" % ctx.build.commit[:8],
         "VERSION": "%s" % (ctx.build.ref.replace("refs/tags/", "") if ctx.build.event == "tag" else "daily"),
         "EDITION": "stable" if build_type == "production" else "rolling",
     }

--- a/opencloud/docker/Dockerfile.multiarch
+++ b/opencloud/docker/Dockerfile.multiarch
@@ -11,7 +11,9 @@ RUN --mount=type=bind,target=/build,rw \
     --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache \
     GOOS="${TARGETOS:-linux}" GOARCH="${TARGETARCH:-amd64}" ; \
-    make -C ${SRCDIR:-.}/opencloud release-linux-docker-${TARGETARCH} ENABLE_VIPS=true DIST=/dist
+    make -C ${SRCDIR:-.}/opencloud release-linux-docker-${TARGETARCH} \
+        ENABLE_VIPS=true DIST=/dist \
+        VERSION="${VERSION}" STRING="${STRING}" EDITION="${EDITION}"
 
 FROM alpine:3.24
 ARG VERSION

--- a/opencloud/docker/Dockerfile.multiarch
+++ b/opencloud/docker/Dockerfile.multiarch
@@ -13,7 +13,8 @@ RUN --mount=type=bind,target=/build,rw \
     GOOS="${TARGETOS:-linux}" GOARCH="${TARGETARCH:-amd64}" ; \
     make -C ${SRCDIR:-.}/opencloud release-linux-docker-${TARGETARCH} \
         ENABLE_VIPS=true DIST=/dist \
-        VERSION="${VERSION}" STRING="${STRING}" EDITION="${EDITION}"
+        VERSION="${VERSION}" EDITION="${EDITION}" \
+        ${STRING:+STRING="${STRING}"}
 
 FROM alpine:3.24
 ARG VERSION


### PR DESCRIPTION
Since [d0a0922e89](https://github.com/opencloud-eu/opencloud/commit/d0a0922e8983750ef67e25a18410d62aa874927d) the docker build context moved from ".." to ".", which activated the repo-root .dockerignore that excludes .git.
Without .git the Makefile's `git rev-parse --short HEAD` fails ("fatal: not a git repository") and version.String stays empty, so every daily image reports the fallback LatestTag and looks unchanged.

Pass STRING/VERSION/EDITION as build args into the docker build instead of relying on git inside the build context.