### PR TITLE
refactor(search): re-name the engine parameters

### DIFF
--- a/services/search/pkg/bleve/backend.go
+++ b/services/search/pkg/bleve/backend.go
@@ -173,13 +173,13 @@ func (b *Backend) Upsert(id string, r search.Resource) error {
 	return batch.Push()
 }
 
-func (b *Backend) Move(rootID, parentID, location string) error {
+func (b *Backend) Move(id, parentID, targetPath string) error {
 	batch, err := b.NewBatch(defaultBatchSize)
 	if err != nil {
 		return err
 	}
 
-	if err := batch.Move(rootID, parentID, location); err != nil {
+	if err := batch.Move(id, parentID, targetPath); err != nil {
 		return err
 	}
 

--- a/services/search/pkg/bleve/batch.go
+++ b/services/search/pkg/bleve/batch.go
@@ -40,14 +40,14 @@ func (b *Batch) Upsert(id string, r search.Resource) error {
 	})
 }
 
-func (b *Batch) Move(id, parentID, location string) error {
+func (b *Batch) Move(id string, parentID string, targetPath string) error {
 	return b.withSizeLimit(func() error {
 		rootResource, err := searchResourceByID(id, b.index)
 		if err != nil {
 			return err
 		}
 		currentPath := rootResource.Path
-		nextPath := utils.MakeRelativePath(location)
+		nextPath := utils.MakeRelativePath(targetPath)
 
 		rootResource.Path = nextPath
 		rootResource.Name = path.Base(nextPath)

--- a/services/search/pkg/bleve/index.go
+++ b/services/search/pkg/bleve/index.go
@@ -102,9 +102,9 @@ func searchResourceByID(id string, index bleve.Index) (*search.Resource, error) 
 	return matchToResource(res.Hits[0]), nil
 }
 
-func searchResourcesByPath(rootId, lookupPath string, index bleve.Index) ([]*search.Resource, error) {
+func searchResourcesByPath(rootID string, lookupPath string, index bleve.Index) ([]*search.Resource, error) {
 	q := bleve.NewConjunctionQuery(
-		bleve.NewQueryStringQuery("RootID:"+rootId),
+		bleve.NewQueryStringQuery("RootID:"+rootID),
 		bleve.NewQueryStringQuery("Path:"+escapeQuery(lookupPath+"/*")),
 	)
 	bleveReq := bleve.NewSearchRequest(q)

--- a/services/search/pkg/opensearch/backend.go
+++ b/services/search/pkg/opensearch/backend.go
@@ -194,13 +194,13 @@ func (b *Backend) Upsert(id string, r search.Resource) error {
 	return batch.Push()
 }
 
-func (b *Backend) Move(id string, parentID string, target string) error {
+func (b *Backend) Move(id string, parentID string, targetPath string) error {
 	batch, err := b.NewBatch(defaultBatchSize)
 	if err != nil {
 		return err
 	}
 
-	if err := batch.Move(id, parentID, target); err != nil {
+	if err := batch.Move(id, parentID, targetPath); err != nil {
 		return err
 	}
 

--- a/services/search/pkg/opensearch/batch.go
+++ b/services/search/pkg/opensearch/batch.go
@@ -63,7 +63,7 @@ func (b *Batch) Upsert(id string, r search.Resource) error {
 	})
 }
 
-func (b *Batch) Move(id, parentID, location string) error {
+func (b *Batch) Move(id string, parentID string, targetPath string) error {
 	return b.withSizeLimit(func() error {
 		op := func() error {
 			return updateSelfAndDescendants(context.Background(), b.client, b.index, id, func(rootResource search.Resource) *osu.BodyParamScript {
@@ -77,8 +77,8 @@ func (b *Batch) Move(id, parentID, location string) error {
 						"id":       id,
 						"parentID": parentID,
 						"oldPath":  rootResource.Path,
-						"newPath":  utils.MakeRelativePath(location),
-						"newName":  path.Base(utils.MakeRelativePath(location)),
+						"newPath":  utils.MakeRelativePath(targetPath),
+						"newName":  path.Base(utils.MakeRelativePath(targetPath)),
 					},
 				}
 			})

--- a/services/search/pkg/search/mocks/batch_operator.go
+++ b/services/search/pkg/search/mocks/batch_operator.go
@@ -88,8 +88,8 @@ func (_c *BatchOperator_Delete_Call) RunAndReturn(run func(id string) error) *Ba
 }
 
 // Move provides a mock function for the type BatchOperator
-func (_mock *BatchOperator) Move(rootID string, parentID string, location string) error {
-	ret := _mock.Called(rootID, parentID, location)
+func (_mock *BatchOperator) Move(id string, parentID string, targetPath string) error {
+	ret := _mock.Called(id, parentID, targetPath)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Move")
@@ -97,7 +97,7 @@ func (_mock *BatchOperator) Move(rootID string, parentID string, location string
 
 	var r0 error
 	if returnFunc, ok := ret.Get(0).(func(string, string, string) error); ok {
-		r0 = returnFunc(rootID, parentID, location)
+		r0 = returnFunc(id, parentID, targetPath)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -110,14 +110,14 @@ type BatchOperator_Move_Call struct {
 }
 
 // Move is a helper method to define mock.On call
-//   - rootID string
+//   - id string
 //   - parentID string
-//   - location string
-func (_e *BatchOperator_Expecter) Move(rootID interface{}, parentID interface{}, location interface{}) *BatchOperator_Move_Call {
-	return &BatchOperator_Move_Call{Call: _e.mock.On("Move", rootID, parentID, location)}
+//   - targetPath string
+func (_e *BatchOperator_Expecter) Move(id interface{}, parentID interface{}, targetPath interface{}) *BatchOperator_Move_Call {
+	return &BatchOperator_Move_Call{Call: _e.mock.On("Move", id, parentID, targetPath)}
 }
 
-func (_c *BatchOperator_Move_Call) Run(run func(rootID string, parentID string, location string)) *BatchOperator_Move_Call {
+func (_c *BatchOperator_Move_Call) Run(run func(id string, parentID string, targetPath string)) *BatchOperator_Move_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 string
 		if args[0] != nil {
@@ -145,7 +145,7 @@ func (_c *BatchOperator_Move_Call) Return(err error) *BatchOperator_Move_Call {
 	return _c
 }
 
-func (_c *BatchOperator_Move_Call) RunAndReturn(run func(rootID string, parentID string, location string) error) *BatchOperator_Move_Call {
+func (_c *BatchOperator_Move_Call) RunAndReturn(run func(id string, parentID string, targetPath string) error) *BatchOperator_Move_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/services/search/pkg/search/mocks/engine.go
+++ b/services/search/pkg/search/mocks/engine.go
@@ -144,8 +144,8 @@ func (_c *Engine_DocCount_Call) RunAndReturn(run func() (uint64, error)) *Engine
 }
 
 // Move provides a mock function for the type Engine
-func (_mock *Engine) Move(id string, parentid string, target string) error {
-	ret := _mock.Called(id, parentid, target)
+func (_mock *Engine) Move(id string, parentID string, targetPath string) error {
+	ret := _mock.Called(id, parentID, targetPath)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Move")
@@ -153,7 +153,7 @@ func (_mock *Engine) Move(id string, parentid string, target string) error {
 
 	var r0 error
 	if returnFunc, ok := ret.Get(0).(func(string, string, string) error); ok {
-		r0 = returnFunc(id, parentid, target)
+		r0 = returnFunc(id, parentID, targetPath)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -167,13 +167,13 @@ type Engine_Move_Call struct {
 
 // Move is a helper method to define mock.On call
 //   - id string
-//   - parentid string
-//   - target string
-func (_e *Engine_Expecter) Move(id interface{}, parentid interface{}, target interface{}) *Engine_Move_Call {
-	return &Engine_Move_Call{Call: _e.mock.On("Move", id, parentid, target)}
+//   - parentID string
+//   - targetPath string
+func (_e *Engine_Expecter) Move(id interface{}, parentID interface{}, targetPath interface{}) *Engine_Move_Call {
+	return &Engine_Move_Call{Call: _e.mock.On("Move", id, parentID, targetPath)}
 }
 
-func (_c *Engine_Move_Call) Run(run func(id string, parentid string, target string)) *Engine_Move_Call {
+func (_c *Engine_Move_Call) Run(run func(id string, parentID string, targetPath string)) *Engine_Move_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 string
 		if args[0] != nil {
@@ -201,7 +201,7 @@ func (_c *Engine_Move_Call) Return(err error) *Engine_Move_Call {
 	return _c
 }
 
-func (_c *Engine_Move_Call) RunAndReturn(run func(id string, parentid string, target string) error) *Engine_Move_Call {
+func (_c *Engine_Move_Call) RunAndReturn(run func(id string, parentID string, targetPath string) error) *Engine_Move_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/services/search/pkg/search/mocks/searcher.go
+++ b/services/search/pkg/search/mocks/searcher.go
@@ -40,8 +40,8 @@ func (_m *Searcher) EXPECT() *Searcher_Expecter {
 }
 
 // IndexSpace provides a mock function for the type Searcher
-func (_mock *Searcher) IndexSpace(rID *providerv1beta1.StorageSpaceId, forceRescan bool) error {
-	ret := _mock.Called(rID, forceRescan)
+func (_mock *Searcher) IndexSpace(spaceID *providerv1beta1.StorageSpaceId, forceRescan bool) error {
+	ret := _mock.Called(spaceID, forceRescan)
 
 	if len(ret) == 0 {
 		panic("no return value specified for IndexSpace")
@@ -49,7 +49,7 @@ func (_mock *Searcher) IndexSpace(rID *providerv1beta1.StorageSpaceId, forceResc
 
 	var r0 error
 	if returnFunc, ok := ret.Get(0).(func(*providerv1beta1.StorageSpaceId, bool) error); ok {
-		r0 = returnFunc(rID, forceRescan)
+		r0 = returnFunc(spaceID, forceRescan)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -62,13 +62,13 @@ type Searcher_IndexSpace_Call struct {
 }
 
 // IndexSpace is a helper method to define mock.On call
-//   - rID *providerv1beta1.StorageSpaceId
+//   - spaceID *providerv1beta1.StorageSpaceId
 //   - forceRescan bool
-func (_e *Searcher_Expecter) IndexSpace(rID interface{}, forceRescan interface{}) *Searcher_IndexSpace_Call {
-	return &Searcher_IndexSpace_Call{Call: _e.mock.On("IndexSpace", rID, forceRescan)}
+func (_e *Searcher_Expecter) IndexSpace(spaceID interface{}, forceRescan interface{}) *Searcher_IndexSpace_Call {
+	return &Searcher_IndexSpace_Call{Call: _e.mock.On("IndexSpace", spaceID, forceRescan)}
 }
 
-func (_c *Searcher_IndexSpace_Call) Run(run func(rID *providerv1beta1.StorageSpaceId, forceRescan bool)) *Searcher_IndexSpace_Call {
+func (_c *Searcher_IndexSpace_Call) Run(run func(spaceID *providerv1beta1.StorageSpaceId, forceRescan bool)) *Searcher_IndexSpace_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 *providerv1beta1.StorageSpaceId
 		if args[0] != nil {
@@ -91,7 +91,7 @@ func (_c *Searcher_IndexSpace_Call) Return(err error) *Searcher_IndexSpace_Call 
 	return _c
 }
 
-func (_c *Searcher_IndexSpace_Call) RunAndReturn(run func(rID *providerv1beta1.StorageSpaceId, forceRescan bool) error) *Searcher_IndexSpace_Call {
+func (_c *Searcher_IndexSpace_Call) RunAndReturn(run func(spaceID *providerv1beta1.StorageSpaceId, forceRescan bool) error) *Searcher_IndexSpace_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -188,8 +188,8 @@ func (_c *Searcher_PurgeDeleted_Call) RunAndReturn(run func(spaceID *providerv1b
 }
 
 // PurgeItem provides a mock function for the type Searcher
-func (_mock *Searcher) PurgeItem(rID *providerv1beta1.Reference) {
-	_mock.Called(rID)
+func (_mock *Searcher) PurgeItem(ref *providerv1beta1.Reference) {
+	_mock.Called(ref)
 	return
 }
 
@@ -199,12 +199,12 @@ type Searcher_PurgeItem_Call struct {
 }
 
 // PurgeItem is a helper method to define mock.On call
-//   - rID *providerv1beta1.Reference
-func (_e *Searcher_Expecter) PurgeItem(rID interface{}) *Searcher_PurgeItem_Call {
-	return &Searcher_PurgeItem_Call{Call: _e.mock.On("PurgeItem", rID)}
+//   - ref *providerv1beta1.Reference
+func (_e *Searcher_Expecter) PurgeItem(ref interface{}) *Searcher_PurgeItem_Call {
+	return &Searcher_PurgeItem_Call{Call: _e.mock.On("PurgeItem", ref)}
 }
 
-func (_c *Searcher_PurgeItem_Call) Run(run func(rID *providerv1beta1.Reference)) *Searcher_PurgeItem_Call {
+func (_c *Searcher_PurgeItem_Call) Run(run func(ref *providerv1beta1.Reference)) *Searcher_PurgeItem_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 *providerv1beta1.Reference
 		if args[0] != nil {
@@ -222,7 +222,7 @@ func (_c *Searcher_PurgeItem_Call) Return() *Searcher_PurgeItem_Call {
 	return _c
 }
 
-func (_c *Searcher_PurgeItem_Call) RunAndReturn(run func(rID *providerv1beta1.Reference)) *Searcher_PurgeItem_Call {
+func (_c *Searcher_PurgeItem_Call) RunAndReturn(run func(ref *providerv1beta1.Reference)) *Searcher_PurgeItem_Call {
 	_c.Run(run)
 	return _c
 }
@@ -336,8 +336,8 @@ func (_c *Searcher_Search_Call) RunAndReturn(run func(ctx context.Context, req *
 }
 
 // TrashItem provides a mock function for the type Searcher
-func (_mock *Searcher) TrashItem(rID *providerv1beta1.ResourceId) {
-	_mock.Called(rID)
+func (_mock *Searcher) TrashItem(resourceID *providerv1beta1.ResourceId) {
+	_mock.Called(resourceID)
 	return
 }
 
@@ -347,12 +347,12 @@ type Searcher_TrashItem_Call struct {
 }
 
 // TrashItem is a helper method to define mock.On call
-//   - rID *providerv1beta1.ResourceId
-func (_e *Searcher_Expecter) TrashItem(rID interface{}) *Searcher_TrashItem_Call {
-	return &Searcher_TrashItem_Call{Call: _e.mock.On("TrashItem", rID)}
+//   - resourceID *providerv1beta1.ResourceId
+func (_e *Searcher_Expecter) TrashItem(resourceID interface{}) *Searcher_TrashItem_Call {
+	return &Searcher_TrashItem_Call{Call: _e.mock.On("TrashItem", resourceID)}
 }
 
-func (_c *Searcher_TrashItem_Call) Run(run func(rID *providerv1beta1.ResourceId)) *Searcher_TrashItem_Call {
+func (_c *Searcher_TrashItem_Call) Run(run func(resourceID *providerv1beta1.ResourceId)) *Searcher_TrashItem_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 *providerv1beta1.ResourceId
 		if args[0] != nil {
@@ -370,7 +370,7 @@ func (_c *Searcher_TrashItem_Call) Return() *Searcher_TrashItem_Call {
 	return _c
 }
 
-func (_c *Searcher_TrashItem_Call) RunAndReturn(run func(rID *providerv1beta1.ResourceId)) *Searcher_TrashItem_Call {
+func (_c *Searcher_TrashItem_Call) RunAndReturn(run func(resourceID *providerv1beta1.ResourceId)) *Searcher_TrashItem_Call {
 	_c.Run(run)
 	return _c
 }

--- a/services/search/pkg/search/search.go
+++ b/services/search/pkg/search/search.go
@@ -29,7 +29,7 @@ type Engine interface {
 	DocCount() (uint64, error)
 
 	Upsert(id string, r Resource) error
-	Move(id string, parentid string, target string) error
+	Move(id string, parentID string, targetPath string) error
 	Delete(id string) error
 	Restore(id string) error
 	Purge(id string, onlyDeleted bool) error
@@ -39,7 +39,7 @@ type Engine interface {
 
 type BatchOperator interface {
 	Upsert(id string, r Resource) error
-	Move(rootID, parentID, location string) error
+	Move(id string, parentID string, targetPath string) error
 	Delete(id string) error
 	Restore(id string) error
 	Purge(id string, onlyDeleted bool) error

--- a/services/search/pkg/search/service.go
+++ b/services/search/pkg/search/service.go
@@ -47,11 +47,11 @@ const (
 type Searcher interface {
 	Search(ctx context.Context, req *searchsvc.SearchRequest) (*searchsvc.SearchResponse, error)
 
-	IndexSpace(rID *provider.StorageSpaceId, forceRescan bool) error
+	IndexSpace(spaceID *provider.StorageSpaceId, forceRescan bool) error
 	PurgeDeleted(spaceID *provider.StorageSpaceId) error
 
-	TrashItem(rID *provider.ResourceId)
-	PurgeItem(rID *provider.Reference)
+	TrashItem(resourceID *provider.ResourceId)
+	PurgeItem(ref *provider.Reference)
 	UpsertItem(ref *provider.Reference)
 	RestoreItem(ref *provider.Reference)
 	MoveItem(ref *provider.Reference)
@@ -540,9 +540,9 @@ func (s *Service) IndexSpace(spaceID *provider.StorageSpaceId, forceRescan bool)
 }
 
 // TrashItem marks the item as deleted.
-func (s *Service) TrashItem(rID *provider.ResourceId) {
-	if err := s.engine.Delete(storagespace.FormatResourceID(rID)); err != nil {
-		s.logger.Info().Err(err).Interface("Id", rID).Msg("failed to remove item from index")
+func (s *Service) TrashItem(resourceID *provider.ResourceId) {
+	if err := s.engine.Delete(storagespace.FormatResourceID(resourceID)); err != nil {
+		s.logger.Info().Err(err).Interface("Id", resourceID).Msg("failed to remove item from index")
 	}
 }
 


### PR DESCRIPTION
## Description
we use id as param name all over the place, the pr only changes the naming (is it an id, is it an path lookup) to make it easier to understand what is what.