### PR TITLE
fix(acceptance): fix running acceptance tests against host on Linux

### DIFF
--- a/tests/acceptance/docker/src/acceptance.yml
+++ b/tests/acceptance/docker/src/acceptance.yml
@@ -16,6 +16,8 @@ services:
       EMAIL_PORT: 9000
     env_file:
       - ../../../../.woodpecker.env
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     volumes:
       - ./run-tests.sh:/test/run-tests.sh
       - ../../../../:/woodpecker/src/github.com/opencloud-eu/opencloud


### PR DESCRIPTION
## Description
Add an `host.docker.internal` -> `host-gateway` entry to the acceptable tests container in `tests/acceptance/docker/src/acceptance.yml` in order to be able to run them against an opencloud server running on the host on Linux as well.

Reference: https://www.baeldung.com/ops/docker-compose-add-host

This should not impact other environments, at least as far as documented behaviour goes.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added
