### PR TITLE
fix: return errors instead of calling os.Exit

### DIFF
--- a/changelog/unreleased/fix-replace-exit-calls-with-returns.md
+++ b/changelog/unreleased/fix-replace-exit-calls-with-returns.md
@@ -1,0 +1,20 @@
+Bugfix: Return errors instead of exiting the process
+
+Several error paths called os.Exit(1) directly. A service started in
+supervised mode shares its process with all the other services, so exiting
+from one of them took the whole server down: the remaining services and
+workers got no chance to shut down and the nats index could be left behind
+in a corrupt state.
+
+Those paths now return their error instead. Standalone mode reports the same
+failure as before, because the cobra app is silenced and main() prints the
+error and exits non-zero. In supervised mode the supervisor now logs the
+error and restarts the failed service on its own instead of losing the
+process.
+
+Converted are the config parsing helper shared by every service command, the
+antivirus service startup, the postprocessing event worker loop, the proxy
+and idp TLS certificate generation, the storage-users uploads command and
+the posixfs and backup consistency commands.
+
+https://github.com/opencloud-eu/opencloud/issues/3352

--- a/opencloud/pkg/backup/backup.go
+++ b/opencloud/pkg/backup/backup.go
@@ -2,6 +2,7 @@
 package backup
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"regexp"
@@ -162,7 +163,7 @@ func (c *Consistency) PrintResults(discpath string, fail bool) error {
 	if len(c.Nodes) == 0 && len(c.LinkedNodes) == 0 && len(c.Blobs) == 0 && len(c.BlobReferences) == 0 {
 		fmt.Printf("💚 No inconsistency found. The backup in '%s' seems to be valid.\n", discpath)
 	} else if fail {
-		os.Exit(1)
+		return errors.New("consistency check failed")
 	}
 	return nil
 

--- a/opencloud/pkg/command/posixfs.go
+++ b/opencloud/pkg/command/posixfs.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -84,8 +85,7 @@ the command is aborted with an error before performing any scanning.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg := ocCfg.StorageUsers
 			if cfg.Driver != "posix" {
-				fmt.Fprintf(os.Stderr, "This command is only available when using the 'posix' driver. Current driver: '%s'\n", cfg.Driver)
-				os.Exit(1)
+				return fmt.Errorf("this command is only available when using the 'posix' driver. Current driver: '%s'", cfg.Driver)
 			}
 
 			haltOnError, err := cmd.Flags().GetBool("halt-on-error")
@@ -100,12 +100,11 @@ the command is aborted with an error before performing any scanning.`,
 				for _, v := range args {
 					path := v
 					if !filepath.IsAbs(path) {
-						if v, err := filepath.Abs(path); err != nil {
-							fmt.Fprintf(os.Stderr, "Failed to make the specified path %q absolute: %v\n", v, err)
-							os.Exit(1)
-						} else {
-							path = v
+						abs, err := filepath.Abs(path)
+						if err != nil {
+							return fmt.Errorf("failed to make the specified path %q absolute: %w", path, err)
 						}
+						path = abs
 					}
 					// not ensuring whether the path is under the storage root here, will be done when iterating over them
 					path = filepath.Clean(path)
@@ -123,15 +122,13 @@ the command is aborted with an error before performing any scanning.`,
 				var err error
 				fsStream, err = event.NewStream(cfg)
 				if err != nil {
-					fmt.Fprintf(os.Stderr, "Failed to create event stream for posix driver: %v\n", err)
-					os.Exit(1)
+					return fmt.Errorf("failed to create event stream for posix driver: %w", err)
 				}
 				log := logger("posixfs")
 
 				f, ok := registry.NewFuncs["posix"]
 				if !ok {
-					fmt.Fprintf(os.Stderr, "posix driver not found in registry\n")
-					os.Exit(1)
+					return errors.New("posix driver not found in registry")
 				}
 
 				fs, err := f(drivers["posix"].(map[string]any), fsStream, &log)
@@ -142,8 +139,7 @@ the command is aborted with an error before performing any scanning.`,
 
 				cacher, ok := fs.(IDCacher)
 				if !ok {
-					fmt.Fprintf(os.Stderr, "The posix driver does not expose WarmupIDCache.\n")
-					os.Exit(1)
+					return errors.New("the posix driver does not expose WarmupIDCache")
 				}
 
 				scan = func(path string) error {
@@ -155,7 +151,7 @@ the command is aborted with an error before performing any scanning.`,
 				}
 			}
 
-			errors := processPosixFsResources(paths, !haltOnError,
+			errs := processPosixFsResources(paths, !haltOnError,
 				func(path string) error {
 					fmt.Println("Scanning personal spaces...")
 					return scan(path)
@@ -174,19 +170,19 @@ the command is aborted with an error before performing any scanning.`,
 				},
 			)
 
-			if len(errors) == 0 {
+			if len(errs) == 0 {
 				fmt.Println("Scan completed successfully.")
 				return nil
 			} else {
 				plural := "s"
-				if len(errors) == 1 {
+				if len(errs) == 1 {
 					plural = ""
 				}
 				verb := "completed"
 				if haltOnError {
 					verb = "aborted"
 				}
-				return fmt.Errorf("scan %s with %d error%s", verb, len(errors), plural)
+				return fmt.Errorf("scan %s with %d error%s", verb, len(errs), plural)
 			}
 		},
 	}

--- a/pkg/config/configlog/log.go
+++ b/pkg/config/configlog/log.go
@@ -2,7 +2,6 @@ package configlog
 
 import (
 	"fmt"
-	"os"
 )
 
 // Error logs the error
@@ -20,11 +19,12 @@ func ReturnError(err error) error {
 	return err
 }
 
-// ReturnFatal logs the error and calls os.Exit(1) and returns nil if no error is passed
+// ReturnFatal logs the error and returns it unchanged.
+//
+// Deprecated: ReturnFatal used to call os.Exit(1). Every caller runs it from a
+// cobra PreRunE and returns its result, so the error is reported either way,
+// but exiting also tore down the services and workers sharing the process when
+// a service was started in supervised mode. Use ReturnError instead.
 func ReturnFatal(err error) error {
-	if err != nil {
-		fmt.Printf("%v\n", err)
-		os.Exit(1)
-	}
-	return nil
+	return ReturnError(err)
 }

--- a/services/antivirus/pkg/command/server.go
+++ b/services/antivirus/pkg/command/server.go
@@ -3,7 +3,6 @@ package command
 import (
 	"context"
 	"fmt"
-	"os"
 	"os/signal"
 
 	"github.com/opencloud-eu/opencloud/pkg/config/configlog"
@@ -43,8 +42,7 @@ func Server(cfg *config.Config) *cobra.Command {
 			{
 				svc, err := service.NewAntivirus(cfg, logger, traceProvider)
 				if err != nil {
-					logger.Error().Err(err).Str("server", "antivirus").Msg("Failed to initialize antivirus service")
-					os.Exit(1)
+					return fmt.Errorf("failed to initialize antivirus service: %w", err)
 				}
 
 				gr.Add(runner.New(cfg.Service.Name+".svc", func() error {

--- a/services/idp/pkg/server/http/server.go
+++ b/services/idp/pkg/server/http/server.go
@@ -25,8 +25,7 @@ func Server(opts ...Option) (http.Service, error) {
 		if os.IsNotExist(certErr) || os.IsNotExist(keyErr) {
 			options.Logger.Info().Msgf("Generating certs")
 			if err := pkgcrypto.GenCert(options.Config.HTTP.TLSCert, options.Config.HTTP.TLSKey, options.Logger); err != nil {
-				options.Logger.Fatal().Err(err).Msg("Could not setup TLS")
-				os.Exit(1)
+				return http.Service{}, fmt.Errorf("could not setup TLS: %w", err)
 			}
 		}
 	}

--- a/services/postprocessing/pkg/command/server.go
+++ b/services/postprocessing/pkg/command/server.go
@@ -3,9 +3,9 @@ package command
 import (
 	"context"
 	"fmt"
-	"os"
 	"os/signal"
 
+	"github.com/opencloud-eu/opencloud/pkg/config/configlog"
 	"github.com/opencloud-eu/opencloud/pkg/log"
 	"github.com/opencloud-eu/opencloud/pkg/runner"
 	"github.com/opencloud-eu/opencloud/pkg/tracing"
@@ -25,12 +25,7 @@ func Server(cfg *config.Config) *cobra.Command {
 		Use:   "server",
 		Short: fmt.Sprintf("start %s service without runtime (unsupervised mode)", cfg.Service.Name),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			err := parser.ParseConfig(cfg)
-			if err != nil {
-				fmt.Printf("%v", err)
-				os.Exit(1)
-			}
-			return err
+			return configlog.ReturnError(parser.ParseConfig(cfg))
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			logger := log.Configure(cfg.Service.Name, cfg.Commons, cfg.LogLevel)

--- a/services/postprocessing/pkg/service/service.go
+++ b/services/postprocessing/pkg/service/service.go
@@ -108,6 +108,12 @@ func NewPostprocessingService(ctx context.Context, logger log.Logger, sto store.
 func (pps *PostprocessingService) Run() error {
 	wg := sync.WaitGroup{}
 
+	// the first worker to hit an unrecoverable error stops the service and its
+	// error is returned to the caller, which shuts the service down properly
+	// instead of tearing the whole process down from inside a worker goroutine
+	var fatalErr error
+	var fatalOnce sync.Once
+
 	for range pps.c.Workers {
 		wg.Go(func() {
 
@@ -133,11 +139,17 @@ func (pps *PostprocessingService) Run() error {
 					if err != nil {
 						switch {
 						case errors.Is(err, ErrFatal):
-							pps.log.Fatal().Err(err).Msg("fatal error - exiting")
+							pps.log.Error().Err(err).Msg("fatal error - stopping")
+							fatalOnce.Do(func() { fatalErr = err })
+							pps.Close()
+							break EventLoop
 						case errors.Is(err, ErrEvent):
 							pps.log.Error().Err(err).Msg("continuing")
 						default:
-							pps.log.Fatal().Err(err).Msg("unknown error - exiting")
+							pps.log.Error().Err(err).Msg("unknown error - stopping")
+							fatalOnce.Do(func() { fatalErr = err })
+							pps.Close()
+							break EventLoop
 						}
 					}
 
@@ -152,7 +164,7 @@ func (pps *PostprocessingService) Run() error {
 
 	wg.Wait()
 
-	return nil
+	return fatalErr
 }
 
 // Close will make the postprocessing service to stop processing, so the `Run`

--- a/services/postprocessing/pkg/service/service_test.go
+++ b/services/postprocessing/pkg/service/service_test.go
@@ -92,6 +92,22 @@ var _ = Describe("PostprocessingService", func() {
 		}
 	}
 
+	// stepFinishedForUnknownUpload reports a finished step for an upload the store does
+	// not know about. Handling it fails with ErrEvent, which concerns only that event.
+	stepFinishedForUnknownUpload := func() raw.Event {
+		ev := events.PostprocessingStepFinished{
+			UploadID:     "unknown-" + uuid.New().String(),
+			FinishedStep: events.PPStepAntivirus,
+		}
+		return raw.Event{
+			Event: events.Event{
+				ID:    uuid.New().String(),
+				Type:  reflect.TypeOf(ev).String(),
+				Event: ev,
+			},
+		}
+	}
+
 	BeforeEach(func() {
 		cfg = config.Postprocessing{
 			Steps:                []string{"virusscan"},
@@ -195,6 +211,63 @@ var _ = Describe("PostprocessingService", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(errors.Is(err, ErrEvent)).To(BeTrue())
 			Expect(errors.Is(err, ErrFatal)).To(BeFalse())
+		})
+	})
+
+	Describe("running the event loop", func() {
+		// newRunningService is newService plus the worker count and the event channel
+		// Run needs. The channel is handed back so a test can feed the workers.
+		newRunningService := func(workers int) (*PostprocessingService, chan raw.Event) {
+			cfg.Workers = workers
+			evs := make(chan raw.Event)
+			svc := newService()
+			svc.events = evs
+			return svc, evs
+		}
+
+		It("returns without an error when it is stopped", func() {
+			svc, _ := newRunningService(2)
+
+			done := make(chan error, 1)
+			go func() { done <- svc.Run() }()
+
+			svc.Close()
+
+			Eventually(done, 5*time.Second).Should(Receive(BeNil()))
+		})
+
+		It("returns the fatal error instead of killing the process", func() {
+			// every publish fails, so the first event exhausts the retries and comes
+			// back as ErrFatal. That used to be a log.Fatal, which exits the process
+			// and takes every other service in the same binary with it.
+			pub.failures = 1000
+			svc, evs := newRunningService(2)
+
+			done := make(chan error, 1)
+			go func() { done <- svc.Run() }()
+
+			evs <- bytesReceived()
+
+			var err error
+			Eventually(done, 5*time.Second).Should(Receive(&err))
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, ErrFatal)).To(BeTrue())
+		})
+
+		It("keeps going after an error that only concerns a single event", func() {
+			// a step finished for an upload the store knows nothing about fails with
+			// ErrEvent, which the loop logs and moves on from
+			svc, evs := newRunningService(1)
+
+			done := make(chan error, 1)
+			go func() { done <- svc.Run() }()
+
+			evs <- stepFinishedForUnknownUpload()
+
+			Consistently(done, 200*time.Millisecond).ShouldNot(Receive())
+
+			svc.Close()
+			Eventually(done, 5*time.Second).Should(Receive(BeNil()))
 		})
 	})
 })

--- a/services/proxy/pkg/server/http/server.go
+++ b/services/proxy/pkg/server/http/server.go
@@ -25,8 +25,7 @@ func Server(opts ...Option) (http.Service, error) {
 		if os.IsNotExist(certErr) || os.IsNotExist(keyErr) {
 			// GenCert has side effects as it writes 2 files to the binary running location
 			if err := pkgcrypto.GenCert(httpCfg.TLSCert, httpCfg.TLSKey, l); err != nil {
-				l.Fatal().Err(err).Msgf("Could not generate test-certificate")
-				os.Exit(1)
+				return http.Service{}, fmt.Errorf("could not generate test-certificate: %w", err)
 			}
 		}
 	}

--- a/services/storage-users/pkg/command/uploads.go
+++ b/services/storage-users/pkg/command/uploads.go
@@ -68,8 +68,7 @@ func ListUploadSessions(cfg *config.Config) *cobra.Command {
 			var err error
 			f, ok := registry.NewFuncs[cfg.Driver]
 			if !ok {
-				fmt.Fprintf(os.Stderr, "Unknown filesystem driver '%s'\n", cfg.Driver)
-				os.Exit(1)
+				return fmt.Errorf("unknown filesystem driver '%s'", cfg.Driver)
 			}
 			drivers := revaconfig.StorageProviderDrivers(cfg)
 			var fsStream events.Stream
@@ -79,8 +78,7 @@ func ListUploadSessions(cfg *config.Config) *cobra.Command {
 				// Also posix refuses to start without an events stream
 				fsStream, err = event.NewStream(cfg)
 				if err != nil {
-					fmt.Fprintf(os.Stderr, "Failed to create event stream for posix driver: %v\n", err)
-					os.Exit(1)
+					return fmt.Errorf("failed to create event stream for posix driver: %w", err)
 				}
 			}
 
@@ -92,8 +90,7 @@ func ListUploadSessions(cfg *config.Config) *cobra.Command {
 
 			managingFS, ok := fs.(storage.UploadSessionLister)
 			if !ok {
-				fmt.Fprintf(os.Stderr, "'%s' storage does not support listing upload sessions\n", cfg.Driver)
-				os.Exit(1)
+				return fmt.Errorf("'%s' storage does not support listing upload sessions", cfg.Driver)
 			}
 
 			restart, _ := cmd.Flags().GetBool("restart")
@@ -105,8 +102,7 @@ func ListUploadSessions(cfg *config.Config) *cobra.Command {
 			if restart || resume {
 				stream, err = event.NewStream(cfg)
 				if err != nil {
-					fmt.Fprintf(os.Stderr, "Failed to create event stream: %v\n", err)
-					os.Exit(1)
+					return fmt.Errorf("failed to create event stream: %w", err)
 				}
 			}
 
@@ -172,9 +168,8 @@ func ListUploadSessions(cfg *config.Config) *cobra.Command {
 						UploadID:  u.ID(),
 						Timestamp: utils.TSNow(),
 					}); err != nil {
-						fmt.Fprintf(os.Stderr, "Failed to send restart event for upload session '%s'\n", u.ID())
 						// if publishing fails there is no need to try publishing other events - they will fail too.
-						os.Exit(1)
+						return fmt.Errorf("failed to send restart event for upload session '%s': %w", u.ID(), err)
 					}
 
 				case resume:
@@ -182,9 +177,8 @@ func ListUploadSessions(cfg *config.Config) *cobra.Command {
 						UploadID:  u.ID(),
 						Timestamp: utils.TSNow(),
 					}); err != nil {
-						fmt.Fprintf(os.Stderr, "Failed to send resume event for upload session '%s'\n", u.ID())
 						// if publishing fails there is no need to try publishing other events - they will fail too.
-						os.Exit(1)
+						return fmt.Errorf("failed to send resume event for upload session '%s': %w", u.ID(), err)
 					}
 
 				case clean:


### PR DESCRIPTION
## Description

Replaces the `os.Exit` calls in the service error paths with returned errors, following the pattern established in #3140 and spelled out in https://github.com/opencloud-eu/opencloud/pull/3344#issuecomment-5330650425: return a wrapped error and let the existing top level handle it.

Both ends of that path already work, so nothing is lost by returning:

* standalone mode: `DefaultApp` silences cobra since #3140, so `main()` prints the error to stderr and exits 1.
* supervised mode: the runtime calls `<service>.Execute(cfg)` in process, so suture logs the returned error via `Err()` and restarts only the failed service instead of losing the whole binary.

### Converted

| Call site | Was |
| --- | --- |
| `pkg/config/configlog/log.go` | `ReturnFatal` printed and called `os.Exit(1)` |
| `services/antivirus/pkg/command/server.go` | logged and exited when the service failed to initialize |
| `services/postprocessing/pkg/command/server.go` | `PreRunE` printed and exited on a config parse error |
| `services/postprocessing/pkg/service/service.go` | `log.Fatal()` in the worker goroutines (the one @rhafer pointed at) |
| `services/proxy/pkg/server/http/server.go` | `Fatal()` plus an unreachable `os.Exit(1)` on cert generation |
| `services/idp/pkg/server/http/server.go` | same, on TLS setup |
| `services/storage-users/pkg/command/uploads.go` | 6 exits inside `RunE` |
| `opencloud/pkg/command/posixfs.go` | 5 exits inside `RunE` |
| `opencloud/pkg/backup/backup.go` | `os.Exit(1)` for the `--fail` flag, now returns an error so the exit code stays 1 |

`configlog.ReturnFatal` is the one worth a second look. It is the widest reaching change here, because every service command calls it from `PreRunE`. Every one of those call sites already returns its result (`return configlog.ReturnFatal(parser.ParseConfig(cfg))`), so returning the error instead of exiting reports the same failure, and cobra skips `RunE` either way. Before this, a bad config for a single service killed the whole process in supervised mode. I marked it deprecated in favour of the identical `ReturnError` rather than rewriting all 50 call sites in this PR. Happy to do that rename as a follow up, or in here if you prefer.

The postprocessing worker loop needed slightly more than a `return`: the `log.Fatal()` sat inside the worker goroutines. The first worker to hit an unrecoverable error now records it, calls `Close()` so the other workers stop, and `Run()` returns it. `Close()` already uses a `CompareAndSwap`, so calling it from a worker is safe. `ErrEvent` still only logs and continues, unchanged.

### Deliberately left alone

* `opencloud/cmd/opencloud/main.go` is the top level that turns the returned error into the exit code. It has to stay.
* `pkg/log/log.go` exits when a log file cannot be opened. `log.Configure` returns a `Logger` and no error, so converting it means changing that signature and all 76 call sites. That felt like its own PR, and it is the one case where logging genuinely does not exist yet.
* `pkg/natsjsregistry/registry.go` exits from the nats `ReconnectedCB` and `ClosedCB` callbacks. There is no error path to return to from there, so it needs a real shutdown signal rather than a mechanical change.
* `services/storage-users/pkg/command/trash_bin.go` calls `os.Exit(0)` when the trash bin is empty. Converting it changes either the exit code or the output of the command, so it looked like your call rather than mine. Separately, the `fmt.Errorf` on the line above it is discarded, so the "trash-bin is empty" message is never actually printed. `go vet` flags it on main already. Say the word and I will fix it here or open a separate issue.
* `TestMain` in `opencloud/pkg/revisions/revisions_test.go` and `services/search/pkg/opensearch/opensearch_test.go`, where `os.Exit` is the idiomatic way to end a test binary.

After this PR the only `os.Exit` calls left outside `vendor/` are those, `main.go`, `pkg/log/log.go`, `pkg/natsjsregistry/registry.go` and `trash_bin.go`.

## Related Issue

- Fixes https://github.com/opencloud-eu/opencloud/issues/3352

## Motivation and Context

Quoting the issue: abrupt termination "might corrupt the nats index and sucks in general, because other goroutines used for services and workers have no way to shut down properly". In supervised mode all services share one process, so an `os.Exit` in any one of them takes down every other service and worker with it and skips suture's restart logic entirely.

## How Has This Been Tested?

Test environment: `golang:1.25` container on linux/amd64, `go1.25.14`.

- `go build -mod=vendor ./...`: passes.
- `go test -mod=vendor` for every touched package (`pkg/config/configlog`, `services/antivirus/...`, `services/postprocessing/...`, `services/proxy/pkg/server/...`, `services/idp/pkg/server/...`, `services/storage-users/pkg/command`, `opencloud/pkg/backup`, `opencloud/pkg/command`): passes.
- `go test -race -count=1 ./services/postprocessing/pkg/service/...`: passes, 10 of 10 specs, which matters because the worker change shares state across goroutines.
- `go vet` on the touched packages: identical output to `main`, no new findings. The `services/storage-users/pkg/command` findings (lock copies, the discarded `fmt.Errorf`) are all pre-existing, I diffed them against a clean clone of `main`.
- `gofmt -l` on every changed file: clean.

Three specs were added for the postprocessing event loop, covering that `Run` returns the fatal error, that a single bad event does not stop the loop, and that a stop still returns without an error.

Not run: the acceptance and API test suites, and no live server run. The converted paths are startup and CLI failure paths, so if you would like a specific one exercised on a real deployment, tell me which and I will do it.

## Screenshots (if appropriate):

n/a

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests only (no source changes)

## Checklist:

- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added

---

**AI assistance:** Claude Code helped with investigation and implementation of this fix. I reviewed, tested, and take full responsibility for the change.

Assisted-by: Claude Code:claude-opus-5
