### PR TITLE
fix(thumbnails): respect the requested height in libvips builds

### DIFF
--- a/services/thumbnails/pkg/thumbnail/generator_vips.go
+++ b/services/thumbnails/pkg/thumbnail/generator_vips.go
@@ -59,7 +59,7 @@ func (g SimpleGenerator) Generate(size image.Rectangle, img interface{}) (interf
 		return nil, errors.ErrInvalidType
 	}
 
-	if err := m.ThumbnailWithSize(size.Dx(), 0, g.crop, g.size); err != nil {
+	if err := m.ThumbnailWithSize(size.Dx(), size.Dy(), g.crop, g.size); err != nil {
 		return nil, err
 	}
 

--- a/tests/acceptance/features/coreApiWebdavPreviews/previewsAutoAdustedSizing.feature
+++ b/tests/acceptance/features/coreApiWebdavPreviews/previewsAutoAdustedSizing.feature
@@ -17,20 +17,22 @@ Feature: sizing of previews of files downloaded through the webdav API
     When user "Alice" downloads the preview of "/parent.txt" with width <request-width> and height <request-height> using the WebDAV API
     Then the HTTP status code should be "200"
     And the downloaded image should be <return-width> pixels wide and <return-height> pixels high
+    # the source preview of a text file is always 640x480,
+    # so a request bigger than that is capped to the source size
     Examples:
       | request-width | request-height | return-width | return-height | dav-path-version |
       | 1             | 1              | 16           | 16            | old              |
       | 32            | 32             | 32           | 32            | old              |
-      | 1024          | 1024           | 640          | 640           | old              |
+      | 1024          | 1024           | 640          | 480           | old              |
       | 1             | 1024           | 16           | 16            | old              |
-      | 1024          | 1              | 640          | 640           | old              |
+      | 1024          | 1              | 640          | 480           | old              |
       | 1             | 1              | 16           | 16            | new              |
       | 32            | 32             | 32           | 32            | new              |
-      | 1024          | 1024           | 640          | 640           | new              |
+      | 1024          | 1024           | 640          | 480           | new              |
       | 1             | 1024           | 16           | 16            | new              |
-      | 1024          | 1              | 640          | 640           | new              |
+      | 1024          | 1              | 640          | 480           | new              |
       | 1             | 1              | 16           | 16            | spaces           |
       | 32            | 32             | 32           | 32            | spaces           |
-      | 1024          | 1024           | 640          | 640           | spaces           |
+      | 1024          | 1024           | 640          | 480           | spaces           |
       | 1             | 1024           | 16           | 16            | spaces           |
-      | 1024          | 1              | 640          | 640           | spaces           |
+      | 1024          | 1              | 640          | 480           | spaces           |


### PR DESCRIPTION
The `libvips` generator passed `0` as the target height to `vips_thumbnail`, so the value was rejected and dropped.

As a result, a preview of a `4000x5000` portrait image requested with e.g. `x=500&y=500` returned a `...x1920` image instead of a `...x1080` one, which would be the next correct size in the pre-defined resolutions list. This was due to the missing height, so it used the width (=1920) to determine the longest side.

This also aligns it with the non-`libvips` behavior.

fixes https://github.com/opencloud-eu/opencloud/issues/3376