### PR TITLE
fix(search): keep the case of a path in the index

### DIFF
--- a/services/search/MIGRATION.md
+++ b/services/search/MIGRATION.md
@@ -1,0 +1,50 @@
+# Migrating the OpenSearch index
+
+Our index definition id versioned. The service does not start on an index that
+was built with an older one. A new installation is not affected.
+
+There are two ways out.
+
+> `$OS` (the OpenSearch address), `opencloud-resource` (default) index name.
+
+## Throw it away and index again
+
+Recommended for small installations. Works for every version, and it also
+removes records that were already orphaned. Every file is read and extracted again,
+so it takes longer on a big installation and search is incomplete until it is
+done.
+
+Writing to a missing index creates one without our analyzer and mappings, so
+opencloud has to be down while it is gone.
+
+```shell
+# stop opencloud
+curl -XDELETE "$OS/opencloud-resource"
+# start opencloud, it creates the index from the current definition
+opencloud search index --all-spaces
+```
+
+## v2 to v3
+
+Keeps the documents, updating the index without reindexing the whole file tree.
+
+```shell
+# stop opencloud
+
+curl -XPOST "$OS/opencloud-resource/_close"
+curl -XPUT "$OS/opencloud-resource/_settings" -H 'Content-Type: application/json' -d '{"analysis":{"analyzer":{"path_hierarchy":{"filter":null}}}}'
+curl -XPOST "$OS/opencloud-resource/_open"
+
+# the updated v3 fields
+curl -XPUT "$OS/opencloud-resource/_mapping" -H 'Content-Type: application/json' -d '
+{"properties":{"Tags":{"type":"text","fields":{"keyword":{"type":"keyword","ignore_above":256}}},
+               "Mtime":{"type":"date","ignore_malformed":true}}}'
+
+# start opencloud
+
+curl -XPOST "$OS/opencloud-resource/_update_by_query?conflicts=proceed&wait_for_completion=false"
+```
+
+The last command answers with a task id, watch it with `GET $OS/_tasks/<task-id>`.
+A million documents take a few minutes. Search keeps working while it runs,
+documents get correct one by one, and the run can be repeated at any time.

--- a/services/search/README.md
+++ b/services/search/README.md
@@ -55,6 +55,14 @@ Additionally, the following optional settings can be set:
 *   `SEARCH_ENGINE_OPEN_SEARCH_CLIENT_ENABLE_DEBUG_LOGGER=val`: Enable debug logging.
 *   `SEARCH_ENGINE_OPEN_SEARCH_CLIENT_INSECURE=val`: Skip TLS certificate verification.
 
+### Bringing an existing index over
+
+A version can bring a new index definition. The service does not start on an index that was built with an
+older one and says so in the error. A new installation is not affected.
+
+An existing index is changed where it is: the new settings are applied and the documents are indexed again from
+their own source. No second index, no indexer run. See [MIGRATION.md](MIGRATION.md).
+
 ## Query language
 
 By default, [KQL](https://learn.microsoft.com/en-us/sharepoint/dev/general-development/keyword-query-language-kql-syntax-reference) is used as the query language.

--- a/services/search/pkg/content/content.go
+++ b/services/search/pkg/content/content.go
@@ -18,7 +18,7 @@ type Document struct {
 	Name      string
 	Content   string
 	Size      uint64
-	Mtime     string
+	Mtime     string `json:"Mtime,omitempty"`
 	MimeType  string
 	Tags      []string
 	Favorites []string

--- a/services/search/pkg/opensearch/backend_test.go
+++ b/services/search/pkg/opensearch/backend_test.go
@@ -281,3 +281,49 @@ func TestEngine_DocCount(t *testing.T) {
 		require.Equal(t, uint64(0), count)
 	})
 }
+
+func TestEngine_UppercasePath(t *testing.T) {
+	indexName := "opencloud-test-engine-uppercase-path"
+	tc := opensearchtest.NewDefaultTestClient(t, defaultConfig.Engine.OpenSearch.Client)
+	tc.Require.IndicesReset([]string{indexName})
+
+	defer tc.Require.IndicesDelete([]string{indexName})
+
+	backend, err := opensearch.NewBackend(indexName, tc.Client())
+	require.NoError(t, err)
+
+	folder := opensearchtest.Testdata.Resources.Folder
+	folder.Path = "./Documents"
+	tc.Require.DocumentCreate(indexName, folder.ID, strings.NewReader(opensearchtest.JSONMustMarshal(t, folder)))
+
+	file := opensearchtest.Testdata.Resources.File
+	file.Path = "./Documents/Picture.jpg"
+	tc.Require.DocumentCreate(indexName, file.ID, strings.NewReader(opensearchtest.JSONMustMarshal(t, file)))
+	tc.Require.IndicesRefresh([]string{indexName}, nil)
+
+	t.Run("a path is indexed as it is written", func(t *testing.T) {
+		require.Len(t, tc.Require.Search(indexName, strings.NewReader(`{"query":{"term":{"Path":"./Documents"}}}`)).Hits, 2)
+		require.Empty(t, tc.Require.Search(indexName, strings.NewReader(`{"query":{"term":{"Path":"./documents"}}}`)).Hits)
+	})
+
+	t.Run("deleting reaches the resource and its descendants", func(t *testing.T) {
+		require.NoError(t, backend.Delete(folder.ID))
+		tc.Require.IndicesRefresh([]string{indexName}, nil)
+
+		deleted := tc.Require.Search(indexName, strings.NewReader(`{"query":{"term":{"Deleted":true}}}`))
+		require.Len(t, deleted.Hits, 2)
+	})
+
+	t.Run("moving takes the descendants along", func(t *testing.T) {
+		require.NoError(t, backend.Move(folder.ID, folder.ParentID, "./Other Documents"))
+		tc.Require.IndicesRefresh([]string{indexName}, nil)
+
+		require.Len(t, tc.Require.Search(indexName, strings.NewReader(`{"query":{"term":{"Path":"./Other Documents"}}}`)).Hits, 2)
+		require.Empty(t, tc.Require.Search(indexName, strings.NewReader(`{"query":{"term":{"Path":"./Documents"}}}`)).Hits)
+	})
+
+	t.Run("purging reaches the resource and its descendants", func(t *testing.T) {
+		require.NoError(t, backend.Purge(folder.ID, false))
+		tc.Require.IndicesCount([]string{indexName}, nil, 0)
+	})
+}

--- a/services/search/pkg/opensearch/index.go
+++ b/services/search/pkg/opensearch/index.go
@@ -16,9 +16,10 @@ import (
 
 var (
 	ErrManualActionRequired                  = errors.New("manual action required")
-	IndexManagerLatest                       = IndexIndexManagerResourceV2
+	IndexManagerLatest                       = IndexIndexManagerResourceV3
 	IndexIndexManagerResourceV1 IndexManager = "resource_v1.json"
 	IndexIndexManagerResourceV2 IndexManager = "resource_v2.json"
+	IndexIndexManagerResourceV3 IndexManager = "resource_v3.json"
 )
 
 //go:embed internal/indexes/*.json

--- a/services/search/pkg/opensearch/internal/convert/kql_expand.go
+++ b/services/search/pkg/opensearch/internal/convert/kql_expand.go
@@ -94,7 +94,7 @@ func (_ kqlExpander) remapKey(current string, defaultKey string) string {
 }
 
 func (_ kqlExpander) lowerValue(key, value string) string {
-	if slices.Contains([]string{"Hidden"}, key) {
+	if slices.Contains([]string{"Hidden", "Path"}, key) {
 		return value // ignore certain keys and return the original value
 	}
 

--- a/services/search/pkg/opensearch/internal/convert/kql_expand_test.go
+++ b/services/search/pkg/opensearch/internal/convert/kql_expand_test.go
@@ -259,6 +259,21 @@ func TestExpandKQLAST(t *testing.T) {
 				},
 			},
 			{
+				Name: "Path: ./Documents -> ./Documents",
+				Got: []ast.Node{
+					ast.StringNode{Key: "Path", Value: "./Documents"},
+					ast.GroupNode{Key: "GroupNode", Nodes: []ast.Node{
+						ast.StringNode{Key: "Path", Value: "./Documents"},
+					}},
+				},
+				Want: []ast.Node{
+					&ast.StringNode{Key: "Path", Value: "./Documents"},
+					&ast.GroupNode{Key: "GroupNode", Nodes: []ast.Node{
+						&ast.StringNode{Key: "Path", Value: "./Documents"},
+					}},
+				},
+			},
+			{
 				Name: "Hidden: StringNode -> StringNode",
 				Got: []ast.Node{
 					ast.StringNode{Key: "Hidden", Value: "StringNode"},

--- a/services/search/pkg/opensearch/internal/indexes/resource_v3.json
+++ b/services/search/pkg/opensearch/internal/indexes/resource_v3.json
@@ -1,0 +1,66 @@
+{
+  "settings": {
+    "number_of_shards": "1",
+    "number_of_replicas": "1",
+    "analysis": {
+      "analyzer": {
+        "path_hierarchy": {
+          "tokenizer": "path_hierarchy",
+          "type": "custom"
+        }
+      },
+      "tokenizer": {
+        "path_hierarchy": {
+          "type": "path_hierarchy"
+        }
+      }
+    }
+  },
+  "mappings": {
+    "properties": {
+      "Content": {
+        "type": "text",
+        "term_vector": "with_positions_offsets"
+      },
+      "ID": {
+        "type": "keyword"
+      },
+      "ParentID": {
+        "type": "keyword"
+      },
+      "RootID": {
+        "type": "keyword"
+      },
+      "MimeType": {
+        "type": "wildcard",
+        "doc_values": false
+      },
+      "Path": {
+        "type": "text",
+        "analyzer": "path_hierarchy"
+      },
+      "Deleted": {
+        "type": "boolean"
+      },
+      "Hidden": {
+        "type": "boolean"
+      },
+      "Favorites": {
+        "type": "keyword"
+      },
+      "Tags": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "Mtime": {
+        "type": "date",
+        "ignore_malformed": true
+      }
+    }
+  }
+}

--- a/services/search/pkg/search/service.go
+++ b/services/search/pkg/search/service.go
@@ -616,7 +616,13 @@ func (s *Service) doUpsertItem(ref *provider.Reference, batch BatchOperator) {
 		Type:     uint64(stat.Info.Type),
 		Document: doc,
 	}
-	r.Hidden = strings.HasPrefix(r.Path, ".")
+
+	for name := range strings.SplitSeq(filepath.Clean(r.Path), string(filepath.Separator)) {
+		if name != "." && strings.HasPrefix(name, ".") {
+			r.Hidden = true
+			break
+		}
+	}
 
 	if parentID := stat.GetInfo().GetParentId(); parentID != nil {
 		r.ParentID = storagespace.FormatResourceID(parentID)

--- a/services/search/pkg/search/service_test.go
+++ b/services/search/pkg/search/service_test.go
@@ -138,6 +138,46 @@ var _ = Describe("Searchprovider", func() {
 		})
 	})
 
+	Describe("UpsertItem", func() {
+		DescribeTable("marks a resource hidden when a dot starts one of its names",
+			func(path string, hidden bool) {
+				info := &sprovider.ResourceInfo{
+					Id:       &sprovider.ResourceId{StorageId: "storageid", SpaceId: "spaceid", OpaqueId: "hidden-opaqueid"},
+					ParentId: &sprovider.ResourceId{StorageId: "storageid", OpaqueId: "parentopaqueid"},
+					Path:     path,
+				}
+
+				gatewayClient.On("Stat", mock.Anything, mock.Anything).Return(&sprovider.StatResponse{
+					Status: status.NewOK(context.Background()),
+					Info:   info,
+				}, nil)
+
+				gatewayClient.On("GetPath", mock.Anything, mock.MatchedBy(func(req *sprovider.GetPathRequest) bool {
+					return req.GetResourceId().GetOpaqueId() == info.GetId().GetOpaqueId()
+				})).Return(&sprovider.GetPathResponse{
+					Status: status.NewOK(context.Background()),
+					Path:   path,
+				}, nil)
+
+				extractor.On("Extract", mock.Anything, mock.Anything, mock.Anything).Return(content.Document{}, nil)
+
+				var indexed search.Resource
+				indexClient.On("Upsert", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+					indexed = args.Get(1).(search.Resource)
+				}).Return(nil)
+
+				s.UpsertItem(&sprovider.Reference{ResourceId: info.GetId()})
+				Expect(indexed.Hidden).To(Equal(hidden))
+			},
+			Entry("/folder", "/documents", false),
+			Entry("/folder/file", "/documents/notes.txt", false),
+			Entry("/folder/.file", "/documents/.notes.txt", true),
+			Entry("/.folder/file", "/.git/config", true),
+			Entry("/folder/.folder/file", "/documents/.git/config", true),
+			Entry("/", "/", false),
+		)
+	})
+
 	Describe("Search", func() {
 		It("fails when an empty query is given", func() {
 			res, err := s.Search(ctx, &searchsvc.SearchRequest{


### PR DESCRIPTION
## Description

### openSearch index

livecycle update for out openSearch index,
it removes the path lowercase filter which fixes an issues which appears when searching for folders!
It also adds strict mappings for Tags & Mtime.

### code changes

there was a bug that incorrectly evaluated the hidden state, this is fixed too.

There is no auto migration, all necessary steps are described in the new migration guide (FYI @Svanvith)

## How Has This Been Tested?
- manually in my lab 
- tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added
