### PR TITLE
ci: run search acceptance tests against OpenSearch in nightly

### DIFF
--- a/.woodpecker.star
+++ b/.woodpecker.star
@@ -202,12 +202,14 @@ config = {
                 "apiSearch1",
             ],
             "skip": False,
+            "nightlyOpenSearch": True,
         },
         "search2": {
             "suites": [
                 "apiSearch2",
             ],
             "skip": False,
+            "nightlyOpenSearch": True,
         },
         "sharingNg": {
             "suites": [
@@ -271,6 +273,7 @@ config = {
             ],
             "skip": False,
             "tikaNeeded": True,
+            "nightlyOpenSearch": True,
         },
         "ocm": {
             "suites": [
@@ -817,30 +820,7 @@ def testOpencloud(ctx):
             ],
             "environment": CI_HTTP_PROXY_ENV,
         },
-        {
-            "name": "open-search",
-            "image": OPEN_SEARCH,
-            "detach": True,
-            "environment": {
-                "discovery.type": "single-node",
-                "DISABLE_INSTALL_DEMO_CONFIG": True,
-                "DISABLE_SECURITY_PLUGIN": True,
-            },
-            "entrypoint": ["/usr/share/opensearch/opensearch-docker-entrypoint.sh", "opensearch"],
-        },
-        {
-            "name": "wait-for-open-search",
-            "image": OC_CI_ALPINE,
-            "commands": [
-                "bash -c '" +
-                "until curl -sS \"http://open-search:9200/_cat/health?h=status\" | grep \"green\\|yellow\"; do\n" +
-                "  echo \"Waiting for http://open-search:9200 to be healthy...\"\n" +
-                "  sleep 5\n" +
-                "done\n" +
-                "echo \"http://open-search:9200 healthy...\"\n" +
-                "'",
-            ],
-        },
+    ] + openSearchService() + waitForOpenSearch() + [
         {
             "name": "test",
             "image": OC_CI_GOLANG,
@@ -1284,14 +1264,29 @@ def build_api_test_workflow_matrix(ctx, storage, suite_cfg, default_cfg):
         matrix = {
             "withRemotePhp": m["withRemotePhp"],
             "enableWatchFs": m["enableWatchFs"],
+            "openSearch": False,
         }
         if override_with_remote_php != None:
             matrix["withRemotePhp"] = override_with_remote_php
         if override_enable_watch_fs != None:
             matrix["enableWatchFs"] = override_enable_watch_fs
 
-        if matrix not in workflow_metrices and matrix in matrices:
+        base = {
+            "withRemotePhp": matrix["withRemotePhp"],
+            "enableWatchFs": matrix["enableWatchFs"],
+        }
+        if matrix not in workflow_metrices and base in matrices:
             workflow_metrices.append(matrix)
+
+    # Add an OpenSearch search-engine variant for nightly running search tests
+    if (ctx.build.event == "cron" or ctx.build.event == "pull_request") and storage == "posix" and suite_cfg.get("nightlyOpenSearch", default_cfg["nightlyOpenSearch"]):
+        os_matrix = {
+            "withRemotePhp": False,
+            "enableWatchFs": False,
+            "openSearch": True,
+        }
+        if os_matrix not in workflow_metrices:
+            workflow_metrices.append(os_matrix)
     return workflow_metrices
 
 def localApiTestPipeline(ctx):
@@ -1312,6 +1307,7 @@ def localApiTestPipeline(ctx):
         "withRemotePhp": False,
         "enableWatchFs": False,
         "ldapNeeded": False,
+        "nightlyOpenSearch": False,
     }
 
     if "localApiTests" in config:
@@ -1337,6 +1333,7 @@ def localApiTestPipeline(ctx):
                     for m in matrices:
                         run_with_remote_php = m["withRemotePhp"]
                         run_with_watch_fs = m["enableWatchFs"]
+                        run_with_open_search = m["openSearch"]
 
                         pipeline_name = "test-API"
                         if name.startswith("cli"):
@@ -1347,11 +1344,19 @@ def localApiTestPipeline(ctx):
                             pipeline_name += "-withRemotePhp"
                         if run_with_watch_fs:
                             pipeline_name += "-watchfs"
+                        if run_with_open_search:
+                            pipeline_name += "-opensearch"
+
+                        server_environment = dict(params["extraServerEnvironment"])
+                        if run_with_open_search:
+                            server_environment["SEARCH_ENGINE_TYPE"] = "open-search"
+                            server_environment["SEARCH_ENGINE_OPEN_SEARCH_CLIENT_ADDRESSES"] = "http://open-search:9200"
 
                         pipeline = {
                             "name": pipeline_name,
                             "steps": evaluateWorkflowStep() + restoreBuildArtifactCache(ctx, dirs["opencloudBinArtifact"], dirs["opencloudBinPath"]) +
                                      (tikaService() if params["tikaNeeded"] else []) +
+                                     (waitForOpenSearch() if run_with_open_search else []) +
                                      (waitForWebOffices(["https://collabora:9980", "https://onlyoffice", "http://fakeoffice:8080"]) if params["collaborationServiceNeeded"] else []) +
                                      (waitForClamavService() if params["antivirusNeeded"] else []) +
                                      (waitForEmailService() if params["emailNeeded"] else []) +
@@ -1359,7 +1364,7 @@ def localApiTestPipeline(ctx):
                                      (waitForLdapService() if params["ldapNeeded"] else []) +
                                      opencloudServer(
                                          storage,
-                                         extra_server_environment = params["extraServerEnvironment"],
+                                         extra_server_environment = server_environment,
                                          with_wrapper = True,
                                          tika_enabled = params["tikaNeeded"],
                                          watch_fs_enabled = run_with_watch_fs,
@@ -1371,6 +1376,7 @@ def localApiTestPipeline(ctx):
                                      logRequests(),
                             "services": (emailService() if params["emailNeeded"] else []) +
                                         (clamavService() if params["antivirusNeeded"] else []) +
+                                        (openSearchService() if run_with_open_search else []) +
                                         ((fakeOffice() + collaboraService() + onlyofficeService()) if params["collaborationServiceNeeded"] else []),
                             "depends_on": getPipelineNames(buildOpencloudBinaryForTesting(ctx)),
                             "when": [
@@ -3433,6 +3439,34 @@ def tikaService():
         "image": OC_CI_WAIT_FOR,
         "commands": [
             "wait-for -host tika -port 9998 -timeout 300",
+        ],
+    }]
+
+def openSearchService():
+    return [{
+        "name": "open-search",
+        "image": OPEN_SEARCH,
+        "detach": True,
+        "environment": {
+            "discovery.type": "single-node",
+            "DISABLE_INSTALL_DEMO_CONFIG": True,
+            "DISABLE_SECURITY_PLUGIN": True,
+        },
+        "entrypoint": ["/usr/share/opensearch/opensearch-docker-entrypoint.sh", "opensearch"],
+    }]
+
+def waitForOpenSearch():
+    return [{
+        "name": "wait-for-open-search",
+        "image": OC_CI_ALPINE,
+        "commands": [
+            "bash -c '" +
+            "until curl -sS \"http://open-search:9200/_cat/health?h=status\" | grep \"green\\|yellow\"; do\n" +
+            "  echo \"Waiting for http://open-search:9200 to be healthy...\"\n" +
+            "  sleep 5\n" +
+            "done\n" +
+            "echo \"http://open-search:9200 healthy...\"\n" +
+            "'",
         ],
     }]
 

--- a/.woodpecker.star
+++ b/.woodpecker.star
@@ -1279,7 +1279,7 @@ def build_api_test_workflow_matrix(ctx, storage, suite_cfg, default_cfg):
             workflow_metrices.append(matrix)
 
     # Add an OpenSearch search-engine variant for nightly running search tests
-    if (ctx.build.event == "cron" or ctx.build.event == "pull_request") and storage == "posix" and suite_cfg.get("nightlyOpenSearch", default_cfg["nightlyOpenSearch"]):
+    if (ctx.build.event == "cron" or ctx.build.event == "pull_request") and storage == "posix" and suite_cfg.get("nightlyOpenSearch", False):
         os_matrix = {
             "withRemotePhp": False,
             "enableWatchFs": False,

--- a/.woodpecker.star
+++ b/.woodpecker.star
@@ -820,7 +820,7 @@ def testOpencloud(ctx):
             ],
             "environment": CI_HTTP_PROXY_ENV,
         },
-    ] + openSearchService() + waitForOpenSearch() + [
+    ] + waitForOpenSearch() + [
         {
             "name": "test",
             "image": OC_CI_GOLANG,
@@ -852,6 +852,7 @@ def testOpencloud(ctx):
     pipeline = {
         "name": "test-lint-unit",
         "steps": steps,
+        "services": openSearchService(),
         "when": [
             event["base"],
             event["cron"],
@@ -1279,7 +1280,7 @@ def build_api_test_workflow_matrix(ctx, storage, suite_cfg, default_cfg):
             workflow_metrices.append(matrix)
 
     # Add an OpenSearch search-engine variant for nightly running search tests
-    if (ctx.build.event == "cron" or ctx.build.event == "pull_request") and storage == "posix" and suite_cfg.get("nightlyOpenSearch", False):
+    if ctx.build.event == "cron" and storage == "posix" and suite_cfg.get("nightlyOpenSearch", False):
         os_matrix = {
             "withRemotePhp": False,
             "enableWatchFs": False,
@@ -3446,7 +3447,6 @@ def openSearchService():
     return [{
         "name": "open-search",
         "image": OPEN_SEARCH,
-        "detach": True,
         "environment": {
             "discovery.type": "single-node",
             "DISABLE_INSTALL_DEMO_CONFIG": True,

--- a/tests/acceptance/features/apiSearch1/favoriteSearch.feature
+++ b/tests/acceptance/features/apiSearch1/favoriteSearch.feature
@@ -114,7 +114,7 @@ Feature: search for favorites
     Then the HTTP status code should be "207"
     And the search result should contain "0" entries
 
-
+  @issue-3309
   Scenario: search for favorite files after deleting a file
     Given user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile.txt"
     And user "Alice" has marked file "textfile.txt" as favorite from space "Personal"

--- a/tests/acceptance/features/apiSearch1/search.feature
+++ b/tests/acceptance/features/apiSearch1/search.feature
@@ -97,7 +97,7 @@ Feature: Search
       | new              |
       | spaces           |
 
-  @issue-10329
+  @issue-10329 @issue-3310
   Scenario Outline: user can search hidden files
     Given using <dav-path-version> DAV path
     And user "Alice" has created a folder ".space" in space "project101"
@@ -320,7 +320,7 @@ Feature: Search
       | name:*der2   | subFOLDER2    | patern 'name:''                 |
       | name:"*der2" | subFOLDER2    | pattern 'name:""' (with quotes) |
 
-  @issue-7812 @issue-8442 @issue-10329
+  @issue-7812 @issue-8442 @issue-10329 @issue-3312
   Scenario: try to search with invalid patterns
     Given using spaces DAV path
     And user "Alice" has uploaded file with content "test file" to "testFile.txt"
@@ -395,7 +395,7 @@ Feature: Search
       | new              |
       | spaces           |
 
-  @issue-10329
+  @issue-10329 @issue-3310
   Scenario Outline: search for entry with emoji by pattern
     Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file with content "hello world" to "upload😀 😁.txt"

--- a/tests/acceptance/features/apiSearchContent/contentSearch.feature
+++ b/tests/acceptance/features/apiSearchContent/contentSearch.feature
@@ -26,7 +26,7 @@ Feature: content search
       | new              |
       | spaces           |
 
-  @issue-10329
+  @issue-10329 @issue-3310
   Scenario Outline: search files by different content types
     Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file with content "Using k6, you can test the reliability and performance of your systems" to "wordWithNumber.md"


### PR DESCRIPTION
- running all api-search tests against opensearch in nightly

These tests don't work:
```
- apiSearch1/favoriteSearch.feature:118
- apiSearch1/search.feature:111
- apiSearch1/search.feature:112
- apiSearch1/search.feature:113
- apiSearch1/search.feature:324
- apiSearch1/search.feature:408
- apiSearch1/search.feature:409
- apiSearch1/search.feature:410

- apiSearchContent/contentSearch.feature:49
- apiSearchContent/contentSearch.feature:50
- apiSearchContent/contentSearch.feature:51
```

Created bugs: 
- https://github.com/opencloud-eu/opencloud/issues/3309
- https://github.com/opencloud-eu/opencloud/issues/3310
- https://github.com/opencloud-eu/opencloud/issues/3311
- https://github.com/opencloud-eu/opencloud/issues/3312
