### PR TITLE
[full-ci] chore: bump web to v7.1.5

### DIFF
--- a/.woodpecker.env
+++ b/.woodpecker.env
@@ -1,4 +1,4 @@
 # The test runner source for UI tests
-WEB_COMMITID=2cf68437639154cff66f8d6920470ee25a80f6b3
+WEB_COMMITID=170677dc06b1dfab57bc4bea2dac8a5cd78b2784
 WEB_BRANCH=stable-7.1
 

--- a/services/web/Makefile
+++ b/services/web/Makefile
@@ -1,6 +1,6 @@
 SHELL := bash
 NAME := web
-WEB_ASSETS_VERSION = v7.1.4
+WEB_ASSETS_VERSION = v7.1.5
 WEB_ASSETS_BRANCH = stable-7.1
 
 ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI


### PR DESCRIPTION
Bump web to v7.1.5

### 🐛 Bug Fixes

- fix(text-editor): update editor content when loaded via recovery [[#3081](https://github.com/opencloud-eu/web/pull/3081)]
- [stable-7.1] fix: encode hash character in app route URLs to prevent truncation (#3075) [[#3080](https://github.com/opencloud-eu/web/pull/3080)]

### ✅ Tests

- split keycloak test [[#2897](https://github.com/opencloud-eu/web/pull/2897)]