### PR TITLE
fix(search): keep the hidden flag in sync

### DIFF
--- a/services/search/pkg/bleve/backend_test.go
+++ b/services/search/pkg/bleve/backend_test.go
@@ -20,6 +20,20 @@ import (
 	"github.com/opencloud-eu/opencloud/services/search/pkg/search"
 )
 
+func hiddenByID(idx bleveSearch.Index, id string) bool {
+	GinkgoHelper()
+
+	req := bleveSearch.NewSearchRequest(bleveSearch.NewDocIDQuery([]string{id}))
+	req.Fields = []string{"Hidden"}
+
+	res, err := idx.Search(req)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(res.Hits).To(HaveLen(1), "no record for %s", id)
+
+	hidden, _ := res.Hits[0].Fields["Hidden"].(bool)
+	return hidden
+}
+
 var _ = Describe("Bleve", func() {
 	var (
 		eng *bleve.Backend
@@ -576,6 +590,44 @@ var _ = Describe("Bleve", func() {
 			matches := assertDocCount(rootResource.ID, "Name:child.pdf", 1)
 			Expect(matches[0].Entity.ParentId.OpaqueId).To(Equal("3"))
 			Expect(matches[0].Entity.Ref.Path).To(Equal("./my/newname/child.pdf"))
+		})
+
+		DescribeTable("keeps the flag in step with the path",
+			func(from, target string, hidden bool) {
+				parentResource.Path = from
+				parentResource.Hidden = search.IsHidden(from)
+				childResource.Path = from + "/child.pdf"
+				childResource.Hidden = parentResource.Hidden
+
+				Expect(eng.Upsert(parentResource.ID, parentResource)).To(Succeed())
+				Expect(eng.Upsert(childResource.ID, childResource)).To(Succeed())
+
+				Expect(eng.Move(parentResource.ID, parentResource.ParentID, target)).To(Succeed())
+
+				for _, id := range []string{parentResource.ID, childResource.ID} {
+					Expect(hiddenByID(idx, id)).
+						To(Equal(hidden), "%s after moving from %s to %s", id, from, target)
+				}
+			},
+			Entry("into a dot folder", "./parent", "./.trash/parent", true),
+			Entry("into a plain folder", "./parent", "./archive/parent", false),
+			Entry("renamed with a leading dot", "./parent", "./.parent", true),
+			Entry("out of a dot folder", "./.trash/parent", "./archive/parent", false),
+			Entry("renamed without the leading dot", "./.parent", "./parent", false),
+			Entry("within the same dot folder", "./.trash/parent", "./.trash/moved", true),
+		)
+
+		// the trash leaves the path alone, so the flag has to come through untouched
+		It("carries the flag through the trash and back", func() {
+			childResource.Path = "./.secret/file.txt"
+			childResource.Hidden = true
+			Expect(eng.Upsert(childResource.ID, childResource)).To(Succeed())
+
+			Expect(eng.Delete(childResource.ID)).To(Succeed())
+			Expect(hiddenByID(idx, childResource.ID)).To(BeTrue(), "after trashing")
+
+			Expect(eng.Restore(childResource.ID)).To(Succeed())
+			Expect(hiddenByID(idx, childResource.ID)).To(BeTrue(), "after restoring")
 		})
 
 		It("moves the parent and its child resources", func() {

--- a/services/search/pkg/bleve/batch.go
+++ b/services/search/pkg/bleve/batch.go
@@ -68,6 +68,8 @@ func (b *Batch) Move(id string, parentID string, targetPath string) error {
 		}
 
 		for _, resource := range resources {
+			resource.Hidden = search.IsHidden(resource.Path)
+
 			if err := b.batch.Index(resource.ID, resource); err != nil {
 				return err
 			}

--- a/services/search/pkg/bleve/bleve.go
+++ b/services/search/pkg/bleve/bleve.go
@@ -185,6 +185,7 @@ func matchToResource(match *bleveSearch.DocumentMatch) *search.Resource {
 		ParentID: getFieldValue[string](match.Fields, "ParentID"),
 		Type:     uint64(getFieldValue[float64](match.Fields, "Type")),
 		Deleted:  getFieldValue[bool](match.Fields, "Deleted"),
+		Hidden:   getFieldValue[bool](match.Fields, "Hidden"),
 		Document: content.Document{
 			Name:      getFieldValue[string](match.Fields, "Name"),
 			Title:     getFieldValue[string](match.Fields, "Title"),

--- a/services/search/pkg/opensearch/backend_test.go
+++ b/services/search/pkg/opensearch/backend_test.go
@@ -399,6 +399,64 @@ var _ = Describe("Backend", func() {
 		})
 	})
 
+	Describe("Hidden", func() {
+		const indexName = "opencloud-test-engine-hidden"
+
+		DescribeTable("keeps the flag in step with the path",
+			func(from, target string, hidden bool) {
+				folder := opensearchtest.Testdata.Resources.Folder
+				folder.ID = "1$1!30"
+				folder.Name = "parent"
+				folder.Path = from
+				folder.Hidden = search.IsHidden(from)
+
+				child := opensearchtest.Testdata.Resources.File
+				child.ID = "1$1!31"
+				child.Name = "child.txt"
+				child.Path = from + "/child.txt"
+				child.ParentID = folder.ID
+				child.Hidden = folder.Hidden
+
+				backend, tc := newBackend(indexName, folder, child)
+				deleteIndexOnCleanup(tc, indexName)
+				tc.Require.IndicesRefresh([]string{indexName}, nil)
+
+				Expect(backend.Move(folder.ID, folder.ParentID, target)).To(Succeed())
+				tc.Require.IndicesRefresh([]string{indexName}, nil)
+
+				for _, id := range []string{folder.ID, child.ID} {
+					Expect(resourceByID(tc, indexName, id).Hidden).
+						To(Equal(hidden), "%s after moving from %s to %s", id, from, target)
+				}
+			},
+			Entry("into a dot folder", "./parent", "./.trash/parent", true),
+			Entry("into a plain folder", "./parent", "./archive/parent", false),
+			Entry("renamed with a leading dot", "./parent", "./.parent", true),
+			Entry("out of a dot folder", "./.trash/parent", "./archive/parent", false),
+			Entry("renamed without the leading dot", "./.parent", "./parent", false),
+			Entry("within the same dot folder", "./.trash/parent", "./.trash/moved", true),
+		)
+
+		It("carries the flag through the trash and back", func() {
+			hidden := opensearchtest.Testdata.Resources.File
+			hidden.ID = "1$1!32"
+			hidden.Path = "./.secret/file.txt"
+			hidden.Hidden = true
+
+			backend, tc := newBackend(indexName, hidden)
+			deleteIndexOnCleanup(tc, indexName)
+			tc.Require.IndicesRefresh([]string{indexName}, nil)
+
+			Expect(backend.Delete(hidden.ID)).To(Succeed())
+			tc.Require.IndicesRefresh([]string{indexName}, nil)
+			Expect(resourceByID(tc, indexName, hidden.ID).Hidden).To(BeTrue(), "after trashing")
+
+			Expect(backend.Restore(hidden.ID)).To(Succeed())
+			tc.Require.IndicesRefresh([]string{indexName}, nil)
+			Expect(resourceByID(tc, indexName, hidden.ID).Hidden).To(BeTrue(), "after restoring")
+		})
+	})
+
 	Describe("DocCount", func() {
 		const indexName = "opencloud-test-engine-doc-count"
 

--- a/services/search/pkg/opensearch/batch.go
+++ b/services/search/pkg/opensearch/batch.go
@@ -70,7 +70,12 @@ func (b *Batch) Move(id string, parentID string, targetPath string) error {
 				return &osu.BodyParamScript{
 					Source: `
 					if (ctx._source.ID == params.id ) { ctx._source.Name = params.newName; ctx._source.ParentID = params.parentID; }
-					ctx._source.Path = ctx._source.Path.replace(params.oldPath, params.newPath)
+					ctx._source.Path = ctx._source.Path.replace(params.oldPath, params.newPath);
+					boolean hidden = false;
+					for (String name : ctx._source.Path.splitOnToken('/')) {
+						if (!name.equals('.') && !name.equals('..') && name.startsWith('.')) { hidden = true; break; }
+					}
+					ctx._source.Hidden = hidden;
 				`,
 					Lang: "painless",
 					Params: map[string]any{

--- a/services/search/pkg/search/service.go
+++ b/services/search/pkg/search/service.go
@@ -647,7 +647,7 @@ func (s *Service) doUpsertItem(ref *provider.Reference, batch BatchOperator) {
 		Type:     uint64(stat.Info.Type),
 		Document: doc,
 	}
-	r.Hidden = strings.HasPrefix(r.Path, ".")
+	r.Hidden = IsHidden(r.Path)
 
 	if parentID := stat.GetInfo().GetParentId(); parentID != nil {
 		r.ParentID = storagespace.FormatResourceID(parentID)
@@ -692,6 +692,17 @@ func (s *Service) doUpsertItem(ref *provider.Reference, batch BatchOperator) {
 		s.logger.Error().Err(err).Int32("status", int32(resp.GetStatus().GetCode())).Msg("error storing metadata")
 		return
 	}
+}
+
+// IsHidden identifies if a node is hidden or not based on its name & path.
+func IsHidden(path string) bool {
+	for name := range strings.SplitSeq(filepath.Clean(path), string(filepath.Separator)) {
+		if name != "." && name != ".." && strings.HasPrefix(name, ".") {
+			return true
+		}
+	}
+
+	return false
 }
 
 func addAudioMetadata(metadata map[string]string, audio *libregraph.Audio) {

--- a/services/search/pkg/search/service_test.go
+++ b/services/search/pkg/search/service_test.go
@@ -138,6 +138,58 @@ var _ = Describe("Searchprovider", func() {
 		})
 	})
 
+	Describe("UpsertItem", func() {
+		DescribeTable("marks a resource hidden when a dot starts one of its names",
+			func(path string, hidden bool) {
+				info := &sprovider.ResourceInfo{
+					Id:       &sprovider.ResourceId{StorageId: "storageid", SpaceId: "spaceid", OpaqueId: "hidden-opaqueid"},
+					ParentId: &sprovider.ResourceId{StorageId: "storageid", OpaqueId: "parentopaqueid"},
+					Path:     path,
+				}
+				gatewayClient.On("Stat", mock.Anything, mock.Anything).Return(&sprovider.StatResponse{
+					Status: status.NewOK(context.Background()),
+					Info:   info,
+				}, nil)
+				gatewayClient.On("GetPath", mock.Anything, mock.MatchedBy(func(req *sprovider.GetPathRequest) bool {
+					return req.GetResourceId().GetOpaqueId() == info.GetId().GetOpaqueId()
+				})).Return(&sprovider.GetPathResponse{
+					Status: status.NewOK(context.Background()),
+					Path:   path,
+				}, nil)
+				extractor.On("Extract", mock.Anything, mock.Anything, mock.Anything).Return(content.Document{}, nil)
+
+				var indexed search.Resource
+				indexClient.On("Upsert", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+					indexed = args.Get(1).(search.Resource)
+				}).Return(nil)
+
+				s.UpsertItem(&sprovider.Reference{ResourceId: info.GetId()})
+				Expect(indexed.Hidden).To(Equal(hidden))
+			},
+			Entry("./documents/notes.txt", "./documents/notes.txt", false),
+			Entry("./documents/.notes.txt", "./documents/.notes.txt", true),
+			Entry("documents/.notes.txt", "documents/.notes.txt", true),
+			Entry("./.git/config", "./.git/config", true),
+			Entry(".git/config", ".git/config", true),
+			Entry("/.git/config", "/.git/config", true),
+			Entry("./", "./", false),
+			Entry("/", "/", false),
+		)
+	})
+
+	DescribeTable("IsHidden",
+		func(path string, hidden bool) {
+			Expect(search.IsHidden(path)).To(Equal(hidden))
+		},
+		Entry("a plain path", "./documents/notes.txt", false),
+		Entry("a dot file", "./documents/.notes.txt", true),
+		Entry("a dot folder above it", "./.git/config", true),
+		Entry("the current folder", ".", false),
+		Entry("a leading traversal", "../documents/notes.txt", false),
+		Entry("a traversal in the middle", "./documents/../notes.txt", false),
+		Entry("a traversal out of a dot folder", "./.git/../notes.txt", false),
+	)
+
 	Describe("Search", func() {
 		It("fails when an empty query is given", func() {
 			res, err := s.Search(ctx, &searchsvc.SearchRequest{


### PR DESCRIPTION
## Description
the hidden flag got out of sync which lead to some unwanted side effects

## Motivation and Context
be able to search for files that are hidden should work, using painless script allows us to keep it in sync easily  

## How Has This Been Tested?
- unit tests

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [X] Code changes
- [X] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added
