### PR TITLE
[stable-7.2] backport fixes for the opencloud posixfs command

### DIFF
--- a/opencloud/pkg/command/posixfs.go
+++ b/opencloud/pkg/command/posixfs.go
@@ -1,18 +1,15 @@
 package command
 
 import (
-	"bufio"
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/opencloud-eu/opencloud/opencloud/pkg/register"
 	"github.com/opencloud-eu/opencloud/pkg/config"
 	"github.com/opencloud-eu/opencloud/pkg/config/configlog"
 	"github.com/opencloud-eu/opencloud/pkg/config/parser"
-	oclog "github.com/opencloud-eu/opencloud/pkg/log"
 	"github.com/opencloud-eu/opencloud/pkg/x/path/filepathx"
 	storageUsersParser "github.com/opencloud-eu/opencloud/services/storage-users/pkg/config/parser"
 	"github.com/opencloud-eu/opencloud/services/storage-users/pkg/event"
@@ -21,27 +18,10 @@ import (
 	"github.com/opencloud-eu/reva/v2/pkg/storage/fs/posix/ignore"
 	"github.com/opencloud-eu/reva/v2/pkg/storage/fs/posix/options"
 	"github.com/opencloud-eu/reva/v2/pkg/storage/fs/registry"
+	"github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/metadata/prefixes"
 
 	"github.com/pkg/xattr"
-	"github.com/rs/zerolog"
 	"github.com/spf13/cobra"
-	"github.com/theckman/yacspin"
-	"github.com/vmihailenco/msgpack/v5"
-)
-
-// Define the names of the extended attributes we are working with.
-const (
-	parentIDAttrName = "user.oc.parentid"
-	idAttrName       = "user.oc.id"
-	nameAttrName     = "user.oc.name"
-	spaceIDAttrName  = "user.oc.space.id"
-	ownerIDAttrName  = "user.oc.owner.id"
-)
-
-var (
-	spinner         *yacspin.Spinner
-	restartRequired = false
-	ignorer         *ignore.Ignorer
 )
 
 type IDCacher interface {
@@ -140,11 +120,7 @@ func scanCmd(ocCfg *config.Config) *cobra.Command {
 				fmt.Fprintf(os.Stderr, "Failed to create event stream for posix driver: %v\n", err)
 				os.Exit(1)
 			}
-			log := oclog.NewLogger(
-				oclog.Name("posixfs scan"),
-				oclog.Level("error"),
-				oclog.Pretty(true),
-				oclog.Color(false)).Logger
+			log := logger("posixfs")
 
 			if !defaultRoot {
 				log = log.With().Str("basepath", root).Logger()
@@ -188,403 +164,93 @@ func scanCmd(ocCfg *config.Config) *cobra.Command {
 }
 
 // consistencyCmd returns a command to check the consistency of the posixfs storage.
-func consistencyCmd(cfg *config.Config) *cobra.Command {
+func consistencyCmd(ocCfg *config.Config) *cobra.Command {
 	consCmd := &cobra.Command{
-		Use:   "consistency",
-		Short: "check the consistency of the posixfs storage",
+		Use:   "consistency [path ...]",
+		Short: "Check the consistency of the posixfs storage",
+		Long: `Check the consistency of the posixfs storage.
+
+You can specify one or more paths to limit the scope of the check.
+If no path is provided, the whole storage is checked.
+
+The provided arguments determines the scope of the check:
+  - a storage root:   the whole storage (all personal and project spaces) is checked
+  - a space root:     only that space is checked
+  - a file or directory: only that single entity is checked (and its children, if it is a directory)`,
+		Args: cobra.ArbitraryArgs,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+
+			if err := parser.ParseConfig(ocCfg, true); err != nil {
+				return configlog.ReturnError(err)
+			}
+
+			// Parse storage users config
+			ocCfg.StorageUsers.Commons = ocCfg.Commons
+
+			return configlog.ReturnFatal(storageUsersParser.ParseConfig(ocCfg.StorageUsers))
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return checkPosixfsConsistency(cmd, cfg)
+			cfg := ocCfg.StorageUsers
+			if len(args) == 0 {
+				args = []string{cfg.Drivers.Posix.Root}
+			}
+			log := logger("posixfs")
+			recalculateChecksums, _ := cmd.Flags().GetBool("fix-checksums")
+
+			drivers := revaconfig.StorageProviderDrivers(cfg)
+			drivers["posix"] = revaconfig.Posix(cfg, false, false)
+			opts, err := options.New(drivers["posix"].(map[string]any))
+			if err != nil {
+				return err
+			}
+			ignorer := ignore.NewIgnorer(opts, &log)
+
+			checker := &consistencyChecker{
+				cfg:                  cfg,
+				ignorer:              ignorer,
+				recalculateChecksums: recalculateChecksums,
+			}
+
+			return checker.Check(args)
 		},
 	}
-	consCmd.Flags().StringP("root", "r", "", "Path to the root directory of the posixfs storage")
-	_ = consCmd.MarkFlagRequired("root")
+	consCmd.Flags().Bool("fix-checksums", false, "Recalculate and fix the file checksums. This reads every file and can be slow on large storages.")
 
 	return consCmd
 }
 
-// checkPosixfsConsistency checks the consistency of the posixfs storage.
-func checkPosixfsConsistency(cmd *cobra.Command, cfg *config.Config) error {
-	rootPath, _ := cmd.Flags().GetString("root")
-	indexesPath := filepath.Join(rootPath, "indexes")
-
-	opt, _ := options.New(map[string]interface{}{
-		"root": rootPath,
-	})
-	log := zerolog.Nop()
-	ignorer = ignore.NewIgnorer(opt, &log)
-
-	_, err := os.Stat(indexesPath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return fmt.Errorf("consistency check failed: '%s' is not a posixfs root", rootPath)
-		}
-		return fmt.Errorf("error accessing '%s': %w", indexesPath, err)
-	}
-
-	spinnerCfg := yacspin.Config{
-		Frequency:         100 * time.Millisecond,
-		CharSet:           yacspin.CharSets[11],
-		StopCharacter:     "✓",
-		StopColors:        []string{"fgGreen"},
-		StopFailCharacter: "✗",
-		StopFailColors:    []string{"fgRed"},
-	}
-
-	spinner, err = yacspin.New(spinnerCfg)
-	err = spinner.Start()
-	if err != nil {
-		return fmt.Errorf("error creating spinner: %w", err)
-	}
-
-	checkSpaces(filepath.Join(rootPath, "users"))
-	spinner.Suffix(" Personal spaces check ")
-	spinner.StopMessage("completed\n")
-	spinner.Stop()
-
-	checkSpaces(filepath.Join(rootPath, "projects"))
-	spinner.Suffix(" Project spaces check ")
-	spinner.StopMessage("completed")
-	spinner.Stop()
-
-	if restartRequired {
-		fmt.Println("\n\n  ⚠️  Please restart your openCloud instance to apply changes.")
-	}
-	return nil
-}
-
-func checkSpaces(basePath string) {
-	dirEntries, err := os.ReadDir(basePath)
-	if err != nil {
-		spinner.Message(fmt.Sprintf("Error reading spaces directory '%s'\n", basePath))
-		spinner.StopFail()
-		return
-	}
-
-	for _, entry := range dirEntries {
-		if entry.IsDir() {
-			fullPath := filepath.Join(basePath, entry.Name())
-			checkSpace(fullPath)
-		}
-	}
-}
-
-func checkSpace(spacePath string) {
-	spinner.Message("")
-	spinner.Suffix(fmt.Sprintf(" Checking space '%s'", spacePath))
-
-	info, err := os.Stat(spacePath)
-	if err != nil {
-		logFailure("Error accessing path '%s': %v", spacePath, err)
-		return
-	}
-	if !info.IsDir() {
-		logFailure("Error: The provided path '%s' is not a directory\n", spacePath)
-		return
-	}
-
-	spaceID, err := xattr.Get(spacePath, spaceIDAttrName)
-	if err != nil || len(spaceID) == 0 {
-		logFailure("Error: The directory '%s' does not seem to be a space root, it's missing the '%s' attribute\n", spacePath, spaceIDAttrName)
-		return
-	}
-
-	checkSpaceID(spacePath)
-	checkNodeIDs(spacePath)
-}
-
-func checkSpaceID(spacePath string) {
-	spinner.Message(" - checking space ID uniqueness")
-
-	entries, uniqueIDs, oldestEntry, err := gatherAttributes(spacePath)
-	if err != nil {
-		logFailure("Failed to gather attributes: %v", err)
-		return
-	}
-
-	if len(entries) == 0 {
-		return
-	}
-
-	if len(uniqueIDs) > 1 {
-		spinner.Pause()
-		fmt.Println("\n  ⚠ Multiple space IDs found:")
-		for id := range uniqueIDs {
-			fmt.Printf("    - %s\n", id)
-		}
-
-		fmt.Printf("\n  ⏳ Oldest entry is '%s' (modified on %s).\n",
-			filepath.Base(oldestEntry.Path), oldestEntry.ModTime.Format(time.RFC1123))
-
-		targetID := oldestEntry.ParentID
-		fmt.Printf("  ✅ Proposed target Parent ID: %s\n", targetID)
-
-		fmt.Printf("\n  Do you want to unify all parent IDs to '%s'? This will modify %d entries, the directory, and the user index. (y/N): ", targetID, len(entries))
-
-		reader := bufio.NewReader(os.Stdin)
-		input, _ := reader.ReadString('\n')
-		input = strings.TrimSpace(strings.ToLower(input))
-
-		if input != "y" {
-			spinner.Unpause()
-			logFailure("Operation cancelled by user.")
-			return
-		}
-		restartRequired = true
-
-		obsoleteIDs := []string{}
-		for id := range uniqueIDs {
-			if id != targetID {
-				obsoleteIDs = append(obsoleteIDs, id)
-			}
-		}
-		fixSpaceID(spacePath, obsoleteIDs, targetID, entries)
-		spinner.Unpause()
-	}
-}
-
-func walkNodes(dir string, parentID string) int {
-	fixes := 0
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		logFailure("Error reading directory '%s': %v", dir, err)
-		return 0
-	}
-
-	for _, entry := range entries {
-		fullPath := filepath.Join(dir, entry.Name())
-
-		if ignorer.IsIgnored(fullPath) {
-			continue
-		}
-
-		// Check if the parent ID attribute matches the expected parent ID, if not, fix it.
-		actualParentID, err := xattr.Get(fullPath, parentIDAttrName)
-		if err != nil || string(actualParentID) != parentID {
-			err = xattr.Set(fullPath, parentIDAttrName, []byte(parentID))
-			if err != nil {
-				logFailure("Failed to fix parent ID for '%s': %v", fullPath, err)
-			} else {
-				spinner.Pause()
-				fmt.Printf("  + Fixed parent ID for '%s'", fullPath)
-				spinner.Unpause()
-				fixes++
-				restartRequired = true
-			}
-		}
-
-		// Check that the name attribute matches the actual name of the file/directory, if not, fix it.
-		nameAttr, err := xattr.Get(fullPath, nameAttrName)
-		if err != nil || string(nameAttr) != entry.Name() {
-			err = xattr.Set(fullPath, nameAttrName, []byte(entry.Name()))
-			if err != nil {
-				logFailure("Failed to fix name attribute for '%s': %v", fullPath, err)
-			} else {
-				spinner.Pause()
-				fmt.Printf("  + Fixed name attribute for '%s'", fullPath)
-				spinner.Unpause()
-				fixes++
-				restartRequired = true
-			}
-		}
-
-		if entry.IsDir() {
-			nodeID, err := xattr.Get(fullPath, idAttrName)
-			if err != nil || len(nodeID) == 0 {
-				logFailure("Directory '%s' missing '%s', skipping its children", fullPath, idAttrName)
-				continue
-			}
-			walkNodes(fullPath, string(nodeID))
-		}
-	}
-	return fixes
-}
-
-func checkNodeIDs(spacePath string) {
-	spinner.Message(" - checking nodes")
-
-	rootID, err := xattr.Get(spacePath, idAttrName)
-	if err != nil || len(rootID) == 0 {
-		logFailure("Space root '%s' missing '%s' attribute", spacePath, idAttrName)
-		return
-	}
-
-	fixes := walkNodes(spacePath, string(rootID))
-
-	if fixes > 0 {
-		spinner.Pause()
-		fmt.Printf("\n  ✓ Fixed %d incorrect node attributes in %s\n", fixes, filepath.Base(spacePath))
-		spinner.Unpause()
-	}
-}
-
-func fixSpaceID(spacePath string, obsoleteIDs []string, targetID string, entries []EntryInfo) {
-	// Set all parentid attributes to the proper space ID
-	err := setAllParentIDAttributes(entries, targetID)
-	if err != nil {
-		logFailure("an error occurred during file attribute update: %v", err)
-		return
-	}
-
-	// Update space ID itself
-	fmt.Printf("  Updating directory '%s' with attribute '%s' -> %s\n", filepath.Base(spacePath), idAttrName, targetID)
-	err = xattr.Set(spacePath, idAttrName, []byte(targetID))
-	if err != nil {
-		logFailure("Failed to set attribute on directory '%s': %v", spacePath, err)
-		return
-	}
-	err = xattr.Set(spacePath, spaceIDAttrName, []byte(targetID))
-	if err != nil {
-		logFailure("Failed to set attribute on directory '%s': %v", spacePath, err)
-		return
-	}
-
-	// update the index
-	err = updateOwnerIndexFile(spacePath, obsoleteIDs)
-	if err != nil {
-		logFailure("Could not update the owner index file: %v", err)
-	}
-}
-
-func gatherAttributes(path string) ([]EntryInfo, map[string]struct{}, EntryInfo, error) {
-	dirEntries, err := os.ReadDir(path)
-	if err != nil {
-		return nil, nil, EntryInfo{}, fmt.Errorf("failed to read directory: %w", err)
-	}
-
-	var allEntries []EntryInfo
-	uniqueIDs := make(map[string]struct{})
-	var oldestEntry EntryInfo
-	oldestTime := time.Now().Add(100 * 365 * 24 * time.Hour) // Set to a future date to find the oldest entry
-
-	for _, entry := range dirEntries {
-		fullPath := filepath.Join(path, entry.Name())
-		if ignorer.IsIgnored(fullPath) {
-			continue
-		}
-		info, err := os.Stat(fullPath)
-		if err != nil {
-			fmt.Printf("  - Warning: could not stat %s: %v\n", entry.Name(), err)
-			continue
-		}
-
-		parentID, err := xattr.Get(fullPath, parentIDAttrName)
-		if err != nil {
-			continue // Skip if attribute doesn't exist or can't be read
-		}
-
-		entryInfo := EntryInfo{
-			Path:     fullPath,
-			ModTime:  info.ModTime(),
-			ParentID: string(parentID),
-		}
-
-		allEntries = append(allEntries, entryInfo)
-		uniqueIDs[string(parentID)] = struct{}{}
-
-		if entryInfo.ModTime.Before(oldestTime) {
-			oldestTime = entryInfo.ModTime
-			oldestEntry = entryInfo
-		}
-	}
-
-	return allEntries, uniqueIDs, oldestEntry, nil
-}
-
-func setAllParentIDAttributes(entries []EntryInfo, targetID string) error {
-	fmt.Printf("  Setting all parent IDs to '%s':\n", targetID)
-
-	for _, entry := range entries {
-		if entry.ParentID == targetID {
-			fmt.Printf("    - Skipping '%s' (already has target ID).\n", filepath.Base(entry.Path))
-			continue
-		}
-
-		fmt.Printf("    - Removing all attributes from '%s'. It will be re-assimilated\n", filepath.Base(entry.Path))
-		filepath.WalkDir(entry.Path, func(path string, d os.DirEntry, err error) error {
-			if err != nil {
-				return fmt.Errorf("error walking path '%s': %w", path, err)
-			}
-
-			// Remove all attributes from the file.
-			if err := removeAttributes(path); err != nil {
-				fmt.Printf("failed to remove attributes from '%s': %v", path, err)
-			}
-			return nil
-		})
-	}
-	return nil
-}
-
-// updateOwnerIndexFile handles the logic of reading, modifying, and writing the MessagePack index file.
-func updateOwnerIndexFile(basePath string, obsoleteIDs []string) error {
-	fmt.Printf("  Rewriting index file '%s'\n", basePath)
-
-	ownerID, err := xattr.Get(basePath, ownerIDAttrName)
-	if err != nil {
-		return fmt.Errorf("could not get owner ID from oldest entry '%s' to find index: %w", basePath, err)
-	}
-
-	indexPath := filepath.Join(basePath, "../../indexes/by-user-id", string(ownerID)+".mpk")
-	indexPath = filepath.Clean(indexPath)
-
-	// Read the MessagePack file
-	fileData, err := os.ReadFile(indexPath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return fmt.Errorf("index file does not exist, skipping update")
-		}
-		return fmt.Errorf("could not read index file: %w", err)
-	}
-	var indexMap map[string]string
-	if err := msgpack.Unmarshal(fileData, &indexMap); err != nil {
-		return fmt.Errorf("failed to parse MessagePack index file (is it corrupt?): %w", err)
-	}
-
-	// Remove obsolete IDs from the map
-	itemsRemoved := 0
-	for _, id := range obsoleteIDs {
-		if _, exists := indexMap[id]; exists {
-			fmt.Printf("    - Removing obsolete ID '%s' from index.\n", id)
-			delete(indexMap, id)
-			itemsRemoved++
-		} else {
-			fmt.Printf("    - Obsolete ID '%s' not found in index\n", id)
-		}
-	}
-
-	if itemsRemoved == 0 {
-		return nil
-	}
-
-	// Write the data back to the file
-	updatedData, err := msgpack.Marshal(&indexMap)
-	if err != nil {
-		return fmt.Errorf("failed to marshal updated index map: %w", err)
-	}
-	if err := os.WriteFile(indexPath, updatedData, 0644); err != nil {
-		return fmt.Errorf("failed to write updated index file: %w", err)
-	}
-
-	fmt.Printf("  ✓ Successfully removed %d item(s) and saved index file.\n", itemsRemoved)
-	return nil
-}
-
-func removeAttributes(path string) error {
-	attrNames, err := xattr.List(path)
-	if err != nil {
-		return fmt.Errorf("failed to list attributes for '%s': %w", path, err)
-	}
-
-	for _, attrName := range attrNames {
-		if err := xattr.Remove(path, attrName); err != nil {
-			return fmt.Errorf("failed to remove attribute '%s' from '%s': %w", attrName, path, err)
-		}
-	}
-	return nil
-}
-
 func logFailure(message string, args ...any) {
-	spinner.StopFailMessage(fmt.Sprintf("\n"+message, args...))
-	spinner.StopFail()
-	spinner.Start()
+	fmt.Fprintf(os.Stderr, message+"\n", args...)
+}
+
+// findStorageRoot walks up the directory tree starting at path until it finds a
+// directory that contains an "indexes" subdirectory which marks the root of a
+// posixfs storage. A user directory inside a space might also be named "indexes",
+// so to disambiguate we require that the "indexes" directory is an internal
+// directory: the storage's own indexes directory is skipped during assimilation
+// and therefore never receives a node ID attribute, whereas a regular user
+// directory would have one.
+func findStorageRoot(path string) (string, error) {
+	current := path
+	for {
+		indexesPath := filepath.Join(current, "indexes")
+		if info, err := os.Stat(indexesPath); err == nil && info.IsDir() {
+			if id, err := xattr.Get(indexesPath, prefixes.IDAttr); err != nil || len(id) == 0 {
+				return current, nil
+			}
+		}
+
+		parent := filepath.Dir(current)
+		if parent == current {
+			return "", fmt.Errorf("'%s' does not appear to be inside a posixfs storage (no 'indexes' directory found)", path)
+		}
+		current = parent
+	}
+}
+
+// isSpaceRoot reports whether the given path is a space root, which is
+// identified by the presence of the space ID attribute.
+func isSpaceRoot(path string) bool {
+	spaceID, err := xattr.Get(path, prefixes.SpaceIDAttr)
+	return err == nil && len(spaceID) > 0
 }

--- a/opencloud/pkg/command/posixfs.go
+++ b/opencloud/pkg/command/posixfs.go
@@ -55,11 +55,23 @@ func init() {
 
 // scanCmd performs a posixfs id cache warmup scan
 func scanCmd(ocCfg *config.Config) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "scan",
+	scanCmd := &cobra.Command{
+		Use:   "scan [path ...]",
 		Short: "Perform a filesystem scan and update the ID and filemetadata cache",
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		Long: `Perform a filesystem scan and update the ID and filemetadata cache.
 
+You can specify one or more paths to limit the scope of the scan.
+If no path is provided, the whole storage is checked, starting at the storage root directory.
+
+The provided arguments determines the scope of the check:
+  - a storage root:   the whole storage (all personal and project spaces) is scanned
+  - a space root:     only that space is scanned
+  - a file or directory: only that single resource is scanned (and its children, if it is a directory)
+
+Any specified file or directory must be underneath the storage root directory and if that is not the case,
+the command is aborted with an error before performing any scanning.`,
+		Args: cobra.ArbitraryArgs,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := parser.ParseConfig(ocCfg, true); err != nil {
 				return configlog.ReturnError(err)
 			}
@@ -76,91 +88,110 @@ func scanCmd(ocCfg *config.Config) *cobra.Command {
 				os.Exit(1)
 			}
 
+			haltOnError, err := cmd.Flags().GetBool("halt-on-error")
+			if err != nil {
+				return err
+			}
+
 			storageRoot := cfg.Drivers.Posix.Root
-			root := storageRoot
-			defaultRoot := true
-			if v, err := cmd.Flags().GetString("basepath"); err != nil {
-				fmt.Fprintf(os.Stderr, "Failed to parse command-line parameter '--basepath': %v\n", err)
-				os.Exit(1)
-			} else if v != "" {
-				root = v
-				if !filepath.IsAbs(v) {
-					if v, err = filepath.Abs(v); err != nil {
-						fmt.Fprintf(os.Stderr, "Failed to make the basepath mentioned using '--basepath' absolute: %v\n", err)
-						os.Exit(1)
-					} else {
-						root = v
+			paths := []string{storageRoot}
+			if len(args) > 0 {
+				paths = []string{}
+				for _, v := range args {
+					path := v
+					if !filepath.IsAbs(path) {
+						if v, err := filepath.Abs(path); err != nil {
+							fmt.Fprintf(os.Stderr, "Failed to make the specified path %q absolute: %v\n", v, err)
+							os.Exit(1)
+						} else {
+							path = v
+						}
 					}
-				} else {
-					root = v
-				}
-				root = filepath.Clean(root)
-				defaultRoot = false
-			}
-
-			// ensure that, if a basepath has been indicated, it is under the storage root
-			if !defaultRoot {
-				if contained, err := filepathx.IsSameOrContainedBy(storageRoot, root); err != nil {
-					fmt.Fprintf(os.Stderr, "Failed to determine whether the specified basepath %q is contained by the storage root %q: %v\n", root, storageRoot, err)
-					os.Exit(1)
-				} else if !contained {
-					fmt.Fprintf(os.Stderr, "The specified basepath %q is neither the storage root %q, nor a subdirectory thereof, nor a file underneath it\n", root, storageRoot)
-					os.Exit(1)
+					// not ensuring whether the path is under the storage root here, will be done when iterating over them
+					path = filepath.Clean(path)
+					paths = append(paths, path)
 				}
 			}
 
-			// We want to initialize the driver but disable scanfs on boot, so we can trigger it manually afterwards
-			drivers := revaconfig.StorageProviderDrivers(cfg)
-			drivers["posix"] = revaconfig.Posix(cfg, false, false)
+			var scan func(path string) error = nil
+			{
+				// We want to initialize the driver but disable scanfs on boot, so we can trigger it manually afterwards
+				drivers := revaconfig.StorageProviderDrivers(cfg)
+				drivers["posix"] = revaconfig.Posix(cfg, false, false)
 
-			var fsStream events.Stream
-			var err error
-			fsStream, err = event.NewStream(cfg)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Failed to create event stream for posix driver: %v\n", err)
-				os.Exit(1)
+				var fsStream events.Stream
+				var err error
+				fsStream, err = event.NewStream(cfg)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "Failed to create event stream for posix driver: %v\n", err)
+					os.Exit(1)
+				}
+				log := logger("posixfs")
+
+				f, ok := registry.NewFuncs["posix"]
+				if !ok {
+					fmt.Fprintf(os.Stderr, "posix driver not found in registry\n")
+					os.Exit(1)
+				}
+
+				fs, err := f(drivers["posix"].(map[string]any), fsStream, &log)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "Failed to initialize filesystem driver '%s': %v\n", cfg.Driver, err)
+					return err
+				}
+
+				cacher, ok := fs.(IDCacher)
+				if !ok {
+					fmt.Fprintf(os.Stderr, "The posix driver does not expose WarmupIDCache.\n")
+					os.Exit(1)
+				}
+
+				scan = func(path string) error {
+					err := cacher.WarmupIDCache(path, true, false)
+					if err != nil {
+						logFailure("Error scanning path '%s': %v", path, err)
+					}
+					return err
+				}
 			}
-			log := logger("posixfs")
 
-			if !defaultRoot {
-				log = log.With().Str("basepath", root).Logger()
-			}
+			errors := processPosixFsResources(paths, !haltOnError,
+				func(path string) error {
+					fmt.Println("Scanning personal spaces...")
+					return scan(path)
+				},
+				func(path string) error {
+					fmt.Println("Scanning project spaces...")
+					return scan(path)
+				},
+				func(path string) error {
+					fmt.Printf("Scanning space '%s'...\n", path)
+					return scan(path)
+				},
+				func(path string) error {
+					fmt.Printf("Scanning '%s'...\n", path)
+					return scan(path)
+				},
+			)
 
-			f, ok := registry.NewFuncs["posix"]
-			if !ok {
-				fmt.Fprintf(os.Stderr, "posix driver not found in registry\n")
-				os.Exit(1)
-			}
-
-			fs, err := f(drivers["posix"].(map[string]any), fsStream, &log)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Failed to initialize filesystem driver '%s': %v\n", cfg.Driver, err)
-				return err
-			}
-
-			cacher, ok := fs.(IDCacher)
-			if !ok {
-				fmt.Fprintf(os.Stderr, "The posix driver does not expose WarmupIDCache.\n")
-				os.Exit(1)
-			}
-
-			if defaultRoot {
-				fmt.Println("Starting posixfs scan...")
+			if len(errors) == 0 {
+				fmt.Println("Scan completed successfully.")
+				return nil
 			} else {
-				fmt.Printf("Starting posixfs scan at '%s'...\n", root)
+				plural := "s"
+				if len(errors) == 1 {
+					plural = ""
+				}
+				verb := "completed"
+				if haltOnError {
+					verb = "aborted"
+				}
+				return fmt.Errorf("scan %s with %d error%s", verb, len(errors), plural)
 			}
-			err = cacher.WarmupIDCache(root, true, false)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Scan failed: %v\n", err)
-				return err
-			}
-
-			fmt.Println("Scan completed successfully.")
-			return nil
 		},
 	}
-	cmd.Flags().StringP("basepath", "p", "", "the root under which to scan files, which may be a directory or a file (when omitted, detaults to using the storage root)")
-	return cmd
+	scanCmd.Flags().BoolP("halt-on-error", "E", false, "Halt at once when an error occurs when processing one of the paths (default behaviour is to keep going and attempt to process all paths).")
+	return scanCmd
 }
 
 // consistencyCmd returns a command to check the consistency of the posixfs storage.
@@ -195,7 +226,10 @@ The provided arguments determines the scope of the check:
 				args = []string{cfg.Drivers.Posix.Root}
 			}
 			log := logger("posixfs")
-			recalculateChecksums, _ := cmd.Flags().GetBool("fix-checksums")
+			recalculateChecksums, err := cmd.Flags().GetBool("fix-checksums")
+			if err != nil {
+				return err
+			}
 
 			drivers := revaconfig.StorageProviderDrivers(cfg)
 			drivers["posix"] = revaconfig.Posix(cfg, false, false)
@@ -215,7 +249,6 @@ The provided arguments determines the scope of the check:
 		},
 	}
 	consCmd.Flags().Bool("fix-checksums", false, "Recalculate and fix the file checksums. This reads every file and can be slow on large storages.")
-
 	return consCmd
 }
 
@@ -253,4 +286,83 @@ func findStorageRoot(path string) (string, error) {
 func isSpaceRoot(path string) bool {
 	spaceID, err := xattr.Get(path, prefixes.SpaceIDAttr)
 	return err == nil && len(spaceID) > 0
+}
+
+// iterates over a list of paths and processes them all, using the appropriate function
+// depending on the type of resource
+//
+// note that whenever an error occurs, it collects that error and continues processing
+// subsequent paths, and then returns a slice of errors at the end (or an empty slice
+// if no errors occured)
+func processPosixFsResources(paths []string,
+	keepGoing bool,
+	personalSpaceDir func(string) error,
+	projectSpaceDir func(string) error,
+	spaceRoot func(string) error,
+	entity func(string) error,
+) []error {
+	// no need to guard this with a mutex for now, since the implementation is not parallelized
+	errors := []error{}
+
+	for _, path := range paths {
+		rootPath, err := findStorageRoot(path)
+		if err != nil {
+			errors = append(errors, err)
+			logFailure("error: %s", err)
+			if keepGoing {
+				continue
+			} else {
+				return errors
+			}
+		}
+		path = filepath.Clean(path)
+		if _, err := os.Stat(path); err != nil {
+			errors = append(errors, err)
+			logFailure("error accessing '%s': %w", path, err)
+			if keepGoing {
+				continue
+			} else {
+				return errors
+			}
+		}
+		contained, _ := filepathx.IsSameOrContainedBy(rootPath, path)
+
+		switch {
+		case path == rootPath:
+			if err := personalSpaceDir(filepath.Join(path, "users")); err != nil {
+				errors = append(errors, err)
+				if !keepGoing {
+					return errors
+				}
+			}
+			if err := projectSpaceDir(filepath.Join(path, "projects")); err != nil {
+				errors = append(errors, err)
+				if !keepGoing {
+					return errors
+				}
+			}
+		case isSpaceRoot(path):
+			if err := spaceRoot(path); err != nil {
+				errors = append(errors, err)
+				if !keepGoing {
+					return errors
+				}
+			}
+		case contained:
+			if err := entity(path); err != nil {
+				errors = append(errors, err)
+				if !keepGoing {
+					return errors
+				}
+			}
+		default:
+			err := fmt.Errorf("error: the provided path '%s' is neither a space root nor contained by the storage root '%s'", path, rootPath)
+			errors = append(errors, err)
+			logFailure(err.Error())
+			if !keepGoing {
+				return errors
+			}
+		}
+	}
+	return errors
 }

--- a/opencloud/pkg/command/posixfs.go
+++ b/opencloud/pkg/command/posixfs.go
@@ -13,6 +13,7 @@ import (
 	"github.com/opencloud-eu/opencloud/pkg/config/configlog"
 	"github.com/opencloud-eu/opencloud/pkg/config/parser"
 	oclog "github.com/opencloud-eu/opencloud/pkg/log"
+	"github.com/opencloud-eu/opencloud/pkg/x/path/filepathx"
 	storageUsersParser "github.com/opencloud-eu/opencloud/services/storage-users/pkg/config/parser"
 	"github.com/opencloud-eu/opencloud/services/storage-users/pkg/event"
 	"github.com/opencloud-eu/opencloud/services/storage-users/pkg/revaconfig"
@@ -95,6 +96,39 @@ func scanCmd(ocCfg *config.Config) *cobra.Command {
 				os.Exit(1)
 			}
 
+			storageRoot := cfg.Drivers.Posix.Root
+			root := storageRoot
+			defaultRoot := true
+			if v, err := cmd.Flags().GetString("basepath"); err != nil {
+				fmt.Fprintf(os.Stderr, "Failed to parse command-line parameter '--basepath': %v\n", err)
+				os.Exit(1)
+			} else if v != "" {
+				root = v
+				if !filepath.IsAbs(v) {
+					if v, err = filepath.Abs(v); err != nil {
+						fmt.Fprintf(os.Stderr, "Failed to make the basepath mentioned using '--basepath' absolute: %v\n", err)
+						os.Exit(1)
+					} else {
+						root = v
+					}
+				} else {
+					root = v
+				}
+				root = filepath.Clean(root)
+				defaultRoot = false
+			}
+
+			// ensure that, if a basepath has been indicated, it is under the storage root
+			if !defaultRoot {
+				if contained, err := filepathx.IsSameOrContainedBy(storageRoot, root); err != nil {
+					fmt.Fprintf(os.Stderr, "Failed to determine whether the specified basepath %q is contained by the storage root %q: %v\n", root, storageRoot, err)
+					os.Exit(1)
+				} else if !contained {
+					fmt.Fprintf(os.Stderr, "The specified basepath %q is neither the storage root %q, nor a subdirectory thereof, nor a file underneath it\n", root, storageRoot)
+					os.Exit(1)
+				}
+			}
+
 			// We want to initialize the driver but disable scanfs on boot, so we can trigger it manually afterwards
 			drivers := revaconfig.StorageProviderDrivers(cfg)
 			drivers["posix"] = revaconfig.Posix(cfg, false, false)
@@ -111,6 +145,10 @@ func scanCmd(ocCfg *config.Config) *cobra.Command {
 				oclog.Level("error"),
 				oclog.Pretty(true),
 				oclog.Color(false)).Logger
+
+			if !defaultRoot {
+				log = log.With().Str("basepath", root).Logger()
+			}
 
 			f, ok := registry.NewFuncs["posix"]
 			if !ok {
@@ -130,8 +168,12 @@ func scanCmd(ocCfg *config.Config) *cobra.Command {
 				os.Exit(1)
 			}
 
-			fmt.Println("Starting posixfs scan...")
-			err = cacher.WarmupIDCache(cfg.Drivers.Posix.Root, true, false)
+			if defaultRoot {
+				fmt.Println("Starting posixfs scan...")
+			} else {
+				fmt.Printf("Starting posixfs scan at '%s'...\n", root)
+			}
+			err = cacher.WarmupIDCache(root, true, false)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Scan failed: %v\n", err)
 				return err
@@ -141,6 +183,7 @@ func scanCmd(ocCfg *config.Config) *cobra.Command {
 			return nil
 		},
 	}
+	cmd.Flags().StringP("basepath", "p", "", "the root under which to scan files, which may be a directory or a file (when omitted, detaults to using the storage root)")
 	return cmd
 }
 

--- a/opencloud/pkg/command/posixfs_consistency.go
+++ b/opencloud/pkg/command/posixfs_consistency.go
@@ -57,6 +57,9 @@ func (c *consistencyChecker) Check(paths []string) error {
 			fmt.Printf("Checking space '%s'...\n", path)
 			c.checkSpace(path)
 		case contained:
+			if c.ignorer.IsIgnored(path) {
+				continue
+			}
 			fmt.Printf("Checking '%s'...\n", path)
 			c.checkEntity(path)
 		default:

--- a/opencloud/pkg/command/posixfs_consistency.go
+++ b/opencloud/pkg/command/posixfs_consistency.go
@@ -1,0 +1,494 @@
+// Copyright 2026 OpenCloud GmbH <mail@opencloud.eu>
+// SPDX-License-Identifier: Apache-2.0
+
+package command
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/opencloud-eu/opencloud/pkg/x/path/filepathx"
+	storageUsersConfig "github.com/opencloud-eu/opencloud/services/storage-users/pkg/config"
+	"github.com/opencloud-eu/reva/v2/pkg/storage/fs/posix/ignore"
+	"github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/metadata/prefixes"
+	"github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/node"
+	"github.com/pkg/xattr"
+	"github.com/shamaton/msgpack/v2"
+)
+
+type consistencyChecker struct {
+	cfg                  *storageUsersConfig.Config
+	ignorer              *ignore.Ignorer
+	recalculateChecksums bool
+
+	restartRequired bool
+}
+
+// checkPosixfsConsistency checks the consistency of the posixfs storage. The
+// given path determines the scope of the check: the whole storage, a single
+// space or a single entity within a space.
+func (c *consistencyChecker) Check(paths []string) error {
+	for _, path := range paths {
+		rootPath, err := findStorageRoot(path)
+		if err != nil {
+			return err
+		}
+		path = filepath.Clean(path)
+		if _, err := os.Stat(path); err != nil {
+			return fmt.Errorf("error accessing '%s': %w", path, err)
+		}
+		contained, _ := filepathx.IsSameOrContainedBy(rootPath, path)
+
+		switch {
+		case path == rootPath:
+			fmt.Println("Checking personal spaces...")
+			c.checkSpaces(filepath.Join(path, "users"))
+
+			fmt.Println("Checking project spaces...")
+			c.checkSpaces(filepath.Join(path, "projects"))
+		case isSpaceRoot(path):
+			fmt.Printf("Checking space '%s'...\n", path)
+			c.checkSpace(path)
+		case contained:
+			fmt.Printf("Checking '%s'...\n", path)
+			c.checkEntity(path)
+		default:
+			return fmt.Errorf("the provided path '%s' is neither a space root nor contained by the storage root '%s'", path, rootPath)
+		}
+	}
+
+	if c.restartRequired {
+		fmt.Println("\n\n  ⚠️  Please restart your openCloud instance to apply changes.")
+	}
+	return nil
+}
+
+func (c *consistencyChecker) checkSpaces(basePath string) {
+	dirEntries, err := os.ReadDir(basePath)
+	if err != nil {
+		logFailure("Error reading spaces directory '%s': %v", basePath, err)
+		return
+	}
+
+	for _, entry := range dirEntries {
+		if entry.IsDir() {
+			fullPath := filepath.Join(basePath, entry.Name())
+			c.checkSpace(fullPath)
+		}
+	}
+}
+
+func (c *consistencyChecker) checkSpace(spacePath string) {
+	info, err := os.Stat(spacePath)
+	if err != nil {
+		logFailure("Error accessing path '%s': %v", spacePath, err)
+		return
+	}
+	if !info.IsDir() {
+		logFailure("Error: The provided path '%s' is not a directory\n", spacePath)
+		return
+	}
+
+	spaceID, err := xattr.Get(spacePath, prefixes.SpaceIDAttr)
+	if err != nil || len(spaceID) == 0 {
+		logFailure("Error: The directory '%s' does not seem to be a space root, it's missing the '%s' attribute\n", spacePath, prefixes.SpaceIDAttr)
+		return
+	}
+
+	c.checkSpaceID(spacePath)
+	c.checkNodes(spacePath)
+}
+
+func (c *consistencyChecker) checkSpaceID(spacePath string) {
+	entries, uniqueIDs, oldestEntry, err := c.gatherAttributes(spacePath)
+	if err != nil {
+		logFailure("Failed to gather attributes: %v", err)
+		return
+	}
+
+	if len(entries) == 0 {
+		return
+	}
+
+	if len(uniqueIDs) > 1 {
+		fmt.Println("\n  ⚠ Multiple space IDs found:")
+		for id := range uniqueIDs {
+			fmt.Printf("    - %s\n", id)
+		}
+
+		fmt.Printf("\n  ⏳ Oldest entry is '%s' (modified on %s).\n",
+			filepath.Base(oldestEntry.Path), oldestEntry.ModTime.Format(time.RFC1123))
+
+		targetID := oldestEntry.ParentID
+		fmt.Printf("  ✅ Proposed target Parent ID: %s\n", targetID)
+
+		fmt.Printf("\n  Do you want to unify all parent IDs to '%s'? This will modify %d entries, the directory, and the user index. (y/N): ", targetID, len(entries))
+
+		reader := bufio.NewReader(os.Stdin)
+		input, _ := reader.ReadString('\n')
+		input = strings.TrimSpace(strings.ToLower(input))
+
+		if input != "y" {
+			logFailure("Operation cancelled by user.")
+			return
+		}
+		c.restartRequired = true
+
+		obsoleteIDs := []string{}
+		for id := range uniqueIDs {
+			if id != targetID {
+				obsoleteIDs = append(obsoleteIDs, id)
+			}
+		}
+		c.fixSpaceID(spacePath, obsoleteIDs, targetID, entries)
+	}
+}
+
+func (c *consistencyChecker) walkNodes(dir string, parentID string) int {
+	fixes := 0
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		logFailure("Error reading directory '%s': %v", dir, err)
+		return 0
+	}
+
+	for _, entry := range entries {
+		fullPath := filepath.Join(dir, entry.Name())
+
+		if c.ignorer.IsIgnored(fullPath) {
+			continue
+		}
+
+		fixes += c.checkNodeAttributes(fullPath, entry.Name(), parentID, entry.IsDir())
+
+		if entry.IsDir() {
+			nodeID, err := xattr.Get(fullPath, prefixes.IDAttr)
+			if err != nil || len(nodeID) == 0 {
+				logFailure("Directory '%s' missing '%s', skipping its children", fullPath, prefixes.IDAttr)
+				continue
+			}
+			fixes += c.walkNodes(fullPath, string(nodeID))
+		}
+	}
+	return fixes
+}
+
+// checkNodeAttributes checks and fixes the parent ID and name attributes of a
+// single node. For files it additionally checks the blobsize and, when
+// requested, the checksums. It returns the number of fixes applied.
+func (c *consistencyChecker) checkNodeAttributes(path, name, parentID string, isDir bool) int {
+	fixes := 0
+
+	// Check if the parent ID attribute matches the expected parent ID, if not, fix it.
+	actualParentID, err := xattr.Get(path, prefixes.ParentidAttr)
+	if err != nil || string(actualParentID) != parentID {
+		if err := xattr.Set(path, prefixes.ParentidAttr, []byte(parentID)); err != nil {
+			logFailure("Failed to fix parent ID for '%s': %v", path, err)
+		} else {
+			fmt.Printf("  + Fixed parent ID for '%s'\n", path)
+			fixes++
+			c.restartRequired = true
+		}
+	}
+
+	// Check that the name attribute matches the actual name of the file/directory, if not, fix it.
+	nameAttr, err := xattr.Get(path, prefixes.NameAttr)
+	if err != nil || string(nameAttr) != name {
+		if err := xattr.Set(path, prefixes.NameAttr, []byte(name)); err != nil {
+			logFailure("Failed to fix name attribute for '%s': %v", path, err)
+		} else {
+			fmt.Printf("  + Fixed name attribute for '%s'\n", path)
+			fixes++
+			c.restartRequired = true
+		}
+	}
+
+	if !isDir {
+		fixes += c.checkBlobsize(path)
+		if c.recalculateChecksums {
+			fixes += c.fixChecksums(path)
+		}
+	}
+
+	return fixes
+}
+
+// checkEntity checks a single file or directory within a space, including its own
+// parent ID, name and (for files) blobsize/checksums. If the entity is a directory
+// its children are checked recursively.
+func (c *consistencyChecker) checkEntity(path string) {
+	info, err := os.Stat(path)
+	if err != nil {
+		logFailure("Error accessing path '%s': %v", path, err)
+		return
+	}
+
+	// The expected parent ID is the ID attribute of the containing directory.
+	parentDir := filepath.Dir(path)
+	parentID, err := xattr.Get(parentDir, prefixes.IDAttr)
+	if err != nil || len(parentID) == 0 {
+		logFailure("Parent directory '%s' is missing the '%s' attribute", parentDir, prefixes.IDAttr)
+		return
+	}
+
+	fixes := c.checkNodeAttributes(path, info.Name(), string(parentID), info.IsDir())
+
+	if info.IsDir() {
+		nodeID, err := xattr.Get(path, prefixes.IDAttr)
+		if err != nil || len(nodeID) == 0 {
+			logFailure("Directory '%s' missing '%s' attribute", path, prefixes.IDAttr)
+		} else {
+			fixes += c.walkNodes(path, string(nodeID))
+		}
+	}
+
+	if fixes > 0 {
+		fmt.Printf("  ✓ Fixed %d incorrect node attributes for %s\n", fixes, filepath.Base(path))
+	}
+}
+
+// checkBlobsize verifies that the stored blobsize attribute matches the actual
+// file size and fixes it if it doesn't. It returns the number of fixes applied.
+func (c *consistencyChecker) checkBlobsize(path string) int {
+	info, err := os.Stat(path)
+	if err != nil {
+		logFailure("Error accessing file '%s': %v", path, err)
+		return 0
+	}
+
+	expectedSize := strconv.FormatInt(info.Size(), 10)
+	blobsize, err := xattr.Get(path, prefixes.BlobsizeAttr)
+	if err == nil && string(blobsize) == expectedSize {
+		return 0
+	}
+
+	if err := xattr.Set(path, prefixes.BlobsizeAttr, []byte(expectedSize)); err != nil {
+		logFailure("Failed to fix blobsize for '%s': %v", path, err)
+		return 0
+	}
+
+	fmt.Printf("  + Fixed blobsize for '%s'\n", path)
+	c.restartRequired = true
+	return 1
+}
+
+// fixChecksums recalculates the sha1, md5 and adler32 checksums of the file and
+// updates the stored attributes if they differ. It returns the number of fixes applied.
+func (c *consistencyChecker) fixChecksums(path string) int {
+	sha1h, md5h, adler32h, err := node.CalculateChecksums(context.Background(), path)
+	if err != nil {
+		logFailure("Failed to calculate checksums for '%s': %v", path, err)
+		return 0
+	}
+
+	checksums := map[string][]byte{
+		prefixes.ChecksumPrefix + "sha1":    sha1h.Sum(nil),
+		prefixes.ChecksumPrefix + "md5":     md5h.Sum(nil),
+		prefixes.ChecksumPrefix + "adler32": adler32h.Sum(nil),
+	}
+
+	fixes := 0
+	for attrName, sum := range checksums {
+		current, err := xattr.Get(path, attrName)
+		if err == nil && bytes.Equal(current, sum) {
+			continue
+		}
+		if err := xattr.Set(path, attrName, sum); err != nil {
+			logFailure("Failed to fix checksum '%s' for '%s': %v", attrName, path, err)
+			continue
+		}
+		fmt.Printf("  + Fixed checksum '%s' for '%s'\n", attrName, path)
+		c.restartRequired = true
+		fixes++
+	}
+	return fixes
+}
+
+func (c *consistencyChecker) checkNodes(spacePath string) {
+	rootID, err := xattr.Get(spacePath, prefixes.IDAttr)
+	if err != nil || len(rootID) == 0 {
+		logFailure("Space root '%s' missing '%s' attribute", spacePath, prefixes.IDAttr)
+		return
+	}
+
+	fixes := c.walkNodes(spacePath, string(rootID))
+
+	if fixes > 0 {
+		fmt.Printf("  ✓ Fixed %d incorrect node attributes in %s\n", fixes, filepath.Base(spacePath))
+	}
+}
+
+// fixSpaceID updates the parentid attributes of all entries in a space to a new target ID,
+// updates the space's own ID attributes, and removes obsolete IDs from the user index file.
+func (c *consistencyChecker) fixSpaceID(spacePath string, obsoleteIDs []string, targetID string, entries []EntryInfo) {
+	// Set all parentid attributes to the proper space ID
+	err := setAllParentIDAttributes(entries, targetID)
+	if err != nil {
+		logFailure("an error occurred during file attribute update: %v", err)
+		return
+	}
+
+	// Update space ID itself
+	fmt.Printf("  Updating directory '%s' with attribute '%s' -> %s\n", filepath.Base(spacePath), prefixes.IDAttr, targetID)
+	err = xattr.Set(spacePath, prefixes.IDAttr, []byte(targetID))
+	if err != nil {
+		logFailure("Failed to set attribute on directory '%s': %v", spacePath, err)
+		return
+	}
+	err = xattr.Set(spacePath, prefixes.SpaceIDAttr, []byte(targetID))
+	if err != nil {
+		logFailure("Failed to set attribute on directory '%s': %v", spacePath, err)
+		return
+	}
+
+	// update the index
+	err = c.updateOwnerIndexFile(spacePath, obsoleteIDs)
+	if err != nil {
+		logFailure("Could not update the owner index file: %v", err)
+	}
+}
+
+func (c *consistencyChecker) gatherAttributes(path string) ([]EntryInfo, map[string]struct{}, EntryInfo, error) {
+	dirEntries, err := os.ReadDir(path)
+	if err != nil {
+		return nil, nil, EntryInfo{}, fmt.Errorf("failed to read directory: %w", err)
+	}
+
+	var allEntries []EntryInfo
+	uniqueIDs := make(map[string]struct{})
+	var oldestEntry EntryInfo
+	oldestTime := time.Now().Add(100 * 365 * 24 * time.Hour) // Set to a future date to find the oldest entry
+
+	for _, entry := range dirEntries {
+		fullPath := filepath.Join(path, entry.Name())
+		if c.ignorer.IsIgnored(fullPath) {
+			continue
+		}
+		info, err := os.Stat(fullPath)
+		if err != nil {
+			fmt.Printf("  - Warning: could not stat %s: %v\n", entry.Name(), err)
+			continue
+		}
+
+		parentID, err := xattr.Get(fullPath, prefixes.ParentidAttr)
+		if err != nil {
+			continue // Skip if attribute doesn't exist or can't be read
+		}
+
+		entryInfo := EntryInfo{
+			Path:     fullPath,
+			ModTime:  info.ModTime(),
+			ParentID: string(parentID),
+		}
+
+		allEntries = append(allEntries, entryInfo)
+		uniqueIDs[string(parentID)] = struct{}{}
+
+		if entryInfo.ModTime.Before(oldestTime) {
+			oldestTime = entryInfo.ModTime
+			oldestEntry = entryInfo
+		}
+	}
+
+	return allEntries, uniqueIDs, oldestEntry, nil
+}
+
+func setAllParentIDAttributes(entries []EntryInfo, targetID string) error {
+	fmt.Printf("  Setting all parent IDs to '%s':\n", targetID)
+
+	for _, entry := range entries {
+		if entry.ParentID == targetID {
+			fmt.Printf("    - Skipping '%s' (already has target ID).\n", filepath.Base(entry.Path))
+			continue
+		}
+
+		fmt.Printf("    - Removing all attributes from '%s'. It will be re-assimilated\n", filepath.Base(entry.Path))
+		filepath.WalkDir(entry.Path, func(path string, d os.DirEntry, err error) error {
+			if err != nil {
+				return fmt.Errorf("error walking path '%s': %w", path, err)
+			}
+
+			// Remove all attributes from the file.
+			if err := removeAttributes(path); err != nil {
+				fmt.Printf("failed to remove attributes from '%s': %v", path, err)
+			}
+			return nil
+		})
+	}
+	return nil
+}
+
+// updateOwnerIndexFile handles the logic of reading, modifying, and writing the MessagePack index file.
+func (c *consistencyChecker) updateOwnerIndexFile(basePath string, obsoleteIDs []string) error {
+	fmt.Printf("  Rewriting index file '%s'\n", basePath)
+
+	ownerID, err := xattr.Get(basePath, prefixes.OwnerIDAttr)
+	if err != nil {
+		return fmt.Errorf("could not get owner ID from oldest entry '%s' to find index: %w", basePath, err)
+	}
+
+	indexPath := filepath.Join(c.cfg.Drivers.Posix.Root, "indexes", "by-user-id", string(ownerID)+".mpk")
+	indexPath = filepath.Clean(indexPath)
+
+	// Read the MessagePack file
+	fileData, err := os.ReadFile(indexPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("index file does not exist, skipping update")
+		}
+		return fmt.Errorf("could not read index file: %w", err)
+	}
+	var indexMap map[string]string
+	if err := msgpack.Unmarshal(fileData, &indexMap); err != nil {
+		return fmt.Errorf("failed to parse MessagePack index file (is it corrupt?): %w", err)
+	}
+
+	// Remove obsolete IDs from the map
+	itemsRemoved := 0
+	for _, id := range obsoleteIDs {
+		if _, exists := indexMap[id]; exists {
+			fmt.Printf("    - Removing obsolete ID '%s' from index.\n", id)
+			delete(indexMap, id)
+			itemsRemoved++
+		} else {
+			fmt.Printf("    - Obsolete ID '%s' not found in index\n", id)
+		}
+	}
+
+	if itemsRemoved == 0 {
+		return nil
+	}
+
+	// Write the data back to the file
+	updatedData, err := msgpack.Marshal(&indexMap)
+	if err != nil {
+		return fmt.Errorf("failed to marshal updated index map: %w", err)
+	}
+	if err := os.WriteFile(indexPath, updatedData, 0644); err != nil {
+		return fmt.Errorf("failed to write updated index file: %w", err)
+	}
+
+	fmt.Printf("  ✓ Successfully removed %d item(s) and saved index file.\n", itemsRemoved)
+	return nil
+}
+
+func removeAttributes(path string) error {
+	attrNames, err := xattr.List(path)
+	if err != nil {
+		return fmt.Errorf("failed to list attributes for '%s': %w", path, err)
+	}
+
+	for _, attrName := range attrNames {
+		if err := xattr.Remove(path, attrName); err != nil {
+			return fmt.Errorf("failed to remove attribute '%s' from '%s': %w", attrName, path, err)
+		}
+	}
+	return nil
+}

--- a/opencloud/pkg/command/posixfs_consistency.go
+++ b/opencloud/pkg/command/posixfs_consistency.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/opencloud-eu/opencloud/pkg/x/path/filepathx"
 	storageUsersConfig "github.com/opencloud-eu/opencloud/services/storage-users/pkg/config"
 	"github.com/opencloud-eu/reva/v2/pkg/storage/fs/posix/ignore"
 	"github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/metadata/prefixes"
@@ -35,38 +34,31 @@ type consistencyChecker struct {
 // given path determines the scope of the check: the whole storage, a single
 // space or a single entity within a space.
 func (c *consistencyChecker) Check(paths []string) error {
-	for _, path := range paths {
-		rootPath, err := findStorageRoot(path)
-		if err != nil {
-			return err
-		}
-		path = filepath.Clean(path)
-		if _, err := os.Stat(path); err != nil {
-			return fmt.Errorf("error accessing '%s': %w", path, err)
-		}
-		contained, _ := filepathx.IsSameOrContainedBy(rootPath, path)
-
-		switch {
-		case path == rootPath:
+	_ = processPosixFsResources(paths, true,
+		func(path string) error {
 			fmt.Println("Checking personal spaces...")
-			c.checkSpaces(filepath.Join(path, "users"))
-
+			c.checkSpaces(path)
+			return nil
+		},
+		func(path string) error {
 			fmt.Println("Checking project spaces...")
-			c.checkSpaces(filepath.Join(path, "projects"))
-		case isSpaceRoot(path):
+			c.checkSpaces(path)
+			return nil
+		},
+		func(path string) error {
 			fmt.Printf("Checking space '%s'...\n", path)
 			c.checkSpace(path)
-		case contained:
+			return nil
+		},
+		func(path string) error {
 			if c.ignorer.IsIgnored(path) {
-				continue
+				return nil
 			}
 			fmt.Printf("Checking '%s'...\n", path)
 			c.checkEntity(path)
-		default:
-			return fmt.Errorf("the provided path '%s' is neither a space root nor contained by the storage root '%s'", path, rootPath)
-		}
-	}
-
+			return nil
+		},
+	)
 	if c.restartRequired {
 		fmt.Println("\n\n  ⚠️  Please restart your openCloud instance to apply changes.")
 	}

--- a/opencloud/pkg/command/root.go
+++ b/opencloud/pkg/command/root.go
@@ -6,11 +6,13 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/rs/zerolog"
+	"github.com/spf13/cobra"
+
 	"github.com/opencloud-eu/opencloud/opencloud/pkg/register"
 	"github.com/opencloud-eu/opencloud/pkg/clihelper"
 	"github.com/opencloud-eu/opencloud/pkg/config"
-
-	"github.com/spf13/cobra"
+	oclog "github.com/opencloud-eu/opencloud/pkg/log"
 )
 
 // Execute is the entry point for the opencloud command.
@@ -37,4 +39,12 @@ func Execute() error {
 	app.SetArgs(os.Args[1:])
 	ctx, _ := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGHUP)
 	return app.ExecuteContext(ctx)
+}
+
+func logger(name string) zerolog.Logger {
+	return oclog.NewLogger(
+		oclog.Name(name),
+		oclog.Level("info"),
+		oclog.Pretty(true),
+		oclog.Color(true)).Logger
 }

--- a/opencloud/pkg/command/shares.go
+++ b/opencloud/pkg/command/shares.go
@@ -9,7 +9,6 @@ import (
 	"github.com/opencloud-eu/opencloud/pkg/config"
 	"github.com/opencloud-eu/opencloud/pkg/config/configlog"
 	"github.com/opencloud-eu/opencloud/pkg/config/parser"
-	oclog "github.com/opencloud-eu/opencloud/pkg/log"
 	mregistry "github.com/opencloud-eu/opencloud/pkg/registry"
 	sharing "github.com/opencloud-eu/opencloud/services/sharing/pkg/config"
 	sharingparser "github.com/opencloud-eu/opencloud/services/sharing/pkg/config/parser"
@@ -85,7 +84,7 @@ func cleanup(_ *cobra.Command, cfg *config.Config) error {
 		return configlog.ReturnError(errors.New("cleanup is only implemented for the jsoncs3 share manager"))
 	}
 
-	l := logger()
+	l := logger("migrate")
 
 	zerolog.SetGlobalLevel(zerolog.InfoLevel)
 
@@ -94,7 +93,7 @@ func cleanup(_ *cobra.Command, cfg *config.Config) error {
 	if !ok {
 		return configlog.ReturnError(errors.New("Unknown share manager type '" + driver + "'"))
 	}
-	mgr, err := f(rcfg[driver].(map[string]any), l)
+	mgr, err := f(rcfg[driver].(map[string]any), &l)
 	if err != nil {
 		return configlog.ReturnError(err)
 	}
@@ -166,13 +165,4 @@ func revaShareConfig(cfg *sharing.Config) map[string]any {
 			"machine_auth_apikey": cfg.UserSharingDrivers.JSONCS3.SystemUserAPIKey,
 		},
 	}
-}
-
-func logger() *zerolog.Logger {
-	log := oclog.NewLogger(
-		oclog.Name("migrate"),
-		oclog.Level("info"),
-		oclog.Pretty(true),
-		oclog.Color(true)).Logger
-	return &log
 }

--- a/pkg/x/path/filepathx/path.go
+++ b/pkg/x/path/filepathx/path.go
@@ -1,7 +1,9 @@
 package filepathx
 
 import (
+	"fmt"
 	"path/filepath"
+	"strings"
 )
 
 // JailJoin joins any number of path elements into a single path,
@@ -9,4 +11,28 @@ import (
 // and ensuring that the path is always under the jail.
 func JailJoin(jail string, elem ...string) string {
 	return filepath.Join(jail, filepath.Join(append([]string{"/"}, elem...)...))
+}
+
+// Determines whether the file or directory 'child' is same as or underneath the directory 'parent'.
+//
+// Note that 'parent' is expected to be a directory.
+func IsSameOrContainedBy(parent string, child string) (bool, error) {
+	absParent, err := filepath.Abs(parent)
+	if err != nil {
+		return false, fmt.Errorf("failed to make parent directory absolute: %q: %w", parent, err)
+	}
+
+	absChild, err := filepath.Abs(child)
+	if err != nil {
+		return false, fmt.Errorf("failed to make child file/directory absolute: %q: %w", child, err)
+	}
+
+	rel, err := filepath.Rel(absParent, absChild)
+	if err != nil {
+		return false, fmt.Errorf("failed to determine the relative path between the parent directory %q and the child file/directory: %q: %w", absParent, absChild, err)
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return false, nil
+	}
+	return true, nil
 }

--- a/pkg/x/path/filepathx/path_test.go
+++ b/pkg/x/path/filepathx/path_test.go
@@ -1,9 +1,12 @@
 package filepathx_test
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/opencloud-eu/opencloud/pkg/x/path/filepathx"
+	"github.com/stretchr/testify/require"
 )
 
 func TestJailJoin(t *testing.T) {
@@ -58,6 +61,26 @@ func TestJailJoin(t *testing.T) {
 			if got := filepathx.JailJoin(tt.args.jail, tt.args.elem...); got != tt.want {
 				t.Errorf("JailJoin() = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+func TestIsSameOrContainedBy(t *testing.T) {
+	for _, tt := range []struct {
+		parent   string
+		child    string
+		expected bool
+	}{
+		{"foo", "foo", true},
+		{"/foo", "/foo", true},
+		{"foo", "foo/bar", true},
+		{"foo", "bar", false},
+	} {
+		t.Run(fmt.Sprintf("%s: %s vs %s", t.Name(), strings.ReplaceAll(tt.parent, "/", "."), strings.ReplaceAll(tt.child, "/", ".")), func(t *testing.T) {
+			require := require.New(t)
+			b, err := filepathx.IsSameOrContainedBy(tt.parent, tt.child)
+			require.NoError(err)
+			require.Equal(tt.expected, b)
 		})
 	}
 }


### PR DESCRIPTION
This backports #3191, #3235, #3220 and #3233 to the stable-7.2 branch

It include fixes and small improvements for the `opencloud posixfs scan` and `opencloud posixfs consistency` command.