### PR TITLE
[stable-7.2] fix(postprocessing): retry publishing events

### DIFF
--- a/changelog/unreleased/fix-postprocessing-fatal-on-publish-error.md
+++ b/changelog/unreleased/fix-postprocessing-fatal-on-publish-error.md
@@ -1,0 +1,21 @@
+Bugfix: Retry publishing postprocessing events before giving up
+
+A single transient failure while publishing an event to the event system took
+the whole server down. The postprocessing service treated every publish error
+as fatal and called log.Fatal, which exits the process and so also stopped all
+the other services running in the same binary. A burst of uploads was enough to
+run into one nats publish timeout and lose the server with it.
+
+Publishing is now retried using the same exponential backoff that is already
+used for failed postprocessing steps. Between the attempts the source event is
+marked as in progress and the backoff is capped at half the ack wait, so the
+event should not be redelivered to another worker while we are still retrying.
+The number of retries is configurable via POSTPROCESSING_PUBLISH_MAX_RETRIES.
+
+Should all attempts fail, the source event is no longer acknowledged. Before,
+the event was acknowledged even though its successor was never published, so
+the upload was left half processed in the store and did not recover on restart.
+
+https://github.com/opencloud-eu/opencloud/issues/3271
+https://github.com/opencloud-eu/opencloud/issues/2232
+https://github.com/opencloud-eu/opencloud/issues/2422

--- a/services/postprocessing/README.md
+++ b/services/postprocessing/README.md
@@ -69,6 +69,8 @@ Once the service defined as custom step has finished its work, it should send an
 
 The backoff behavior as mentioned in the `retry` outcome can be configured using the `POSTPROCESSING_RETRY_BACKOFF_DURATION` and `POSTPROCESSING_MAX_RETRIES` environment variables. The backoff duration is calculated using the following formula after each failure: `backoff_duration = POSTPROCESSING_RETRY_BACKOFF_DURATION * 2^(number of failures - 1)`. This means that the time between the next round grows exponentially limited by the number of retries. Steps that still don't succeed after the maximum number of retries will be automatically moved to the `abort` state.
 
+The same backoff formula is used when publishing an event to the event system fails, which can happen when the event system is briefly unavailable or slow to acknowledge. The number of publish retries is configured with the `POSTPROCESSING_PUBLISH_MAX_RETRIES` environment variable, setting it to `0` disables retrying. A single wait is never longer than half the configured ack wait, so that the event being processed is not redelivered to another worker while the publish is still being retried. If publishing still fails after the last retry, the incoming event is not acknowledged so that it gets redelivered and postprocessing can pick up where it left off.
+
 See the [cs3 org](https://github.com/cs3org/reva/blob/edge/pkg/events/postprocessing.go) for up-to-date information of reserved step names and event definitions.
 
 ## CLI Commands

--- a/services/postprocessing/pkg/config/config.go
+++ b/services/postprocessing/pkg/config/config.go
@@ -32,6 +32,7 @@ type Postprocessing struct {
 
 	RetryBackoffDuration time.Duration `yaml:"retry_backoff_duration" env:"POSTPROCESSING_RETRY_BACKOFF_DURATION" desc:"The base for the exponential backoff duration before retrying a failed postprocessing step. See the Environment Variable Types description for more details." introductionVersion:"1.0.0"`
 	MaxRetries           int           `yaml:"max_retries" env:"POSTPROCESSING_MAX_RETRIES" desc:"The maximum number of retries for a failed postprocessing step." introductionVersion:"1.0.0"`
+	PublishMaxRetries    int           `yaml:"publish_max_retries" env:"POSTPROCESSING_PUBLISH_MAX_RETRIES" desc:"The maximum number of retries when publishing an event to the event system fails. The same exponential backoff as for failed postprocessing steps is used, based on POSTPROCESSING_RETRY_BACKOFF_DURATION. Set to 0 to not retry at all." introductionVersion:"%NEXT%"`
 }
 
 // Events combines the configuration options for the event bus.

--- a/services/postprocessing/pkg/config/defaults/defaultconfig.go
+++ b/services/postprocessing/pkg/config/defaults/defaultconfig.go
@@ -36,6 +36,7 @@ func DefaultConfig() *config.Config {
 			Workers:              3,
 			RetryBackoffDuration: 5 * time.Second,
 			MaxRetries:           14,
+			PublishMaxRetries:    5,
 		},
 		Store: config.Store{
 			Store:    "nats-js-kv",

--- a/services/postprocessing/pkg/postprocessing/postprocessing.go
+++ b/services/postprocessing/pkg/postprocessing/postprocessing.go
@@ -86,7 +86,17 @@ func (pp *Postprocessing) Delay(f func(next any)) {
 
 // BackoffDuration calculates the duration for exponential backoff based on the number of failures.
 func (pp *Postprocessing) BackoffDuration() time.Duration {
-	return pp.config.RetryBackoffDuration * time.Duration(math.Pow(2, float64(pp.Failures-1)))
+	return BackoffDuration(pp.config.RetryBackoffDuration, pp.Failures)
+}
+
+// BackoffDuration calculates an exponential backoff duration from a base duration and the
+// number of failures that happened so far. The first failure waits the base duration, every
+// subsequent one waits twice as long as the previous one.
+func BackoffDuration(base time.Duration, failures int) time.Duration {
+	if failures < 1 {
+		return 0
+	}
+	return base * time.Duration(math.Pow(2, float64(failures-1)))
 }
 
 func (pp *Postprocessing) next(current events.Postprocessingstep) any {

--- a/services/postprocessing/pkg/service/service.go
+++ b/services/postprocessing/pkg/service/service.go
@@ -293,12 +293,64 @@ func (pps *PostprocessingService) processEvent(e raw.Event) error {
 	}
 
 	if next != nil {
-		if err := events.Publish(ctx, pps.pub, next); err != nil {
+		if err := pps.publishWithRetry(ctx, &e, next); err != nil {
+			// The successor event never made it onto the bus. Don't ack the source event so
+			// jetstream redelivers it and the upload can continue instead of being stuck in
+			// the store forever.
+			ackEvent = false
 			pps.log.Error().Err(err).Msg("unable to publish event")
+
+			if pps.stopped.Load() || ctx.Err() != nil {
+				// we are shutting down anyway, no need to take the whole process down with us
+				return fmt.Errorf("%w: unable to publish event", ErrEvent)
+			}
 			return fmt.Errorf("%w: unable to publish event", ErrFatal) // we can't publish -> we are screwed
 		}
 	}
 	return nil
+}
+
+// publishWithRetry publishes an event, retrying transient failures of the event system with
+// the same exponential backoff that is used for failed postprocessing steps. Between the
+// attempts the source event is marked as in progress and the wait is capped to half the ack
+// wait, so jetstream should not hand the source event to a second worker while we are still
+// retrying. Note that marking the event as in progress is best effort: it is a fire and forget
+// publish, so it can be lost exactly when the event system is unhealthy. A redelivery during a
+// retry is therefore possible, it is just unlikely. If all attempts fail, the last error is
+// returned.
+func (pps *PostprocessingService) publishWithRetry(ctx context.Context, e *raw.Event, ev any) error {
+	for attempt := 0; ; attempt++ {
+		err := events.Publish(ctx, pps.pub, ev)
+		if err == nil {
+			return nil
+		}
+
+		if attempt >= pps.c.PublishMaxRetries {
+			return err
+		}
+
+		backoff := postprocessing.BackoffDuration(pps.c.RetryBackoffDuration, attempt+1)
+		// Never wait longer than half the ack wait. We only refresh the redelivery timer
+		// between the attempts, so a longer wait would let jetstream hand the source event
+		// to a second worker while we are still retrying here.
+		if maxBackoff := pps.c.Events.AckWait / 2; maxBackoff > 0 && backoff > maxBackoff {
+			backoff = maxBackoff
+		}
+		pps.log.Warn().Err(err).Int("attempt", attempt+1).Dur("backoff", backoff).Msg("unable to publish event, retrying")
+
+		// tell jetstream that we are still working on the source event
+		if ipErr := e.InProgress(); ipErr != nil {
+			pps.log.Debug().Err(ipErr).Msg("unable to mark event as in progress")
+		}
+
+		select {
+		case <-ctx.Done():
+			return err
+		case <-pps.stopCh:
+			return err
+		case <-time.After(backoff):
+		}
+	}
 }
 
 func (pps *PostprocessingService) getPP(sto store.Store, uploadID string) (*postprocessing.Postprocessing, error) {

--- a/services/postprocessing/pkg/service/service_suite_test.go
+++ b/services/postprocessing/pkg/service/service_suite_test.go
@@ -1,0 +1,13 @@
+package service
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestPostprocessing(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Service Suite")
+}

--- a/services/postprocessing/pkg/service/service_test.go
+++ b/services/postprocessing/pkg/service/service_test.go
@@ -1,0 +1,200 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/opencloud-eu/opencloud/pkg/log"
+	"github.com/opencloud-eu/opencloud/services/postprocessing/pkg/config"
+	"github.com/opencloud-eu/opencloud/services/postprocessing/pkg/metrics"
+	"github.com/opencloud-eu/reva/v2/pkg/events"
+	"github.com/opencloud-eu/reva/v2/pkg/events/raw"
+	"github.com/opencloud-eu/reva/v2/pkg/store"
+	microevents "go-micro.dev/v4/events"
+	"go.opentelemetry.io/otel/trace/noop"
+)
+
+// errPublish is the error a nats publish returns when the ack of the message was not
+// received in time. It is transient: the very next publish usually succeeds.
+var errPublish = errors.New("nats: timeout")
+
+// testPublisher is a publisher that fails the first `failures` publish attempts and
+// records everything it accepted afterwards.
+type testPublisher struct {
+	mu       sync.Mutex
+	failures int
+	attempts int
+	accepted []any
+}
+
+func (p *testPublisher) Publish(_ string, ev any, _ ...microevents.PublishOption) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.attempts++
+	if p.attempts <= p.failures {
+		return errPublish
+	}
+	p.accepted = append(p.accepted, ev)
+	return nil
+}
+
+func (p *testPublisher) stats() (attempts int, accepted []any) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.attempts, p.accepted
+}
+
+var _ = Describe("PostprocessingService", func() {
+	var (
+		cfg config.Postprocessing
+		pub *testPublisher
+		pps *PostprocessingService
+	)
+
+	// newService builds a service that is wired to the fake publisher only. It deliberately
+	// does not go through NewPostprocessingService, which would need a running nats.
+	newService := func() *PostprocessingService {
+		return &PostprocessingService{
+			ctx:     context.Background(),
+			log:     log.NopLogger(),
+			pub:     pub,
+			steps:   getSteps(cfg),
+			store:   store.Create(),
+			c:       cfg,
+			tp:      noop.NewTracerProvider(),
+			metrics: metrics.New(),
+			stopCh:  make(chan struct{}, 1),
+		}
+	}
+
+	// bytesReceived is the event that starts a postprocessing chain. Handling it makes the
+	// service publish the first StartPostprocessingStep, which is the publish that used to
+	// take the whole process down when nats hiccuped.
+	bytesReceived := func() raw.Event {
+		ev := events.BytesReceived{
+			UploadID: "upload-" + uuid.New().String(),
+			Filename: "test.txt",
+			Filesize: 1234,
+		}
+		return raw.Event{
+			Event: events.Event{
+				ID:    uuid.New().String(),
+				Type:  reflect.TypeOf(ev).String(),
+				Event: ev,
+			},
+		}
+	}
+
+	BeforeEach(func() {
+		cfg = config.Postprocessing{
+			Steps:                []string{"virusscan"},
+			RetryBackoffDuration: 5 * time.Millisecond,
+			MaxRetries:           14,
+			PublishMaxRetries:    3,
+		}
+		pub = &testPublisher{}
+	})
+
+	Describe("publishing the next event", func() {
+		It("publishes once when the event system is healthy", func() {
+			pps = newService()
+
+			Expect(pps.processEvent(bytesReceived())).To(Succeed())
+
+			attempts, accepted := pub.stats()
+			Expect(attempts).To(Equal(1))
+			Expect(accepted).To(HaveLen(1))
+			Expect(accepted[0]).To(BeAssignableToTypeOf(events.StartPostprocessingStep{}))
+			Expect(accepted[0].(events.StartPostprocessingStep).StepToStart).To(Equal(events.PPStepAntivirus))
+		})
+
+		It("retries a transient publish failure and succeeds on a later attempt", func() {
+			pub.failures = 2
+			pps = newService()
+
+			Expect(pps.processEvent(bytesReceived())).To(Succeed())
+
+			attempts, accepted := pub.stats()
+			Expect(attempts).To(Equal(3))
+			Expect(accepted).To(HaveLen(1))
+			Expect(accepted[0]).To(BeAssignableToTypeOf(events.StartPostprocessingStep{}))
+		})
+
+		It("uses an exponential backoff between the attempts", func() {
+			pub.failures = 3
+			pps = newService()
+
+			start := time.Now()
+			Expect(pps.processEvent(bytesReceived())).To(Succeed())
+			elapsed := time.Since(start)
+
+			// 5ms + 10ms + 20ms, minus a margin so a coarse clock cannot make this flaky
+			Expect(elapsed).To(BeNumerically(">=", 30*time.Millisecond))
+		})
+
+		It("caps the backoff at half the ack wait", func() {
+			// Without a cap the waits would grow to 10+20+40+80=150ms, far beyond the ack
+			// wait, and jetstream would redeliver the source event to a second worker while
+			// this one is still retrying. Capped at AckWait/2 they are 10+10+10+10=40ms.
+			cfg.RetryBackoffDuration = 10 * time.Millisecond
+			cfg.PublishMaxRetries = 4
+			cfg.Events.AckWait = 20 * time.Millisecond
+			pub.failures = 4
+			pps = newService()
+
+			start := time.Now()
+			Expect(pps.processEvent(bytesReceived())).To(Succeed())
+			elapsed := time.Since(start)
+
+			Expect(elapsed).To(BeNumerically("<", 100*time.Millisecond))
+
+			attempts, _ := pub.stats()
+			Expect(attempts).To(Equal(5))
+		})
+
+		It("is fatal once the retries are genuinely exhausted", func() {
+			pub.failures = 1000
+			pps = newService()
+
+			err := pps.processEvent(bytesReceived())
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, ErrFatal)).To(BeTrue())
+
+			// the initial attempt plus PublishMaxRetries retries
+			attempts, accepted := pub.stats()
+			Expect(attempts).To(Equal(4))
+			Expect(accepted).To(BeEmpty())
+		})
+
+		It("does not retry when retrying is disabled", func() {
+			cfg.PublishMaxRetries = 0
+			pub.failures = 1000
+			pps = newService()
+
+			err := pps.processEvent(bytesReceived())
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, ErrFatal)).To(BeTrue())
+
+			attempts, _ := pub.stats()
+			Expect(attempts).To(Equal(1))
+		})
+
+		It("does not take the process down when the service is stopping", func() {
+			pub.failures = 1000
+			pps = newService()
+			pps.Close()
+
+			err := pps.processEvent(bytesReceived())
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, ErrEvent)).To(BeTrue())
+			Expect(errors.Is(err, ErrFatal)).To(BeFalse())
+		})
+	})
+})


### PR DESCRIPTION
instead of killing the server

A single transient nats: timeout on event publish was fatal to the whole single-binary server, with no retry despite the service already having backoff machinery for step failures. Now retries with the same exponential backoff, capped at half the ack wait so the source event isn't redelivered to another worker mid-retry. Also stops acking the source event when publish ultimately fails, so the upload resumes after restart instead of staying orphaned, and no longer exits during graceful shutdown.

(cherry picked from commit 654f0e8e20637aea3c1f8eb8c1b9dc13d4edc5f5)

backports #3347 