### PR TITLE
fix(graph): adding the same user as multiple members in a group (#3354)

### DIFF
--- a/services/graph/pkg/identity/ldap_group.go
+++ b/services/graph/pkg/identity/ldap_group.go
@@ -293,6 +293,26 @@ func (i *LDAP) AddMembersToGroup(ctx context.Context, groupID string, memberIDs 
 	if !i.writeEnabled && i.groupCreateBaseDN == i.groupBaseDN {
 		return errorcode.New(errorcode.NotAllowed, "server is configured read-only")
 	}
+
+	// eliminate duplicates in memberIDs by their UUID, to prevent unnecessary LDAP
+	// lookups below, and for https://github.com/opencloud-eu/opencloud/issues/3354
+	{
+		uniqueMemberIDs := make([]string, 0, len(memberIDs))
+		memory := map[string]struct{}{}
+		for _, id := range memberIDs {
+			if len(strings.TrimSpace(id)) == 0 {
+				continue // while we're at it, clean the input parameters and skip empty strings
+			}
+			if _, present := memory[id]; !present {
+				uniqueMemberIDs = append(uniqueMemberIDs, id)
+				memory[id] = struct{}{}
+			} else {
+				logger.Debug().Str("id", id).Msg("Duplicate member in group addition. Skipping")
+			}
+		}
+		memberIDs = uniqueMemberIDs
+	}
+
 	ge, err := i.getLDAPGroupByNameOrID(groupID, true)
 	if err != nil {
 		return err

--- a/tests/acceptance/expected-failures-decomposed-storage.md
+++ b/tests/acceptance/expected-failures-decomposed-storage.md
@@ -56,10 +56,6 @@
 - [apiGraphUserGroup/addUserToGroup.feature:378](https://github.com/opencloud-eu/opencloud/blob/main/tests/acceptance/features/apiGraphUserGroup/addUserToGroup.feature#L378)
 - [apiGraphUserGroup/addUserToGroup.feature:392](https://github.com/opencloud-eu/opencloud/blob/main/tests/acceptance/features/apiGraphUserGroup/addUserToGroup.feature#L392)
 
-#### [Adding the same user as multiple members in a single request results in listing the same user twice in the group](https://github.com/owncloud/ocis/issues/5855)
-
-- [apiGraphUserGroup/addUserToGroup.feature:429](https://github.com/opencloud-eu/opencloud/blob/main/tests/acceptance/features/apiGraphUserGroup/addUserToGroup.feature#L429)
-
 #### [Shared file locking is not possible using different path](https://github.com/owncloud/ocis/issues/7599)
 
 - [apiLocks/lockFiles.feature:185](https://github.com/opencloud-eu/opencloud/blob/main/tests/acceptance/features/apiLocks/lockFiles.feature#L185)

--- a/tests/acceptance/expected-failures-posix-storage.md
+++ b/tests/acceptance/expected-failures-posix-storage.md
@@ -56,11 +56,6 @@
 - [apiGraphUserGroup/addUserToGroup.feature:378](https://github.com/opencloud-eu/opencloud/blob/main/tests/acceptance/features/apiGraphUserGroup/addUserToGroup.feature#L378)
 - [apiGraphUserGroup/addUserToGroup.feature:392](https://github.com/opencloud-eu/opencloud/blob/main/tests/acceptance/features/apiGraphUserGroup/addUserToGroup.feature#L392)
 
-#### [Adding the same user as multiple members in a single request results in listing the same user twice in the group](https://github.com/owncloud/ocis/issues/5855)
-
-
-- [apiGraphUserGroup/addUserToGroup.feature:429](https://github.com/opencloud-eu/opencloud/blob/main/tests/acceptance/features/apiGraphUserGroup/addUserToGroup.feature#L429)
-
 #### [Shared file locking is not possible using different path](https://github.com/owncloud/ocis/issues/7599)
 
 - [apiLocks/lockFiles.feature:185](https://github.com/opencloud-eu/opencloud/blob/main/tests/acceptance/features/apiLocks/lockFiles.feature#L185)


### PR DESCRIPTION
## Description
* make sure the list of members to add to a group is unique, both on the level of the inbound list of member IDs as on the level of the LDAP DNs they resolve to
* remove the corresponding failing test from the list of expected failures

## Related Issue
- Fixes #3354

## Motivation and Context
When users are added to an existing group, specifying the same user identifier multiple times ended up in that user entry being referenced multiple times in that group, in the IDM as well as in Graph API calls.

That should not be the case as it makes no sense to have the same user referenced multiple times in a group.

## How Has This Been Tested?
Test snippets can be found in #3354 

Used those snippets on a locally running instance.

Also verified using the test suite:
```bash
BEHAT_FEATURE=tests/acceptance/features/apiGraphUserGroup/addUserToGroup.feature:429 \
TEST_SERVER_URL=https://host.docker.internal:9200 \
make -C tests/acceptance/docker/ run-test-only
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation added
