### PR TITLE
feat: add optional heif/avif libvips thumbnails

### DIFF
--- a/changelog/unreleased/heic-thumbnails.md
+++ b/changelog/unreleased/heic-thumbnails.md
@@ -1,0 +1,23 @@
+Enhancement: Optionally generate thumbnails for HEIC, HEIF and AVIF images
+
+Photos from recent Apple devices are stored as HEIC and there was no way to show
+a preview up until now. A HEVC decoder cannot be shipped as part of the
+OpenCloud binaries or images because of the patent situation around HEVC.
+
+But: Builds with libvips support now look for the optional libvips heif loader
+on startup. That loader is packaged separately from libvips and is not part of
+the images we build, so admins who may want to use HEVC can install it
+themselves. When it is there, the thumbnails service registers image/heic,
+image/heic-sequence, image/heif, image/heif-sequence and image/avif and renders
+them like any other image. When it is not, the mimetypes stay unregistered and
+oc:has-preview keeps reporting 0 for those files, so clients do not ask for
+thumbnails the server cannot produce. 
+
+AVIF is registered along with the others because the same loader reads it, so
+it comes along with HEIC at no extra cost.
+
+Displaying HEIC in the web UI also needs the mimetypes in the preview app of
+OpenCloud Web (still an open follow-up task), but file list thumbnails already
+work without it.
+
+https://github.com/opencloud-eu/opencloud/issues/630

--- a/changelog/unreleased/heic-thumbnails.md
+++ b/changelog/unreleased/heic-thumbnails.md
@@ -4,17 +4,19 @@ Photos from recent Apple devices are stored as HEIC and there was no way to show
 a preview up until now. A HEVC decoder cannot be shipped as part of the
 OpenCloud binaries or images because of the patent situation around HEVC.
 
-But: Builds with libvips support now look for the optional libvips heif loader
-on startup. That loader is packaged separately from libvips and is not part of
-the images we build, so admins who may want to use HEVC can install it
-themselves. When it is there, the thumbnails service registers image/heic,
-image/heic-sequence, image/heif, image/heif-sequence and image/avif and renders
-them like any other image. When it is not, the mimetypes stay unregistered and
-oc:has-preview keeps reporting 0 for those files, so clients do not ask for
-thumbnails the server cannot produce. 
+But: Builds with libvips support now test the optional HEVC and AV1 decoders
+when thumbnail support is first queried. The required libvips loader and codec
+backends are packaged separately and are not part of the images we build, so
+admins can install them themselves.
+When decoding succeeds, the thumbnails service registers the corresponding
+image/heic, image/heic-sequence, image/heif, image/heif-sequence or image/avif
+mimetypes and renders them like any other image. When a decoder is not
+available, its mimetypes stay unregistered and oc:has-preview keeps reporting 0
+for those files, so clients do not ask for thumbnails the server cannot
+produce.
 
-AVIF is registered along with the others because the same loader reads it, so
-it comes along with HEIC at no extra cost.
+AVIF uses the same libvips loader but is registered independently because it
+uses an AV1 decoder instead of an HEVC decoder.
 
 Displaying HEIC in the web UI also needs the mimetypes in the preview app of
 OpenCloud Web (still an open follow-up task), but file list thumbnails already

--- a/services/graph/pkg/service/v0/sharedbyme.go
+++ b/services/graph/pkg/service/v0/sharedbyme.go
@@ -49,8 +49,7 @@ func (g Graph) GetSharedByMe(w http.ResponseWriter, r *http.Request) {
 				continue
 			}
 
-			_, match := thumbnail.SupportedMimeTypes[*mt]
-			if match {
+			if thumbnail.IsMimeTypeSupported(*mt) {
 				baseUrl := fmt.Sprintf("%s/dav/spaces/%s?scalingup=0&preview=1&processor=thumbnail",
 					g.config.Commons.OpenCloudURL,
 					item.GetId())

--- a/services/graph/pkg/service/v0/sharedwithme.go
+++ b/services/graph/pkg/service/v0/sharedwithme.go
@@ -78,8 +78,7 @@ func (g Graph) listSharedWithMe(ctx context.Context, expandThumbnails bool) ([]l
 				continue
 			}
 
-			_, match := thumbnail.SupportedMimeTypes[*mt]
-			if match {
+			if thumbnail.IsMimeTypeSupported(*mt) {
 				baseUrl := fmt.Sprintf("%s/dav/spaces/%s?scalingup=0&preview=1&processor=thumbnail",
 					g.config.Commons.OpenCloudURL,
 					item.RemoteItem.GetId())

--- a/services/thumbnails/README.md
+++ b/services/thumbnails/README.md
@@ -31,6 +31,8 @@ Thumbnails can be generated from the following source file types:
 -   bmp
 -   txt
 
+Builds with libvips support additionally handle `webp`, see [Using libvips for Thumbnail Generation](#using-libvips-for-thumbnail-generation), and can optionelly be extended with `heic`/`heif` and `avif` at runtime, see [HEIF, HEIC and AVIF Images](#heif-heic-and-avif-images).
+
 The thumbnail service retrieves source files using the information provided by the backend. The Linux backend identifies source files usually based on the extension.
 
 If a file type was not properly assigned or the type identification failed, thumbnail generation will fail and an error will be logged.
@@ -121,3 +123,57 @@ go build -tags enable_vips -o opencloud -o bin/opencloud ./cmd/opencloud
 When building a docker image using the Dockerfile in the top-level directory of OpenCloud, libvips support is enabled and the libvips shared libraries are included
 in the resulting docker image.
 
+### HEIF, HEIC and AVIF Images
+
+Photos taken with recent Apple devices are usually stored as HEIC (which is a HEIF container holding HEVC coded image data). OpenCloud does not ship a HEVC decoder by default due to legal reasons: HEVC is covered by patent pools that require licensing, when distributing/shipping a decoder as part of the OpenCloud binaries or images.
+
+However, the `libvips` library, that OpenCloud (optionally) uses to generate thumbnails can handle these files easily – if it is extended with an additional HEIF package.
+
+To add HEIF-support based on the official OpenCloud Docker images, which are Alpine-based, one tiny package has to be added to the image: `vips-heif`. This means, due to legal reasons, you have to build your own Docker image and you cannot use the existing images from the public Docker repository.
+
+The `vips-heif` package needs to be either added to the existing Dockerfile or it can be added by creating a second, small Dockerfile wrapper around the official image from the registry. Place this new Dockerfile next to your existing Dockerfile:
+
+```Dockerfile
+FROM opencloudeu/opencloud:latest
+
+USER root
+RUN apk add --no-cache vips-heif
+USER 1000
+```
+
+Then build this new Dockerfile and use the resulting image in place of the stock one. Without Compose, tag it yourself and reference that tag wherever the stock image is used:
+
+```shell
+docker build -t opencloud-heif:latest .
+```
+
+With Compose, replace the `image:` line of the `opencloud` service with a `build:` section. Keeping an `image:` line as well is useful, it gives the image Compose builds a name of its own:
+
+```yaml
+services:
+  opencloud:
+    build: .
+    image: opencloud-heif:latest
+```
+
+Build it and start the stack:
+
+```shell
+docker compose up -d --build
+```
+
+Note that `FROM opencloudeu/opencloud:latest` is resolved while the image is built, not when the container starts, so your image does not follow new OpenCloud releases by itself. Rebuild it whenever you would have pulled a new stock image, with `--pull` so the base image is refreshed as well:
+
+```shell
+docker compose build --pull && docker compose up -d
+```
+
+To verify that the module actually ended up in your image, run this:
+
+```shell
+docker compose exec opencloud sh -c 'ls /usr/lib/vips-modules-*/'
+```
+
+The output should list `vips-heif.so`.
+
+AVIF is not affected by the HEVC patent situation. It is listed here because libvips reads it through the same module, so `vips-heif` brings both along and there is nothing extra to install for it.

--- a/services/thumbnails/README.md
+++ b/services/thumbnails/README.md
@@ -31,7 +31,7 @@ Thumbnails can be generated from the following source file types:
 -   bmp
 -   txt
 
-Builds with libvips support additionally handle `webp`, see [Using libvips for Thumbnail Generation](#using-libvips-for-thumbnail-generation), and can optionelly be extended with `heic`/`heif` and `avif` at runtime, see [HEIF, HEIC and AVIF Images](#heif-heic-and-avif-images).
+Builds with libvips support additionally handle `webp`, see [Using libvips for Thumbnail Generation](#using-libvips-for-thumbnail-generation), and can optionally be extended with `heic`/`heif` and `avif` at runtime, see [HEIF, HEIC and AVIF Images](#heif-heic-and-avif-images).
 
 The thumbnail service retrieves source files using the information provided by the backend. The Linux backend identifies source files usually based on the extension.
 
@@ -131,7 +131,7 @@ However, the `libvips` library, that OpenCloud (optionally) uses to generate thu
 
 To add HEIF-support based on the official OpenCloud Docker images, which are Alpine-based, one tiny package has to be added to the image: `vips-heif`. This means, due to legal reasons, you have to build your own Docker image and you cannot use the existing images from the public Docker repository.
 
-The `vips-heif` package needs to be either added to the existing Dockerfile or it can be added by creating a second, small Dockerfile wrapper around the official image from the registry. Place this new Dockerfile next to your existing Dockerfile:
+The `vips-heif` package needs to be either added to the existing Dockerfile or it can be added by creating a second, small Dockerfile wrapper around the official image from the registry. Save this wrapper as `Dockerfile.heif` next to your existing `Dockerfile`:
 
 ```Dockerfile
 FROM opencloudeu/opencloud:latest
@@ -144,7 +144,7 @@ USER 1000
 Then build this new Dockerfile and use the resulting image in place of the stock one. Without Compose, tag it yourself and reference that tag wherever the stock image is used:
 
 ```shell
-docker build -t opencloud-heif:latest .
+docker build -f Dockerfile.heif -t opencloud-heif:latest .
 ```
 
 With Compose, replace the `image:` line of the `opencloud` service with a `build:` section. Keeping an `image:` line as well is useful, it gives the image Compose builds a name of its own:
@@ -152,7 +152,9 @@ With Compose, replace the `image:` line of the `opencloud` service with a `build
 ```yaml
 services:
   opencloud:
-    build: .
+    build:
+      context: .
+      dockerfile: Dockerfile.heif
     image: opencloud-heif:latest
 ```
 
@@ -176,4 +178,6 @@ docker compose exec opencloud sh -c 'ls /usr/lib/vips-modules-*/'
 
 The output should list `vips-heif.so`.
 
-AVIF is not affected by the HEVC patent situation. It is listed here because libvips reads it through the same module, so `vips-heif` brings both along and there is nothing extra to install for it.
+OpenCloud verifies the HEVC and AV1 decoders independently when thumbnail support is first queried by decoding a tiny image with each codec. It only advertises previews for the formats whose decoder actually works, even on systems where the codec backends are packaged separately.
+
+AVIF is not affected by the HEVC patent situation. It is listed here because libvips reads it through the same module. Alpine's `vips-heif` dependencies provide the required decoders, so there is nothing extra to install for it when using the wrapper image above.

--- a/services/thumbnails/pkg/thumbnail/mimetypes.go
+++ b/services/thumbnails/pkg/thumbnail/mimetypes.go
@@ -20,3 +20,5 @@ var (
 		"application/vnd.geogebra.pinboard": {},
 	}
 )
+
+func initializeSupportedMimeTypes() {}

--- a/services/thumbnails/pkg/thumbnail/mimetypes_vips.go
+++ b/services/thumbnails/pkg/thumbnail/mimetypes_vips.go
@@ -3,10 +3,22 @@
 package thumbnail
 
 import (
+	"encoding/base64"
+	"sync"
+
 	"github.com/davidbyttow/govips/v2/vips"
 )
 
+const (
+	// The probes are stripped 1x1 black images. Decoding an actual pixel checks
+	// both the libvips HEIF loader and the codec backend used by libheif.
+	heicDecodeProbe = "AAAAGGZ0eXBoZWljAAAAAG1pZjFoZWljAAABaG1ldGEAAAAAAAAAIWhkbHIAAAAAAAAAAHBpY3QAAAAAAAAAAAAAAAAAAAAAImlsb2MAAAAAREAAAQABAAAAAAGIAAEAAAAAAAAAIgAAACNpaW5mAAAAAAABAAAAFWluZmUCAAAAAAEAAGh2YzEAAAAADnBpdG0AAAAAAAEAAADoaXBycAAAAMlpcGNvAAAAdWh2Y0MBA3AAAAAAAAAAAAAe8AD8/fj4AAAPA2AAAQAYQAEMAf//A3AAAAMAkAAAAwAAAwAeugJAYQABAClCAQEDcAAAAwCQAAADAAADAB6gIIEFluqumubgIaDAgAAADIAAAAMAhGIAAQAGRAHBc8GJAAAAFGlzcGUAAAAAAAAAQAAAAEAAAAAoY2xhcAAAAAEAAAABAAAAAQAAAAH////BAAAAAv///8EAAAACAAAAEHBpeGkAAAAAAwgICAAAABdpcG1hAAAAAAAAAAEAAQSBAgSDAAAAKm1kYXQAAAAeKAGvBRISTOD6A73n/ug+iFmAr7tlWKOZXGCTU7eA"
+	avifDecodeProbe = "AAAAHGZ0eXBhdmlmAAAAAG1pZjFhdmlmbWlhZgAAANZtZXRhAAAAAAAAACFoZGxyAAAAAAAAAABwaWN0AAAAAAAAAAAAAAAAAAAAACJpbG9jAAAAAERAAAEAAQAAAAAA+gABAAAAAAAAAB4AAAAjaWluZgAAAAAAAQAAABVpbmZlAgAAAAABAABhdjAxAAAAAA5waXRtAAAAAAABAAAAVmlwcnAAAAA4aXBjbwAAAAxhdjFDgQAMAAAAABRpc3BlAAAAAAAAAAEAAAABAAAAEHBpeGkAAAAAAwgICAAAABZpcG1hAAAAAAAAAAEAAQOBAgMAAAAmbWRhdBIACggYAAaICGg0IDIQH/eHhRXAACwAAJA1jjx+3A=="
+)
+
 var (
+	optionalMimeTypesOnce sync.Once
+
 	// SupportedMimeTypes contains an all mimetypes which are supported by the thumbnailer.
 	SupportedMimeTypes = map[string]struct{}{
 		"image/png":                         {},
@@ -25,9 +37,8 @@ var (
 		"image/webp":                        {},
 	}
 
-	// heifMimeTypes are the mimetypes read by the libvips heif loader, which
-	// decodes them as HEVC. They are registered only if that loader is there, see
-	// registerOptionalMimeTypes.
+	// heifMimeTypes are the mimetypes commonly used for HEVC-coded images in a
+	// HEIF container.
 	heifMimeTypes = []string{
 		"image/heic",
 		"image/heic-sequence",
@@ -41,29 +52,52 @@ var (
 	}
 )
 
-func init() {
-	// keep libvips as quiet as the preprocessor wants it. Looking for the loaders
-	// below starts libvips and we cannot rely on the preprocessor init having run
-	// first.
-	vips.LoggingSettings(nil, vips.LogLevelError)
-	registerOptionalMimeTypes()
+func initializeSupportedMimeTypes() {
+	optionalMimeTypesOnce.Do(func() {
+		// Running a decoder during package initialization can deadlock because
+		// libvips evaluates images on worker threads. Defer the probes until the
+		// MIME type set is first queried at runtime.
+		vips.LoggingSettings(nil, vips.LogLevelError)
+		registerOptionalMimeTypes()
+	})
 }
 
-// registerOptionalMimeTypes adds the mimetypes which libvips can only read
-// through a loader that is not part of libvips itself.
-// E.g. OpenCloud does not ship a HEVC decoder because of the patent situation
-// (see Readme.md). Registering the mimetypes only when the loader is really
-// there keeps the `oc:has-preview` flag and the graph thumbnail links in sync
+// registerOptionalMimeTypes adds MIME types that libvips can read only through
+// optional loader and codec packages. OpenCloud does not ship an HEVC decoder
+// because of the patent situation (see README.md). Registering MIME types only
+// when decoding succeeds keeps oc:has-preview and graph thumbnail links in sync
 // with what the thumbnails service can deliver.
 func registerOptionalMimeTypes() {
-	if vips.IsTypeSupported(vips.ImageTypeHEIF) {
+	registerOptionalMimeTypesWithDecoder(SupportedMimeTypes, canDecodeImage)
+}
+
+func registerOptionalMimeTypesWithDecoder(supportedMimeTypes map[string]struct{}, canDecode func(string) bool) {
+	if canDecode(heicDecodeProbe) {
 		for _, mimeType := range heifMimeTypes {
-			SupportedMimeTypes[mimeType] = struct{}{}
+			supportedMimeTypes[mimeType] = struct{}{}
 		}
 	}
-	if vips.IsTypeSupported(vips.ImageTypeAVIF) {
+	if canDecode(avifDecodeProbe) {
 		for _, mimeType := range avifMimeTypes {
-			SupportedMimeTypes[mimeType] = struct{}{}
+			supportedMimeTypes[mimeType] = struct{}{}
 		}
 	}
+}
+
+// canDecodeImage forces libvips to decode one pixel. Creating an ImageRef alone
+// is not enough because libvips evaluates image operations lazily.
+func canDecodeImage(encodedProbe string) bool {
+	probe, err := base64.StdEncoding.DecodeString(encodedProbe)
+	if err != nil {
+		return false
+	}
+
+	img, err := vips.NewImageFromBuffer(probe)
+	if err != nil {
+		return false
+	}
+	defer img.Close()
+
+	_, err = img.GetPoint(0, 0)
+	return err == nil
 }

--- a/services/thumbnails/pkg/thumbnail/mimetypes_vips.go
+++ b/services/thumbnails/pkg/thumbnail/mimetypes_vips.go
@@ -2,6 +2,10 @@
 
 package thumbnail
 
+import (
+	"github.com/davidbyttow/govips/v2/vips"
+)
+
 var (
 	// SupportedMimeTypes contains an all mimetypes which are supported by the thumbnailer.
 	SupportedMimeTypes = map[string]struct{}{
@@ -20,4 +24,46 @@ var (
 		"application/vnd.geogebra.pinboard": {},
 		"image/webp":                        {},
 	}
+
+	// heifMimeTypes are the mimetypes read by the libvips heif loader, which
+	// decodes them as HEVC. They are registered only if that loader is there, see
+	// registerOptionalMimeTypes.
+	heifMimeTypes = []string{
+		"image/heic",
+		"image/heic-sequence",
+		"image/heif",
+		"image/heif-sequence",
+	}
+
+	// avifMimeTypes go through the same loader but are coded as AV1.
+	avifMimeTypes = []string{
+		"image/avif",
+	}
 )
+
+func init() {
+	// keep libvips as quiet as the preprocessor wants it. Looking for the loaders
+	// below starts libvips and we cannot rely on the preprocessor init having run
+	// first.
+	vips.LoggingSettings(nil, vips.LogLevelError)
+	registerOptionalMimeTypes()
+}
+
+// registerOptionalMimeTypes adds the mimetypes which libvips can only read
+// through a loader that is not part of libvips itself.
+// E.g. OpenCloud does not ship a HEVC decoder because of the patent situation
+// (see Readme.md). Registering the mimetypes only when the loader is really
+// there keeps the `oc:has-preview` flag and the graph thumbnail links in sync
+// with what the thumbnails service can deliver.
+func registerOptionalMimeTypes() {
+	if vips.IsTypeSupported(vips.ImageTypeHEIF) {
+		for _, mimeType := range heifMimeTypes {
+			SupportedMimeTypes[mimeType] = struct{}{}
+		}
+	}
+	if vips.IsTypeSupported(vips.ImageTypeAVIF) {
+		for _, mimeType := range avifMimeTypes {
+			SupportedMimeTypes[mimeType] = struct{}{}
+		}
+	}
+}

--- a/services/thumbnails/pkg/thumbnail/mimetypes_vips_test.go
+++ b/services/thumbnails/pkg/thumbnail/mimetypes_vips_test.go
@@ -1,0 +1,106 @@
+//go:build enable_vips
+
+package thumbnail
+
+import (
+	"encoding/base64"
+	"reflect"
+	"testing"
+
+	"github.com/davidbyttow/govips/v2/vips"
+)
+
+func TestRegisterOptionalMimeTypesWithDecoder(t *testing.T) {
+	tests := []struct {
+		name          string
+		canDecodeHEIC bool
+		canDecodeAVIF bool
+		expected      map[string]struct{}
+	}{
+		{
+			name:     "no optional codec",
+			expected: map[string]struct{}{},
+		},
+		{
+			name:          "HEVC decoder only",
+			canDecodeHEIC: true,
+			expected: mimeTypeSet(
+				"image/heic",
+				"image/heic-sequence",
+				"image/heif",
+				"image/heif-sequence",
+			),
+		},
+		{
+			name:          "AV1 decoder only",
+			canDecodeAVIF: true,
+			expected:      mimeTypeSet("image/avif"),
+		},
+		{
+			name:          "both optional codecs",
+			canDecodeHEIC: true,
+			canDecodeAVIF: true,
+			expected: mimeTypeSet(
+				"image/heic",
+				"image/heic-sequence",
+				"image/heif",
+				"image/heif-sequence",
+				"image/avif",
+			),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			canDecode := func(probe string) bool {
+				switch probe {
+				case heicDecodeProbe:
+					return tt.canDecodeHEIC
+				case avifDecodeProbe:
+					return tt.canDecodeAVIF
+				default:
+					t.Fatalf("unexpected decoder probe")
+					return false
+				}
+			}
+
+			got := map[string]struct{}{}
+			registerOptionalMimeTypesWithDecoder(got, canDecode)
+
+			if !reflect.DeepEqual(tt.expected, got) {
+				t.Errorf("registered MIME types = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestDecoderProbesUseExpectedImageTypes(t *testing.T) {
+	tests := []struct {
+		name      string
+		probe     string
+		imageType vips.ImageType
+	}{
+		{name: "HEIC", probe: heicDecodeProbe, imageType: vips.ImageTypeHEIF},
+		{name: "AVIF", probe: avifDecodeProbe, imageType: vips.ImageTypeAVIF},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			probe, err := base64.StdEncoding.DecodeString(tt.probe)
+			if err != nil {
+				t.Fatalf("decode probe: %v", err)
+			}
+			if got := vips.DetermineImageType(probe); got != tt.imageType {
+				t.Errorf("probe image type = %v, want %v", got, tt.imageType)
+			}
+		})
+	}
+}
+
+func mimeTypeSet(mimeTypes ...string) map[string]struct{} {
+	set := make(map[string]struct{}, len(mimeTypes))
+	for _, mimeType := range mimeTypes {
+		set[mimeType] = struct{}{}
+	}
+	return set
+}

--- a/services/thumbnails/pkg/thumbnail/thumbnail.go
+++ b/services/thumbnails/pkg/thumbnail/thumbnail.go
@@ -107,6 +107,7 @@ func IsMimeTypeSupported(m string) bool {
 	if err != nil {
 		return false
 	}
+	initializeSupportedMimeTypes()
 	_, supported := SupportedMimeTypes[mimeType]
 	return supported
 }

--- a/services/webdav/pkg/service/v0/search.go
+++ b/services/webdav/pkg/service/v0/search.go
@@ -222,8 +222,7 @@ func matchToPropResponse(ctx context.Context, davPrefix, publicURL string, match
 	propstatOK.Prop = append(propstatOK.Prop, prop.Escaped("oc:permissions", match.Entity.Permissions))
 	propstatOK.Prop = append(propstatOK.Prop, prop.Escaped("oc:highlights", match.Entity.Highlights))
 	propstatOK.Prop = append(propstatOK.Prop, prop.Escaped("d:getcontenttype", match.Entity.MimeType))
-	_, isSupportedMimeType := thumbnail.SupportedMimeTypes[match.Entity.MimeType]
-	if isSupportedMimeType {
+	if thumbnail.IsMimeTypeSupported(match.Entity.MimeType) {
 		propstatOK.Prop = append(propstatOK.Prop, prop.Escaped("oc:has-preview", "1"))
 	} else {
 		propstatOK.Prop = append(propstatOK.Prop, prop.Escaped("oc:has-preview", "0"))
@@ -270,8 +269,7 @@ func matchToPropResponse(ctx context.Context, davPrefix, publicURL string, match
 }
 
 func hasPreview(md *provider.ResourceInfo, appendToOK func(p ...prop.PropertyXML)) {
-	_, match := thumbnail.SupportedMimeTypes[md.MimeType]
-	if match {
+	if thumbnail.IsMimeTypeSupported(md.MimeType) {
 		appendToOK(prop.Escaped("oc:has-preview", "1"))
 	} else {
 		appendToOK(prop.Escaped("oc:has-preview", "0"))

--- a/vendor/github.com/opencloud-eu/reva/v2/internal/http/services/owncloud/ocdav/propfind/propfind.go
+++ b/vendor/github.com/opencloud-eu/reva/v2/internal/http/services/owncloud/ocdav/propfind/propfind.go
@@ -1727,8 +1727,7 @@ func mdToPropResponse(ctx context.Context, pf *XML, md *provider.ResourceInfo, p
 }
 
 func hasPreview(md *provider.ResourceInfo, appendToOK func(p ...prop.PropertyXML)) {
-	_, match := thumbnail.SupportedMimeTypes[md.MimeType]
-	if match {
+	if thumbnail.IsMimeTypeSupported(md.MimeType) {
 		appendToOK(prop.Escaped("oc:has-preview", "1"))
 	} else {
 		appendToOK(prop.Escaped("oc:has-preview", "0"))


### PR DESCRIPTION
<!--
Thanks for submitting a change to OpenCloud!

For fixing potential security issues please see https://opencloud.eu/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the main branch which holds the next version of OpenCloud.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Preview/thumbnails for HEIC images (which is the default image format on Apple devices) are a long-wanted feature. However HEIF is covered by patents, which don't allow shipping (redistributing) HEIF decoders without a proper license. However admins can decide on their own to evaluate their individual license situation and install the required packages manually. If they decide to do so, this PR will make sure that OpenCloud picks up the optional HEIF decoder and properly reports the ability to create thumbnails for the HEIF formats.

This requires a follow-up PR in the frontend repo: https://github.com/opencloud-eu/web/pull/3187
However it can already be shipped as-is, since it already adds preview for file lists (clicking on it does not work yet – this is what the PR in the web repo will fix).

For AVIF previews to work correctly, this requires https://github.com/opencloud-eu/reva/pull/781 to be merged first.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #630 

## Motivation and Context
It's still not an easy fix for everyone that would like to see previews for photos made with Apple devices. However it's as close as it gets without diving into the whole patent/license situation. And it's definitely an improvement, since HEIF support can be added manually by admins.

## How Has This Been Tested?
Tested end-to-end with actual photos from a recent iOS device.

## Screenshots (if appropriate):

<img width="1509" height="438" alt="Screenshot 2026-08-19 at 21 58 52" src="https://github.com/user-attachments/assets/18e98201-6e80-4cdd-a645-fa90322cca5c" />


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation added

## LLM Disclosure
This PR was created with the support of multiple LLMs. However, I've manually reviewed tested and iterated on it. It's not one-shotted or vibecoded. This PR description and all my GitHub comments are 100% LLM-free.
