### PR TITLE
actually log error on exit

### DIFF
--- a/services/antivirus/pkg/command/server.go
+++ b/services/antivirus/pkg/command/server.go
@@ -43,7 +43,7 @@ func Server(cfg *config.Config) *cobra.Command {
 			{
 				svc, err := service.NewAntivirus(cfg, logger, traceProvider)
 				if err != nil {
-					fmt.Errorf("failed to initialize antivirus service: %v", err)
+					logger.Error().Err(err).Str("server", "antivirus").Msg("Failed to initialize antivirus service")
 					os.Exit(1)
 				}
 


### PR DESCRIPTION
exiting withoul logging is not nice ... fmt.Errorf ... does not log the error, it just renders the string and returns it ...