### PR TITLE
feat(web): add rclone-crypt to default apps

### DIFF
--- a/services/web/pkg/config/defaults/defaultconfig.go
+++ b/services/web/pkg/config/defaults/defaultconfig.go
@@ -102,7 +102,7 @@ func DefaultConfig() *config.Config {
 					ResponseType: "code",
 					Scope:        "openid profile email",
 				},
-				Apps: []string{"files", "search", "text-editor", "pdf-viewer", "external", "admin-settings", "epub-reader", "preview", "app-store"},
+				Apps: []string{"files", "search", "text-editor", "pdf-viewer", "external", "admin-settings", "epub-reader", "preview", "app-store", "rclone-crypt"},
 				Options: config.Options{
 					ContextHelpersReadMore: true,
 					AccountEditLink:        &config.AccountEditLink{},


### PR DESCRIPTION
Enable the `rclone-crypt` app per default for the upcoming release.