### PR TITLE
Fix opensearch space scope

### DIFF
--- a/services/search/pkg/opensearch/backend_test.go
+++ b/services/search/pkg/opensearch/backend_test.go
@@ -1,13 +1,15 @@
 package opensearch_test
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	opensearchgo "github.com/opensearch-project/opensearch-go/v4"
 	opensearchgoAPI "github.com/opensearch-project/opensearch-go/v4/opensearchapi"
-	"github.com/stretchr/testify/require"
 
 	searchService "github.com/opencloud-eu/opencloud/protogen/gen/opencloud/services/search/v0"
 	"github.com/opencloud-eu/opencloud/services/search/pkg/opensearch"
@@ -15,278 +17,21 @@ import (
 	"github.com/opencloud-eu/opencloud/services/search/pkg/search"
 )
 
-func TestNewBackend(t *testing.T) {
-	t.Run("fails to create if the cluster is not healthy", func(t *testing.T) {
-		client, err := opensearchgoAPI.NewClient(opensearchgoAPI.Config{
-			Client: opensearchgo.Config{
-				Addresses: []string{"http://localhost:1025"},
-			},
-		})
-		require.NoError(t, err, "failed to create OpenSearch client")
+func TestOpenSearchBackend(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "OpenSearch Backend Suite")
+}
 
-		backend, err := opensearch.NewBackend("test-engine-new-engine", client)
-		require.Nil(t, backend)
-		require.ErrorIs(t, err, opensearch.ErrUnhealthyCluster)
+func deleteIndexOnCleanup(tc *opensearchtest.TestClient, indexName string) {
+	DeferCleanup(func() {
+		Expect(tc.IndicesDelete(context.Background(), []string{indexName})).To(Succeed())
 	})
 }
 
-func TestEngine_Search(t *testing.T) {
-	indexName := "opencloud-test-engine-search"
-	tc := opensearchtest.NewDefaultTestClient(t, defaultConfig.Engine.OpenSearch.Client)
-	tc.Require.IndicesReset([]string{indexName})
-	tc.Require.IndicesCount([]string{indexName}, nil, 0)
+func resourceByID(tc *opensearchtest.TestClient, index, id string) search.Resource {
+	GinkgoHelper()
 
-	defer tc.Require.IndicesDelete([]string{indexName})
-
-	backend, err := opensearch.NewBackend(indexName, tc.Client())
-	require.NoError(t, err)
-
-	document := opensearchtest.Testdata.Resources.File
-	tc.Require.DocumentCreate(indexName, document.ID, strings.NewReader(opensearchtest.JSONMustMarshal(t, document)))
-	tc.Require.IndicesCount([]string{indexName}, nil, 1)
-
-	t.Run("most simple search", func(t *testing.T) {
-		resp, err := backend.Search(t.Context(), &searchService.SearchIndexRequest{
-			Query: fmt.Sprintf(`"%s"`, document.Name),
-		})
-		require.NoError(t, err)
-		require.Len(t, resp.Matches, 1)
-		require.Equal(t, int32(1), resp.TotalMatches)
-		require.Equal(t, document.ID, fmt.Sprintf("%s$%s!%s", resp.Matches[0].Entity.Id.StorageId, resp.Matches[0].Entity.Id.SpaceId, resp.Matches[0].Entity.Id.OpaqueId))
-	})
-
-	t.Run("ignores files that are marked as deleted", func(t *testing.T) {
-		deletedDocument := opensearchtest.Testdata.Resources.File
-		deletedDocument.ID = "1$2!4"
-		deletedDocument.Deleted = true
-
-		tc.Require.DocumentCreate(indexName, deletedDocument.ID, strings.NewReader(opensearchtest.JSONMustMarshal(t, deletedDocument)))
-		tc.Require.IndicesCount([]string{indexName}, nil, 2)
-
-		resp, err := backend.Search(t.Context(), &searchService.SearchIndexRequest{
-			Query: fmt.Sprintf(`"%s"`, document.Name),
-		})
-		require.NoError(t, err)
-		require.Len(t, resp.Matches, 1)
-		require.Equal(t, int32(1), resp.TotalMatches)
-		require.Equal(t, document.ID, fmt.Sprintf("%s$%s!%s", resp.Matches[0].Entity.Id.StorageId, resp.Matches[0].Entity.Id.SpaceId, resp.Matches[0].Entity.Id.OpaqueId))
-	})
-}
-
-func TestEngine_Upsert(t *testing.T) {
-	indexName := "opencloud-test-engine-upsert"
-	tc := opensearchtest.NewDefaultTestClient(t, defaultConfig.Engine.OpenSearch.Client)
-	tc.Require.IndicesReset([]string{indexName})
-	tc.Require.IndicesCount([]string{indexName}, nil, 0)
-
-	defer tc.Require.IndicesDelete([]string{indexName})
-
-	backend, err := opensearch.NewBackend(indexName, tc.Client())
-	require.NoError(t, err)
-
-	t.Run("upsert with full document", func(t *testing.T) {
-		document := opensearchtest.Testdata.Resources.File
-		require.NoError(t, backend.Upsert(document.ID, document))
-
-		tc.Require.IndicesCount([]string{indexName}, nil, 1)
-	})
-}
-
-func TestEngine_Move(t *testing.T) {
-	indexName := "opencloud-test-engine-move"
-	tc := opensearchtest.NewDefaultTestClient(t, defaultConfig.Engine.OpenSearch.Client)
-	tc.Require.IndicesReset([]string{indexName})
-	tc.Require.IndicesCount([]string{indexName}, nil, 0)
-
-	defer tc.Require.IndicesDelete([]string{indexName})
-
-	backend, err := opensearch.NewBackend(indexName, tc.Client())
-	require.NoError(t, err)
-
-	t.Run("moves the document to a new path", func(t *testing.T) {
-		document := opensearchtest.Testdata.Resources.File
-		tc.Require.DocumentCreate(indexName, document.ID, strings.NewReader(opensearchtest.JSONMustMarshal(t, document)))
-		tc.Require.IndicesCount([]string{indexName}, nil, 1)
-
-		body := opensearchtest.JSONMustMarshal(t, map[string]any{
-			"query": map[string]any{
-				"ids": map[string]any{
-					"values": []string{document.ID},
-				},
-			},
-		})
-
-		resources := opensearchtest.SearchHitsMustBeConverted[search.Resource](t, tc.Require.Search(indexName, strings.NewReader(body)).Hits)
-		require.Len(t, resources, 1)
-		require.Equal(t, document.Path, resources[0].Path)
-
-		document.Path = "./new/path/to/resource"
-		require.NoError(t, backend.Move(document.ID, document.ParentID, document.Path))
-
-		resources = opensearchtest.SearchHitsMustBeConverted[search.Resource](t, tc.Require.Search(indexName, strings.NewReader(body)).Hits)
-		require.Len(t, resources, 1)
-		require.Equal(t, document.Path, resources[0].Path)
-	})
-}
-
-func TestEngine_Delete(t *testing.T) {
-	indexName := "opencloud-test-engine-delete"
-	tc := opensearchtest.NewDefaultTestClient(t, defaultConfig.Engine.OpenSearch.Client)
-	tc.Require.IndicesReset([]string{indexName})
-	tc.Require.IndicesCount([]string{indexName}, nil, 0)
-
-	defer tc.Require.IndicesDelete([]string{indexName})
-
-	backend, err := opensearch.NewBackend(indexName, tc.Client())
-	require.NoError(t, err)
-
-	t.Run("mark document as deleted", func(t *testing.T) {
-		document := opensearchtest.Testdata.Resources.File
-		tc.Require.DocumentCreate(indexName, document.ID, strings.NewReader(opensearchtest.JSONMustMarshal(t, document)))
-		tc.Require.IndicesCount([]string{indexName}, nil, 1)
-
-		body := opensearchtest.JSONMustMarshal(t, map[string]any{
-			"query": map[string]any{
-				"term": map[string]any{
-					"Deleted": map[string]any{
-						"value": true,
-					},
-				},
-			},
-		})
-
-		tc.Require.IndicesCount([]string{indexName}, strings.NewReader(body), 0)
-
-		require.NoError(t, backend.Delete(document.ID))
-		tc.Require.IndicesCount([]string{indexName}, strings.NewReader(body), 1)
-	})
-}
-
-func TestEngine_Restore(t *testing.T) {
-	indexName := "opencloud-test-engine-restore"
-	tc := opensearchtest.NewDefaultTestClient(t, defaultConfig.Engine.OpenSearch.Client)
-	tc.Require.IndicesReset([]string{indexName})
-	tc.Require.IndicesCount([]string{indexName}, nil, 0)
-
-	defer tc.Require.IndicesDelete([]string{indexName})
-
-	backend, err := opensearch.NewBackend(indexName, tc.Client())
-	require.NoError(t, err)
-
-	t.Run("mark document as not deleted", func(t *testing.T) {
-		document := opensearchtest.Testdata.Resources.File
-		document.Deleted = true
-		tc.Require.DocumentCreate(indexName, document.ID, strings.NewReader(opensearchtest.JSONMustMarshal(t, document)))
-		tc.Require.IndicesCount([]string{indexName}, nil, 1)
-
-		body := opensearchtest.JSONMustMarshal(t, map[string]any{
-			"query": map[string]any{
-				"term": map[string]any{
-					"Deleted": map[string]any{
-						"value": true,
-					},
-				},
-			},
-		})
-
-		tc.Require.IndicesCount([]string{indexName}, strings.NewReader(body), 1)
-
-		require.NoError(t, backend.Restore(document.ID))
-		tc.Require.IndicesCount([]string{indexName}, strings.NewReader(body), 0)
-	})
-}
-
-func TestEngine_Purge(t *testing.T) {
-	indexName := "opencloud-test-engine-purge"
-	tc := opensearchtest.NewDefaultTestClient(t, defaultConfig.Engine.OpenSearch.Client)
-	tc.Require.IndicesReset([]string{indexName})
-	tc.Require.IndicesCount([]string{indexName}, nil, 0)
-
-	defer tc.Require.IndicesDelete([]string{indexName})
-
-	backend, err := opensearch.NewBackend(indexName, tc.Client())
-	require.NoError(t, err)
-
-	t.Run("purge with full document", func(t *testing.T) {
-		document := opensearchtest.Testdata.Resources.File
-		tc.Require.DocumentCreate(indexName, document.ID, strings.NewReader(opensearchtest.JSONMustMarshal(t, document)))
-		tc.Require.IndicesCount([]string{indexName}, nil, 1)
-
-		require.NoError(t, backend.Purge(document.ID, false))
-
-		tc.Require.IndicesCount([]string{indexName}, nil, 0)
-	})
-
-	t.Run("purge resource trees", func(t *testing.T) {
-		resourceFolder := opensearchtest.Testdata.Resources.Folder
-		tc.Require.DocumentCreate(indexName, resourceFolder.ID, strings.NewReader(opensearchtest.JSONMustMarshal(t, resourceFolder)))
-
-		resourceFile := opensearchtest.Testdata.Resources.File
-		tc.Require.DocumentCreate(indexName, resourceFile.ID, strings.NewReader(opensearchtest.JSONMustMarshal(t, resourceFile)))
-
-		tc.Require.IndicesCount([]string{indexName}, nil, 2)
-
-		require.NoError(t, backend.Purge(resourceFolder.ID, false))
-
-		tc.Require.IndicesCount([]string{indexName}, nil, 0)
-	})
-
-	t.Run("purge resource trees and ignores undeleted resources", func(t *testing.T) {
-		resourceFolder := opensearchtest.Testdata.Resources.Folder
-		tc.Require.DocumentCreate(indexName, resourceFolder.ID, strings.NewReader(opensearchtest.JSONMustMarshal(t, resourceFolder)))
-
-		resourceFile := opensearchtest.Testdata.Resources.File
-		tc.Require.DocumentCreate(indexName, resourceFile.ID, strings.NewReader(opensearchtest.JSONMustMarshal(t, resourceFile)))
-
-		tc.Require.IndicesCount([]string{indexName}, nil, 2)
-
-		require.NoError(t, backend.Delete(resourceFile.ID))
-		tc.Require.IndicesRefresh([]string{indexName}, nil)
-		require.NoError(t, backend.Purge(resourceFolder.ID, true))
-
-		tc.Require.IndicesCount([]string{indexName}, nil, 1)
-	})
-}
-
-func TestEngine_DocCount(t *testing.T) {
-	indexName := "opencloud-test-engine-doc-count"
-	tc := opensearchtest.NewDefaultTestClient(t, defaultConfig.Engine.OpenSearch.Client)
-	tc.Require.IndicesReset([]string{indexName})
-	tc.Require.IndicesCount([]string{indexName}, nil, 0)
-
-	defer tc.Require.IndicesDelete([]string{indexName})
-
-	backend, err := opensearch.NewBackend(indexName, tc.Client())
-	require.NoError(t, err)
-
-	t.Run("ignore deleted documents", func(t *testing.T) {
-		document := opensearchtest.Testdata.Resources.File
-		tc.Require.DocumentCreate(indexName, document.ID, strings.NewReader(opensearchtest.JSONMustMarshal(t, document)))
-		tc.Require.IndicesCount([]string{indexName}, nil, 1)
-
-		count, err := backend.DocCount()
-		require.NoError(t, err)
-		require.Equal(t, uint64(1), count)
-
-		tc.Require.Update(indexName, document.ID, strings.NewReader(opensearchtest.JSONMustMarshal(t, map[string]any{
-			"doc": map[string]any{
-				"Deleted": true,
-			},
-		})))
-
-		tc.Require.IndicesCount([]string{indexName}, nil, 1)
-
-		count, err = backend.DocCount()
-		require.NoError(t, err)
-		require.Equal(t, uint64(0), count)
-	})
-}
-
-// resourceByID fetches a single indexed resource by its document ID.
-func resourceByID(t *testing.T, tc *opensearchtest.TestClient, index, id string) search.Resource {
-	t.Helper()
-
-	body := opensearchtest.JSONMustMarshal(t, map[string]any{
+	body := opensearchtest.JSONMustMarshal(GinkgoTB(), map[string]any{
 		"query": map[string]any{
 			"ids": map[string]any{
 				"values": []string{id},
@@ -294,8 +39,8 @@ func resourceByID(t *testing.T, tc *opensearchtest.TestClient, index, id string)
 		},
 	})
 
-	resources := opensearchtest.SearchHitsMustBeConverted[search.Resource](t, tc.Require.Search(index, strings.NewReader(body)).Hits)
-	require.Len(t, resources, 1)
+	resources := opensearchtest.SearchHitsMustBeConverted[search.Resource](GinkgoTB(), tc.Require.Search(index, strings.NewReader(body)).Hits)
+	Expect(resources).To(HaveLen(1))
 	return resources[0]
 }
 
@@ -309,74 +54,398 @@ func otherRoot(r search.Resource) search.Resource {
 	return r
 }
 
-// newRootScopeBackend resets the index, applies the resource mapping via NewBackend and
-// indexes the given resources. It is used by the root-scope tests below.
-func newRootScopeBackend(t *testing.T, indexName string, resources ...search.Resource) (*opensearch.Backend, *opensearchtest.TestClient) {
-	t.Helper()
+func newBackend(indexName string, resources ...search.Resource) (*opensearch.Backend, *opensearchtest.TestClient) {
+	GinkgoHelper()
 
-	tc := opensearchtest.NewDefaultTestClient(t, defaultConfig.Engine.OpenSearch.Client)
+	tc := opensearchtest.NewDefaultTestClient(GinkgoTB(), defaultConfig.Engine.OpenSearch.Client)
 	tc.Require.IndicesReset([]string{indexName})
 	tc.Require.IndicesCount([]string{indexName}, nil, 0)
 
 	backend, err := opensearch.NewBackend(indexName, tc.Client())
-	require.NoError(t, err)
+	Expect(err).ToNot(HaveOccurred())
 
 	for _, r := range resources {
-		tc.Require.DocumentCreate(indexName, r.ID, strings.NewReader(opensearchtest.JSONMustMarshal(t, r)))
+		tc.Require.DocumentCreate(indexName, r.ID, strings.NewReader(opensearchtest.JSONMustMarshal(GinkgoTB(), r)))
 	}
 	tc.Require.IndicesCount([]string{indexName}, nil, len(resources))
 
 	return backend, tc
 }
 
-// TestEngine_UpdateSelfAndDescendants_RootScope ensures that updates which affect a
-// resource and its descendants (Delete, Restore, Move) are scoped to the root (space)
-// of the target resource. Two resources living in different roots may share the exact
-// same path, so matching by path alone would incorrectly update the wrong resource.
-func TestEngine_UpdateSelfAndDescendants_RootScope(t *testing.T) {
-	t.Run("delete only affects the resource in the target root", func(t *testing.T) {
-		indexName := "opencloud-test-engine-root-scope-delete"
+var _ = Describe("Backend", func() {
+	Describe("NewBackend", func() {
+		It("fails to create if the cluster is not healthy", func() {
+			client, err := opensearchgoAPI.NewClient(opensearchgoAPI.Config{
+				Client: opensearchgo.Config{
+					Addresses: []string{"http://localhost:1025"},
+				},
+			})
+			Expect(err).ToNot(HaveOccurred(), "failed to create OpenSearch client")
 
-		target := opensearchtest.Testdata.Resources.File
-		other := otherRoot(target)
-
-		backend, tc := newRootScopeBackend(t, indexName, target, other)
-		defer tc.Require.IndicesDelete([]string{indexName})
-
-		require.NoError(t, backend.Delete(target.ID))
-
-		require.True(t, resourceByID(t, tc, indexName, target.ID).Deleted, "target resource should be marked as deleted")
-		require.False(t, resourceByID(t, tc, indexName, other.ID).Deleted, "resource in a different root must not be affected")
+			backend, err := opensearch.NewBackend("test-engine-new-engine", client)
+			Expect(backend).To(BeNil())
+			Expect(err).To(MatchError(opensearch.ErrUnhealthyCluster))
+		})
 	})
 
-	t.Run("restore only affects the resource in the target root", func(t *testing.T) {
-		indexName := "opencloud-test-engine-root-scope-restore"
+	Describe("Search", func() {
+		const indexName = "opencloud-test-engine-search"
 
-		target := opensearchtest.Testdata.Resources.File
-		target.Deleted = true
-		other := otherRoot(target)
+		var (
+			tc       *opensearchtest.TestClient
+			backend  *opensearch.Backend
+			document search.Resource
+		)
 
-		backend, tc := newRootScopeBackend(t, indexName, target, other)
-		defer tc.Require.IndicesDelete([]string{indexName})
+		BeforeEach(func() {
+			tc = opensearchtest.NewDefaultTestClient(GinkgoTB(), defaultConfig.Engine.OpenSearch.Client)
+			tc.Require.IndicesReset([]string{indexName})
+			tc.Require.IndicesCount([]string{indexName}, nil, 0)
+			deleteIndexOnCleanup(tc, indexName)
 
-		require.NoError(t, backend.Restore(target.ID))
+			var err error
+			backend, err = opensearch.NewBackend(indexName, tc.Client())
+			Expect(err).ToNot(HaveOccurred())
 
-		require.False(t, resourceByID(t, tc, indexName, target.ID).Deleted, "target resource should be restored")
-		require.True(t, resourceByID(t, tc, indexName, other.ID).Deleted, "resource in a different root must not be affected")
+			document = opensearchtest.Testdata.Resources.File
+			tc.Require.DocumentCreate(indexName, document.ID, strings.NewReader(opensearchtest.JSONMustMarshal(GinkgoTB(), document)))
+			tc.Require.IndicesCount([]string{indexName}, nil, 1)
+		})
+
+		It("performs the most simple search", func() {
+			resp, err := backend.Search(context.Background(), &searchService.SearchIndexRequest{
+				Query: fmt.Sprintf(`"%s"`, document.Name),
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(resp.Matches).To(HaveLen(1))
+			Expect(resp.TotalMatches).To(Equal(int32(1)))
+			Expect(fmt.Sprintf("%s$%s!%s", resp.Matches[0].Entity.Id.StorageId, resp.Matches[0].Entity.Id.SpaceId, resp.Matches[0].Entity.Id.OpaqueId)).To(Equal(document.ID))
+		})
+
+		It("ignores files that are marked as deleted", func() {
+			deletedDocument := opensearchtest.Testdata.Resources.File
+			deletedDocument.ID = "1$2!4"
+			deletedDocument.Deleted = true
+
+			tc.Require.DocumentCreate(indexName, deletedDocument.ID, strings.NewReader(opensearchtest.JSONMustMarshal(GinkgoTB(), deletedDocument)))
+			tc.Require.IndicesCount([]string{indexName}, nil, 2)
+
+			resp, err := backend.Search(context.Background(), &searchService.SearchIndexRequest{
+				Query: fmt.Sprintf(`"%s"`, document.Name),
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(resp.Matches).To(HaveLen(1))
+			Expect(resp.TotalMatches).To(Equal(int32(1)))
+			Expect(fmt.Sprintf("%s$%s!%s", resp.Matches[0].Entity.Id.StorageId, resp.Matches[0].Entity.Id.SpaceId, resp.Matches[0].Entity.Id.OpaqueId)).To(Equal(document.ID))
+		})
 	})
 
-	t.Run("move only affects the resource in the target root", func(t *testing.T) {
-		indexName := "opencloud-test-engine-root-scope-move"
+	Describe("Upsert", func() {
+		const indexName = "opencloud-test-engine-upsert"
 
-		target := opensearchtest.Testdata.Resources.File
-		other := otherRoot(target)
+		var (
+			tc      *opensearchtest.TestClient
+			backend *opensearch.Backend
+		)
 
-		backend, tc := newRootScopeBackend(t, indexName, target, other)
-		defer tc.Require.IndicesDelete([]string{indexName})
+		BeforeEach(func() {
+			tc = opensearchtest.NewDefaultTestClient(GinkgoTB(), defaultConfig.Engine.OpenSearch.Client)
+			tc.Require.IndicesReset([]string{indexName})
+			tc.Require.IndicesCount([]string{indexName}, nil, 0)
+			deleteIndexOnCleanup(tc, indexName)
 
-		require.NoError(t, backend.Move(target.ID, target.ParentID, "./new/path/to/resource"))
+			var err error
+			backend, err = opensearch.NewBackend(indexName, tc.Client())
+			Expect(err).ToNot(HaveOccurred())
+		})
 
-		require.Equal(t, "./new/path/to/resource", resourceByID(t, tc, indexName, target.ID).Path, "target resource should be moved")
-		require.Equal(t, other.Path, resourceByID(t, tc, indexName, other.ID).Path, "resource in a different root must not be moved")
+		It("upserts a full document", func() {
+			document := opensearchtest.Testdata.Resources.File
+			Expect(backend.Upsert(document.ID, document)).To(Succeed())
+
+			tc.Require.IndicesCount([]string{indexName}, nil, 1)
+		})
 	})
-}
+
+	Describe("Move", func() {
+		const indexName = "opencloud-test-engine-move"
+
+		var (
+			tc      *opensearchtest.TestClient
+			backend *opensearch.Backend
+		)
+
+		BeforeEach(func() {
+			tc = opensearchtest.NewDefaultTestClient(GinkgoTB(), defaultConfig.Engine.OpenSearch.Client)
+			tc.Require.IndicesReset([]string{indexName})
+			tc.Require.IndicesCount([]string{indexName}, nil, 0)
+			deleteIndexOnCleanup(tc, indexName)
+
+			var err error
+			backend, err = opensearch.NewBackend(indexName, tc.Client())
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("moves the document to a new path", func() {
+			document := opensearchtest.Testdata.Resources.File
+			tc.Require.DocumentCreate(indexName, document.ID, strings.NewReader(opensearchtest.JSONMustMarshal(GinkgoTB(), document)))
+			tc.Require.IndicesCount([]string{indexName}, nil, 1)
+
+			body := opensearchtest.JSONMustMarshal(GinkgoTB(), map[string]any{
+				"query": map[string]any{
+					"ids": map[string]any{
+						"values": []string{document.ID},
+					},
+				},
+			})
+
+			resources := opensearchtest.SearchHitsMustBeConverted[search.Resource](GinkgoTB(), tc.Require.Search(indexName, strings.NewReader(body)).Hits)
+			Expect(resources).To(HaveLen(1))
+			Expect(resources[0].Path).To(Equal(document.Path))
+
+			document.Path = "./new/path/to/resource"
+			Expect(backend.Move(document.ID, document.ParentID, document.Path)).To(Succeed())
+
+			resources = opensearchtest.SearchHitsMustBeConverted[search.Resource](GinkgoTB(), tc.Require.Search(indexName, strings.NewReader(body)).Hits)
+			Expect(resources).To(HaveLen(1))
+			Expect(resources[0].Path).To(Equal(document.Path))
+		})
+	})
+
+	Describe("Delete", func() {
+		const indexName = "opencloud-test-engine-delete"
+
+		var (
+			tc      *opensearchtest.TestClient
+			backend *opensearch.Backend
+		)
+
+		BeforeEach(func() {
+			tc = opensearchtest.NewDefaultTestClient(GinkgoTB(), defaultConfig.Engine.OpenSearch.Client)
+			tc.Require.IndicesReset([]string{indexName})
+			tc.Require.IndicesCount([]string{indexName}, nil, 0)
+			deleteIndexOnCleanup(tc, indexName)
+
+			var err error
+			backend, err = opensearch.NewBackend(indexName, tc.Client())
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("marks the document as deleted", func() {
+			document := opensearchtest.Testdata.Resources.File
+			tc.Require.DocumentCreate(indexName, document.ID, strings.NewReader(opensearchtest.JSONMustMarshal(GinkgoTB(), document)))
+			tc.Require.IndicesCount([]string{indexName}, nil, 1)
+
+			body := opensearchtest.JSONMustMarshal(GinkgoTB(), map[string]any{
+				"query": map[string]any{
+					"term": map[string]any{
+						"Deleted": map[string]any{
+							"value": true,
+						},
+					},
+				},
+			})
+
+			tc.Require.IndicesCount([]string{indexName}, strings.NewReader(body), 0)
+
+			Expect(backend.Delete(document.ID)).To(Succeed())
+			tc.Require.IndicesCount([]string{indexName}, strings.NewReader(body), 1)
+		})
+	})
+
+	Describe("Restore", func() {
+		const indexName = "opencloud-test-engine-restore"
+
+		var (
+			tc      *opensearchtest.TestClient
+			backend *opensearch.Backend
+		)
+
+		BeforeEach(func() {
+			tc = opensearchtest.NewDefaultTestClient(GinkgoTB(), defaultConfig.Engine.OpenSearch.Client)
+			tc.Require.IndicesReset([]string{indexName})
+			tc.Require.IndicesCount([]string{indexName}, nil, 0)
+			deleteIndexOnCleanup(tc, indexName)
+
+			var err error
+			backend, err = opensearch.NewBackend(indexName, tc.Client())
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("marks the document as not deleted", func() {
+			document := opensearchtest.Testdata.Resources.File
+			document.Deleted = true
+			tc.Require.DocumentCreate(indexName, document.ID, strings.NewReader(opensearchtest.JSONMustMarshal(GinkgoTB(), document)))
+			tc.Require.IndicesCount([]string{indexName}, nil, 1)
+
+			body := opensearchtest.JSONMustMarshal(GinkgoTB(), map[string]any{
+				"query": map[string]any{
+					"term": map[string]any{
+						"Deleted": map[string]any{
+							"value": true,
+						},
+					},
+				},
+			})
+
+			tc.Require.IndicesCount([]string{indexName}, strings.NewReader(body), 1)
+
+			Expect(backend.Restore(document.ID)).To(Succeed())
+			tc.Require.IndicesCount([]string{indexName}, strings.NewReader(body), 0)
+		})
+	})
+
+	Describe("Purge", func() {
+		const indexName = "opencloud-test-engine-purge"
+
+		var (
+			tc      *opensearchtest.TestClient
+			backend *opensearch.Backend
+		)
+
+		BeforeEach(func() {
+			tc = opensearchtest.NewDefaultTestClient(GinkgoTB(), defaultConfig.Engine.OpenSearch.Client)
+			tc.Require.IndicesReset([]string{indexName})
+			tc.Require.IndicesCount([]string{indexName}, nil, 0)
+			deleteIndexOnCleanup(tc, indexName)
+
+			var err error
+			backend, err = opensearch.NewBackend(indexName, tc.Client())
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("purges a full document", func() {
+			document := opensearchtest.Testdata.Resources.File
+			tc.Require.DocumentCreate(indexName, document.ID, strings.NewReader(opensearchtest.JSONMustMarshal(GinkgoTB(), document)))
+			tc.Require.IndicesCount([]string{indexName}, nil, 1)
+
+			Expect(backend.Purge(document.ID, false)).To(Succeed())
+
+			tc.Require.IndicesCount([]string{indexName}, nil, 0)
+		})
+
+		It("purges resource trees", func() {
+			resourceFolder := opensearchtest.Testdata.Resources.Folder
+			tc.Require.DocumentCreate(indexName, resourceFolder.ID, strings.NewReader(opensearchtest.JSONMustMarshal(GinkgoTB(), resourceFolder)))
+
+			resourceFile := opensearchtest.Testdata.Resources.File
+			tc.Require.DocumentCreate(indexName, resourceFile.ID, strings.NewReader(opensearchtest.JSONMustMarshal(GinkgoTB(), resourceFile)))
+
+			tc.Require.IndicesCount([]string{indexName}, nil, 2)
+
+			Expect(backend.Purge(resourceFolder.ID, false)).To(Succeed())
+
+			tc.Require.IndicesCount([]string{indexName}, nil, 0)
+		})
+
+		It("purges resource trees and ignores undeleted resources", func() {
+			resourceFolder := opensearchtest.Testdata.Resources.Folder
+			tc.Require.DocumentCreate(indexName, resourceFolder.ID, strings.NewReader(opensearchtest.JSONMustMarshal(GinkgoTB(), resourceFolder)))
+
+			resourceFile := opensearchtest.Testdata.Resources.File
+			tc.Require.DocumentCreate(indexName, resourceFile.ID, strings.NewReader(opensearchtest.JSONMustMarshal(GinkgoTB(), resourceFile)))
+
+			tc.Require.IndicesCount([]string{indexName}, nil, 2)
+
+			Expect(backend.Delete(resourceFile.ID)).To(Succeed())
+			tc.Require.IndicesRefresh([]string{indexName}, nil)
+			Expect(backend.Purge(resourceFolder.ID, true)).To(Succeed())
+
+			tc.Require.IndicesCount([]string{indexName}, nil, 1)
+		})
+	})
+
+	Describe("DocCount", func() {
+		const indexName = "opencloud-test-engine-doc-count"
+
+		var (
+			tc      *opensearchtest.TestClient
+			backend *opensearch.Backend
+		)
+
+		BeforeEach(func() {
+			tc = opensearchtest.NewDefaultTestClient(GinkgoTB(), defaultConfig.Engine.OpenSearch.Client)
+			tc.Require.IndicesReset([]string{indexName})
+			tc.Require.IndicesCount([]string{indexName}, nil, 0)
+			deleteIndexOnCleanup(tc, indexName)
+
+			var err error
+			backend, err = opensearch.NewBackend(indexName, tc.Client())
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("ignores deleted documents", func() {
+			document := opensearchtest.Testdata.Resources.File
+			tc.Require.DocumentCreate(indexName, document.ID, strings.NewReader(opensearchtest.JSONMustMarshal(GinkgoTB(), document)))
+			tc.Require.IndicesCount([]string{indexName}, nil, 1)
+
+			count, err := backend.DocCount()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(count).To(Equal(uint64(1)))
+
+			tc.Require.Update(indexName, document.ID, strings.NewReader(opensearchtest.JSONMustMarshal(GinkgoTB(), map[string]any{
+				"doc": map[string]any{
+					"Deleted": true,
+				},
+			})))
+
+			tc.Require.IndicesCount([]string{indexName}, nil, 1)
+
+			count, err = backend.DocCount()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(count).To(Equal(uint64(0)))
+		})
+	})
+
+	// The following specs ensure that updates which affect a resource and its descendants
+	// (Delete, Restore, Move) are scoped to the root (space) of the target resource. Two
+	// resources living in different roots may share the exact same path, so matching by
+	// path alone would incorrectly update the wrong resource.
+	Describe("updateSelfAndDescendants root scope", func() {
+		It("deletes only the resource in the target root", func() {
+			const indexName = "opencloud-test-engine-root-scope-delete"
+
+			target := opensearchtest.Testdata.Resources.File
+			other := otherRoot(target)
+
+			backend, tc := newBackend(indexName, target, other)
+			deleteIndexOnCleanup(tc, indexName)
+
+			Expect(backend.Delete(target.ID)).To(Succeed())
+
+			Expect(resourceByID(tc, indexName, target.ID).Deleted).To(BeTrue(), "target resource should be marked as deleted")
+			Expect(resourceByID(tc, indexName, other.ID).Deleted).To(BeFalse(), "resource in a different root must not be affected")
+		})
+
+		It("restores only the resource in the target root", func() {
+			const indexName = "opencloud-test-engine-root-scope-restore"
+
+			target := opensearchtest.Testdata.Resources.File
+			target.Deleted = true
+			other := otherRoot(target)
+
+			backend, tc := newBackend(indexName, target, other)
+			deleteIndexOnCleanup(tc, indexName)
+
+			Expect(backend.Restore(target.ID)).To(Succeed())
+
+			Expect(resourceByID(tc, indexName, target.ID).Deleted).To(BeFalse(), "target resource should be restored")
+			Expect(resourceByID(tc, indexName, other.ID).Deleted).To(BeTrue(), "resource in a different root must not be affected")
+		})
+
+		It("moves only the resource in the target root", func() {
+			const indexName = "opencloud-test-engine-root-scope-move"
+
+			target := opensearchtest.Testdata.Resources.File
+			other := otherRoot(target)
+
+			backend, tc := newBackend(indexName, target, other)
+			deleteIndexOnCleanup(tc, indexName)
+
+			Expect(backend.Move(target.ID, target.ParentID, "./new/path/to/resource")).To(Succeed())
+
+			Expect(resourceByID(tc, indexName, target.ID).Path).To(Equal("./new/path/to/resource"), "target resource should be moved")
+			Expect(resourceByID(tc, indexName, other.ID).Path).To(Equal(other.Path), "resource in a different root must not be moved")
+		})
+	})
+})

--- a/services/search/pkg/opensearch/backend_test.go
+++ b/services/search/pkg/opensearch/backend_test.go
@@ -11,7 +11,7 @@ import (
 
 	searchService "github.com/opencloud-eu/opencloud/protogen/gen/opencloud/services/search/v0"
 	"github.com/opencloud-eu/opencloud/services/search/pkg/opensearch"
-	"github.com/opencloud-eu/opencloud/services/search/pkg/opensearch/internal/test"
+	opensearchtest "github.com/opencloud-eu/opencloud/services/search/pkg/opensearch/internal/test"
 	"github.com/opencloud-eu/opencloud/services/search/pkg/search"
 )
 
@@ -279,5 +279,104 @@ func TestEngine_DocCount(t *testing.T) {
 		count, err = backend.DocCount()
 		require.NoError(t, err)
 		require.Equal(t, uint64(0), count)
+	})
+}
+
+// resourceByID fetches a single indexed resource by its document ID.
+func resourceByID(t *testing.T, tc *opensearchtest.TestClient, index, id string) search.Resource {
+	t.Helper()
+
+	body := opensearchtest.JSONMustMarshal(t, map[string]any{
+		"query": map[string]any{
+			"ids": map[string]any{
+				"values": []string{id},
+			},
+		},
+	})
+
+	resources := opensearchtest.SearchHitsMustBeConverted[search.Resource](t, tc.Require.Search(index, strings.NewReader(body)).Hits)
+	require.Len(t, resources, 1)
+	return resources[0]
+}
+
+// otherRoot returns a copy of the given resource that lives in a different root (space)
+// while keeping the same path, so it can be used to assert that cross-root updates do
+// not affect identically-named resources in other roots.
+func otherRoot(r search.Resource) search.Resource {
+	r.ID = "2$2!3"
+	r.RootID = "2$2!1"
+	r.ParentID = "2$2!2"
+	return r
+}
+
+// newRootScopeBackend resets the index, applies the resource mapping via NewBackend and
+// indexes the given resources. It is used by the root-scope tests below.
+func newRootScopeBackend(t *testing.T, indexName string, resources ...search.Resource) (*opensearch.Backend, *opensearchtest.TestClient) {
+	t.Helper()
+
+	tc := opensearchtest.NewDefaultTestClient(t, defaultConfig.Engine.OpenSearch.Client)
+	tc.Require.IndicesReset([]string{indexName})
+	tc.Require.IndicesCount([]string{indexName}, nil, 0)
+
+	backend, err := opensearch.NewBackend(indexName, tc.Client())
+	require.NoError(t, err)
+
+	for _, r := range resources {
+		tc.Require.DocumentCreate(indexName, r.ID, strings.NewReader(opensearchtest.JSONMustMarshal(t, r)))
+	}
+	tc.Require.IndicesCount([]string{indexName}, nil, len(resources))
+
+	return backend, tc
+}
+
+// TestEngine_UpdateSelfAndDescendants_RootScope ensures that updates which affect a
+// resource and its descendants (Delete, Restore, Move) are scoped to the root (space)
+// of the target resource. Two resources living in different roots may share the exact
+// same path, so matching by path alone would incorrectly update the wrong resource.
+func TestEngine_UpdateSelfAndDescendants_RootScope(t *testing.T) {
+	t.Run("delete only affects the resource in the target root", func(t *testing.T) {
+		indexName := "opencloud-test-engine-root-scope-delete"
+
+		target := opensearchtest.Testdata.Resources.File
+		other := otherRoot(target)
+
+		backend, tc := newRootScopeBackend(t, indexName, target, other)
+		defer tc.Require.IndicesDelete([]string{indexName})
+
+		require.NoError(t, backend.Delete(target.ID))
+
+		require.True(t, resourceByID(t, tc, indexName, target.ID).Deleted, "target resource should be marked as deleted")
+		require.False(t, resourceByID(t, tc, indexName, other.ID).Deleted, "resource in a different root must not be affected")
+	})
+
+	t.Run("restore only affects the resource in the target root", func(t *testing.T) {
+		indexName := "opencloud-test-engine-root-scope-restore"
+
+		target := opensearchtest.Testdata.Resources.File
+		target.Deleted = true
+		other := otherRoot(target)
+
+		backend, tc := newRootScopeBackend(t, indexName, target, other)
+		defer tc.Require.IndicesDelete([]string{indexName})
+
+		require.NoError(t, backend.Restore(target.ID))
+
+		require.False(t, resourceByID(t, tc, indexName, target.ID).Deleted, "target resource should be restored")
+		require.True(t, resourceByID(t, tc, indexName, other.ID).Deleted, "resource in a different root must not be affected")
+	})
+
+	t.Run("move only affects the resource in the target root", func(t *testing.T) {
+		indexName := "opencloud-test-engine-root-scope-move"
+
+		target := opensearchtest.Testdata.Resources.File
+		other := otherRoot(target)
+
+		backend, tc := newRootScopeBackend(t, indexName, target, other)
+		defer tc.Require.IndicesDelete([]string{indexName})
+
+		require.NoError(t, backend.Move(target.ID, target.ParentID, "./new/path/to/resource"))
+
+		require.Equal(t, "./new/path/to/resource", resourceByID(t, tc, indexName, target.ID).Path, "target resource should be moved")
+		require.Equal(t, other.Path, resourceByID(t, tc, indexName, other.ID).Path, "resource in a different root must not be moved")
 	})
 }

--- a/services/search/pkg/opensearch/internal/test/helper.go
+++ b/services/search/pkg/opensearch/internal/test/helper.go
@@ -11,20 +11,20 @@ import (
 	"github.com/opencloud-eu/opencloud/pkg/conversions"
 )
 
-var TimeMustParse = func(t *testing.T, ts string) time.Time {
+var TimeMustParse = func(t testing.TB, ts string) time.Time {
 	tp, err := time.Parse(time.RFC3339Nano, ts)
 	require.NoError(t, err, "failed to parse time %s", ts)
 
 	return tp
 }
 
-func JSONMustMarshal(t *testing.T, data any) string {
+func JSONMustMarshal(t testing.TB, data any) string {
 	jsonData, err := json.Marshal(data)
 	require.NoError(t, err, "failed to marshal data to JSON")
 	return string(jsonData)
 }
 
-func SearchHitsMustBeConverted[T any](t *testing.T, hits []opensearchgoAPI.SearchHit) []T {
+func SearchHitsMustBeConverted[T any](t testing.TB, hits []opensearchgoAPI.SearchHit) []T {
 	ts := make([]T, len(hits))
 	for i, hit := range hits {
 		resource, err := conversions.To[T](hit.Source)

--- a/services/search/pkg/opensearch/internal/test/os.go
+++ b/services/search/pkg/opensearch/internal/test/os.go
@@ -20,7 +20,7 @@ type TestClient struct {
 	Require *testRequireClient
 }
 
-func NewDefaultTestClient(t *testing.T, cfg config.EngineOpenSearchClient) *TestClient {
+func NewDefaultTestClient(t testing.TB, cfg config.EngineOpenSearchClient) *TestClient {
 	client, err := opensearchgoAPI.NewClient(opensearchgoAPI.Config{
 		Client: opensearchgo.Config{
 			Addresses: cfg.Addresses,
@@ -33,7 +33,7 @@ func NewDefaultTestClient(t *testing.T, cfg config.EngineOpenSearchClient) *Test
 	return NewTestClient(t, client)
 }
 
-func NewTestClient(t *testing.T, client *opensearchgoAPI.Client) *TestClient {
+func NewTestClient(t testing.TB, client *opensearchgoAPI.Client) *TestClient {
 	tc := &TestClient{c: client}
 	trc := &testRequireClient{tc: tc, t: t}
 	tc.Require = trc
@@ -210,7 +210,7 @@ func (tc *TestClient) Search(ctx context.Context, index string, body io.Reader) 
 
 type testRequireClient struct {
 	tc *TestClient
-	t  *testing.T
+	t  testing.TB
 }
 
 func (trc *testRequireClient) IndicesReset(indices []string) {

--- a/services/search/pkg/opensearch/opensearch.go
+++ b/services/search/pkg/opensearch/opensearch.go
@@ -56,7 +56,9 @@ func updateSelfAndDescendants(ctx context.Context, client *opensearchgoAPI.Clien
 				WaitForCompletion: conversions.ToPointer(true),
 			},
 		},
-		osu.NewTermQuery[string]("Path").Value(resource.Path),
+		osu.NewBoolQuery().
+			Must(osu.NewTermQuery[string]("RootID").Value(resource.RootID)).
+			Must(osu.NewTermQuery[string]("Path").Value(resource.Path)),
 		osu.UpdateByQueryBodyParams{
 			Script: scriptProvider(resource),
 		},


### PR DESCRIPTION
Fixes a problem where updates to the search index were only scoped by Path, not by Space+Path.