### PR TITLE
ci: run search API and e2e suites against OpenSearch

### DIFF
--- a/.woodpecker.star
+++ b/.woodpecker.star
@@ -202,14 +202,14 @@ config = {
                 "apiSearch1",
             ],
             "skip": False,
-            "nightlyOpenSearch": True,
+            "openSearch": True,
         },
         "search2": {
             "suites": [
                 "apiSearch2",
             ],
             "skip": False,
-            "nightlyOpenSearch": True,
+            "openSearch": True,
         },
         "sharingNg": {
             "suites": [
@@ -273,7 +273,7 @@ config = {
             ],
             "skip": False,
             "tikaNeeded": True,
-            "nightlyOpenSearch": True,
+            "openSearch": True,
         },
         "ocm": {
             "suites": [
@@ -405,6 +405,16 @@ config = {
                 "fileaction/",
                 "embed",
             ],
+        },
+        # Runs the search-related e2e-tests against an OpenSearch search-engine.
+        "search": {
+            "skip": False,
+            "suites": [
+                "search/",
+                "file-action/favorites.feature",
+            ],
+            "tikaNeeded": True,
+            "openSearch": True,
         },
     },
     "e2eMultiService": {
@@ -1253,10 +1263,8 @@ def build_api_test_workflow_matrix(ctx, storage, suite_cfg, default_cfg):
         if matrix not in workflow_metrices and base in matrices:
             workflow_metrices.append(matrix)
 
-    # Add an OpenSearch search-engine variant for nightly running search tests,
-    # or on demand when "opensearch" is specified in the PR title
-    run_open_search = ctx.build.event == "cron" or "opensearch" in ctx.build.title.lower()
-    if run_open_search and storage == "posix" and suite_cfg.get("nightlyOpenSearch", False):
+    # Add an OpenSearch search-engine variant for the search test suites.
+    if storage == "posix" and suite_cfg.get("openSearch", False):
         os_matrix = {
             "withRemotePhp": False,
             "enableWatchFs": False,
@@ -1284,7 +1292,7 @@ def localApiTestPipeline(ctx):
         "withRemotePhp": False,
         "enableWatchFs": False,
         "ldapNeeded": False,
-        "nightlyOpenSearch": False,
+        "openSearch": False,
     }
 
     if "localApiTests" in config:
@@ -1530,6 +1538,7 @@ def e2eTestPipeline(ctx):
         "reportTracing": False,
         "enableWatchFs": [False],
         "storages": ["posix"],
+        "openSearch": False,
     }
 
     extra_server_environment = {
@@ -1573,14 +1582,30 @@ def e2eTestPipeline(ctx):
         if "[decomposed]" in ctx.build.title.lower():
             params["storages"] = ["decomposed"]
 
-        e2e_args = " ".join(params["suites"]) if params["suites"] else ""
-
         if "with-tracing" in ctx.build.title.lower():
             params["reportTracing"] = True
 
+        e2e_args = " ".join(params["suites"]) if params["suites"] else ""
+
+        # OpenSearch search-engine suites run posix-only without the watchfs matrix.
+        run_with_open_search = params["openSearch"]
+        if run_with_open_search:
+            params["storages"] = ["posix"]
+            params["enableWatchFs"] = [False]
+
         for storage in params["storages"]:
             for watch_fs_enabled in params["enableWatchFs"]:
-                pipeline_name = "test-e2e-%s-%s%s" % (name, storage, "-watchfs" if watch_fs_enabled else "")
+                pipeline_name = "test-e2e-%s-%s%s%s" % (
+                    name,
+                    storage,
+                    "-watchfs" if watch_fs_enabled else "",
+                    "-opensearch" if run_with_open_search else "",
+                )
+
+                server_environment = dict(extra_server_environment)
+                if run_with_open_search:
+                    server_environment["SEARCH_ENGINE_TYPE"] = "open-search"
+                    server_environment["SEARCH_ENGINE_OPEN_SEARCH_CLIENT_ADDRESSES"] = "http://open-search:9200"
 
                 steps = \
                     evaluateWorkflowStep() + \
@@ -1589,9 +1614,10 @@ def e2eTestPipeline(ctx):
                     restoreWebPnpmCache() + \
                     restoreBrowsersCache() + \
                     (tikaService() if params["tikaNeeded"] else []) + \
+                    (waitForOpenSearch() if run_with_open_search else []) + \
                     opencloudServer(
                         storage,
-                        extra_server_environment = extra_server_environment,
+                        extra_server_environment = server_environment,
                         tika_enabled = params["tikaNeeded"],
                         watch_fs_enabled = watch_fs_enabled,
                     ) + \
@@ -1618,6 +1644,7 @@ def e2eTestPipeline(ctx):
                 pipeline = {
                     "name": pipeline_name,
                     "steps": steps,
+                    "services": openSearchService() if run_with_open_search else [],
                     "depends_on": getPipelineNames(buildOpencloudBinaryForTesting(ctx) + buildWebCache(ctx)),
                     "when": e2e_trigger,
                 }


### PR DESCRIPTION
related https://github.com/opencloud-eu/qa/issues/105

run api- `search1` `search2` `searchContent` and e2e - `search/` `file-action/favorites.feature` against opensearch

<img width="803" height="231" alt="image" src="https://github.com/user-attachments/assets/2093569f-76ca-48a4-9a80-1a7ef5c25449" />
<img width="793" height="38" alt="image" src="https://github.com/user-attachments/assets/138ad0be-1770-4ae8-aba2-ab31a95b6794" />
