### PR TITLE
feat(nats): enable the NATS monitoring HTTP endpoint in the embedded NATS server

### DIFF
--- a/services/nats/pkg/command/server.go
+++ b/services/nats/pkg/command/server.go
@@ -75,14 +75,31 @@ func Server(cfg *config.Config) *cobra.Command {
 					Certificates: []tls.Certificate{crt},
 				}
 			}
-			natsServer, err := nats.NewNATSServer(
-				logging.NewLogWrapper(logger),
+
+			opts := []nats.NatsOption{
 				nats.Host(cfg.Nats.Host),
 				nats.Port(cfg.Nats.Port),
 				nats.ClusterID(cfg.Nats.ClusterID),
 				nats.StoreDir(cfg.Nats.StoreDir),
 				nats.TLSConfig(tlsConf),
 				nats.AllowNonTLS(!cfg.Nats.EnableTLS),
+			}
+
+			if cfg.Nats.Monitoring.Enabled {
+				if cfg.Nats.Monitoring.EnableTLS {
+					opts = append(opts,
+						nats.EnableMonitoringHTTPSEndpoint(cfg.Nats.Monitoring.Host, cfg.Nats.Monitoring.Port),
+					)
+				} else {
+					opts = append(opts,
+						nats.EnableMonitoringHTTPEndpoint(cfg.Nats.Monitoring.Host, cfg.Nats.Monitoring.Port),
+					)
+				}
+			}
+
+			natsServer, err := nats.NewNATSServer(
+				logging.NewLogWrapper(logger),
+				opts...,
 			)
 			if err != nil {
 				return err

--- a/services/nats/pkg/config/config.go
+++ b/services/nats/pkg/config/config.go
@@ -18,14 +18,22 @@ type Config struct {
 	Context context.Context `yaml:"-"`
 }
 
+type Monitoring struct {
+	Enabled   bool   `yaml:"enabled" env:"NATS_MONITORING_ENABLED" desc:"Whether to enable the NATS server monitoring HTTP endpoint" introductionVersion:"%NEXT%"`
+	Host      string `yaml:"host" env:"NATS_MONITORING_HTTP_HOST" desc:"The address the NATS server monitoring HTTP endpoint should be bound to" introductionVersion:"%NEXT%"`
+	Port      int    `yaml:"port" env:"NATS_MONITORING_HTTP_PORT" desc:"The port the NATS server monitoring HTTP endpoint should be bound to" introductionVersion:"%NEXT%"`
+	EnableTLS bool   `yaml:"enable_tls" env:"NATS_MONITORING_ENABLE_TLS" desc:"Enable TLS for NATS server monitoring HTTP endpoint. Note that it will use the same TLS configuration as the streaming API." introductionVersion:"%NEXT%"`
+}
+
 // Nats is the nats config
 type Nats struct {
-	Host                    string `yaml:"host" env:"NATS_NATS_HOST" desc:"Bind address." introductionVersion:"1.0.0"`
-	Port                    int    `yaml:"port" env:"NATS_NATS_PORT" desc:"Bind port." introductionVersion:"1.0.0"`
-	ClusterID               string `yaml:"clusterid" env:"NATS_NATS_CLUSTER_ID" desc:"ID of the NATS cluster." introductionVersion:"1.0.0"`
-	StoreDir                string `yaml:"store_dir" env:"NATS_NATS_STORE_DIR" desc:"The directory where the filesystem storage will store NATS JetStream data. If not defined, the root directory derives from $OC_BASE_DATA_PATH/nats." introductionVersion:"1.0.0"`
-	TLSCert                 string `yaml:"tls_cert" env:"NATS_TLS_CERT" desc:"Path/File name of the TLS server certificate (in PEM format) for the NATS listener. If not defined, the root directory derives from $OC_BASE_DATA_PATH/nats." introductionVersion:"1.0.0"`
-	TLSKey                  string `yaml:"tls_key" env:"NATS_TLS_KEY" desc:"Path/File name for the TLS certificate key (in PEM format) for the NATS listener. If not defined, the root directory derives from $OC_BASE_DATA_PATH/nats." introductionVersion:"1.0.0"`
-	TLSSkipVerifyClientCert bool   `yaml:"tls_skip_verify_client_cert" env:"OC_INSECURE;NATS_TLS_SKIP_VERIFY_CLIENT_CERT" desc:"Whether the NATS server should skip the client certificate verification during the TLS handshake." introductionVersion:"1.0.0"`
-	EnableTLS               bool   `yaml:"enable_tls" env:"OC_EVENTS_ENABLE_TLS;NATS_EVENTS_ENABLE_TLS" desc:"Enable TLS for the connection to the events broker. The events broker is the OpenCloud service which receives and delivers events between the services." introductionVersion:"1.0.0"`
+	Host                    string     `yaml:"host" env:"NATS_NATS_HOST" desc:"Bind address." introductionVersion:"1.0.0"`
+	Port                    int        `yaml:"port" env:"NATS_NATS_PORT" desc:"Bind port." introductionVersion:"1.0.0"`
+	ClusterID               string     `yaml:"clusterid" env:"NATS_NATS_CLUSTER_ID" desc:"ID of the NATS cluster." introductionVersion:"1.0.0"`
+	StoreDir                string     `yaml:"store_dir" env:"NATS_NATS_STORE_DIR" desc:"The directory where the filesystem storage will store NATS JetStream data. If not defined, the root directory derives from $OC_BASE_DATA_PATH/nats." introductionVersion:"1.0.0"`
+	TLSCert                 string     `yaml:"tls_cert" env:"NATS_TLS_CERT" desc:"Path/File name of the TLS server certificate (in PEM format) for the NATS listener. If not defined, the root directory derives from $OC_BASE_DATA_PATH/nats." introductionVersion:"1.0.0"`
+	TLSKey                  string     `yaml:"tls_key" env:"NATS_TLS_KEY" desc:"Path/File name for the TLS certificate key (in PEM format) for the NATS listener. If not defined, the root directory derives from $OC_BASE_DATA_PATH/nats." introductionVersion:"1.0.0"`
+	TLSSkipVerifyClientCert bool       `yaml:"tls_skip_verify_client_cert" env:"OC_INSECURE;NATS_TLS_SKIP_VERIFY_CLIENT_CERT" desc:"Whether the NATS server should skip the client certificate verification during the TLS handshake." introductionVersion:"1.0.0"`
+	EnableTLS               bool       `yaml:"enable_tls" env:"OC_EVENTS_ENABLE_TLS;NATS_EVENTS_ENABLE_TLS" desc:"Enable TLS for the connection to the events broker. The events broker is the OpenCloud service which receives and delivers events between the services." introductionVersion:"1.0.0"`
+	Monitoring              Monitoring `yaml:"monitoring"`
 }

--- a/services/nats/pkg/config/defaults/defaultconfig.go
+++ b/services/nats/pkg/config/defaults/defaultconfig.go
@@ -20,6 +20,7 @@ func FullDefaultConfig() *config.Config {
 
 // DefaultConfig returns a basic default configuration
 func DefaultConfig() *config.Config {
+	baseDataPath := defaults.BaseDataPath()
 	return &config.Config{
 		Debug: config.Debug{
 			Addr:   "127.0.0.1:9234",
@@ -34,10 +35,16 @@ func DefaultConfig() *config.Config {
 			Host:      "127.0.0.1",
 			Port:      9233,
 			ClusterID: "opencloud-cluster",
-			StoreDir:  filepath.Join(defaults.BaseDataPath(), "nats"),
-			TLSCert:   filepath.Join(defaults.BaseDataPath(), "nats/tls.crt"),
-			TLSKey:    filepath.Join(defaults.BaseDataPath(), "nats/tls.key"),
+			StoreDir:  filepath.Join(baseDataPath, "nats"),
+			TLSCert:   filepath.Join(baseDataPath, "nats", "tls.crt"),
+			TLSKey:    filepath.Join(baseDataPath, "nats", "tls.key"),
 			EnableTLS: false,
+			Monitoring: config.Monitoring{
+				Enabled:   false,       // don't enable by default for now
+				Host:      "127.0.0.1", // only bind to localhost by default for security reasons
+				Port:      8222,        // default NATS monitoring HTTP endpoint port
+				EnableTLS: false,
+			},
 		},
 	}
 }

--- a/services/nats/pkg/server/nats/options.go
+++ b/services/nats/pkg/server/nats/options.go
@@ -50,3 +50,19 @@ func AllowNonTLS(v bool) NatsOption {
 		o.AllowNonTLS = v
 	}
 }
+
+// enables NATS server monitoring through its HTTP endpoint
+func EnableMonitoringHTTPEndpoint(httpHost string, httpPort int) NatsOption {
+	return func(o *nserver.Options) {
+		o.HTTPHost = httpHost
+		o.HTTPPort = httpPort
+	}
+}
+
+// enables NATS server monitoring through its HTTPS endpoint
+func EnableMonitoringHTTPSEndpoint(httpHost string, httpsPort int) NatsOption {
+	return func(o *nserver.Options) {
+		o.HTTPHost = httpHost
+		o.HTTPSPort = httpsPort
+	}
+}


### PR DESCRIPTION
## Description

Add configuration options to enable the [NATS server HTTP monitoring endpoint](https://www.synadia.com/blog/nats-http-monitoring-endpoints):
* `NATS_MONITORING_ENABLED` (defaults to `false`)
* `NATS_MONITORING_HTTP_HOST` (defaults to `127.0.0.1`)
* `NATS_MONITORING_HTTP_PORT` (defaults to `8222`)
* `NATS_MONITORING_ENABLE_TLS` (defaults to `false`)

Note that, by default, if no configuration changes are made, it does not change the current behaviour: no NATS server monitoring endpoint is enabled nor made available. It requires explicitly enabling it by configuration or environment variable.

## Related Issue
- Fixes #3294

## Motivation and Context
See #3294
* allow monitoring tools such as [`nats-top`](https://github.com/nats-io/nats-top) to inspect consumer stats
* allow Prometheus scraping using [`prometheus-nats-exporter`](https://github.com/nats-io/prometheus-nats-exporter)

## How Has This Been Tested?
- start `opencloud` with `NATS_MONITORING_ENABLED` set to `true`
- run [`nats-top`](https://github.com/nats-io/nats-top) on the same host

To test the Prometheus metrics exporter:
- start `opencloud` with `NATS_MONITORING_ENABLED` set to `true` and `NATS_MONITORING_HTTP_HOST` set to `0.0.0.0`
- start a container of `prometheus-nats-exporter` as follows:
```bash
docker run \
  --add-host host.docker.internal=host-gateway \
  -p 7777:7777 \
  natsio/prometheus-nats-exporter:latest \
  -D -p 7777 \
  -accountz -accstatz -connz_detailed -gatewayz -healthz -leafz -routez -varz \
  http://host.docker.internal:8222
```
- check the list of metrics exported by the exporter:
```bash
curl -sSLf http://localhost:7777/metrics | grep ^gnatsd_
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [X] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added
