### PR TITLE
fix(search): refresh the opensearch index after a write

### DIFF
--- a/services/search/pkg/opensearch/backend_test.go
+++ b/services/search/pkg/opensearch/backend_test.go
@@ -214,6 +214,29 @@ var _ = Describe("Backend", func() {
 		})
 	})
 
+	Describe("WriteVisibility", func() {
+		const indexName = "opencloud-test-engine-write-visibility"
+
+		It("deletes a record that was just written", func() {
+			document := opensearchtest.Testdata.Resources.File
+			document.ID = "1$1!95"
+			document.Name = "textfile.txt"
+			document.Path = "./textfile.txt"
+
+			backend, tc := newBackend(indexName)
+			deleteIndexOnCleanup(tc, indexName)
+
+			Expect(backend.Upsert(document.ID, document)).To(Succeed())
+			Expect(backend.Delete(document.ID)).To(Succeed())
+
+			resp, err := backend.Search(context.Background(), &searchService.SearchIndexRequest{
+				Query: fmt.Sprintf(`name:"%s"`, document.Name),
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(resp.Matches).To(BeEmpty())
+		})
+	})
+
 	Describe("Delete", func() {
 		const indexName = "opencloud-test-engine-delete"
 

--- a/services/search/pkg/opensearch/batch.go
+++ b/services/search/pkg/opensearch/batch.go
@@ -158,6 +158,7 @@ func (b *Batch) Purge(id string, onlyDeleted bool) error {
 				Indices: []string{b.index},
 				Params: opensearchgoAPI.DocumentDeleteByQueryParams{
 					WaitForCompletion: conversions.ToPointer(true),
+					Refresh:           conversions.ToPointer(true),
 				},
 			},
 			query,
@@ -210,7 +211,8 @@ func (b *Batch) Push() error {
 		}
 
 		if _, err := b.client.Bulk(context.Background(), opensearchgoAPI.BulkReq{
-			Body: strings.NewReader(body.String()),
+			Body:   strings.NewReader(body.String()),
+			Params: opensearchgoAPI.BulkParams{Refresh: "wait_for"},
 		}); err != nil {
 			return fmt.Errorf("failed to execute bulk operations: %w", err)
 		}

--- a/services/search/pkg/opensearch/opensearch.go
+++ b/services/search/pkg/opensearch/opensearch.go
@@ -54,6 +54,7 @@ func updateSelfAndDescendants(ctx context.Context, client *opensearchgoAPI.Clien
 			Indices: []string{index},
 			Params: opensearchgoAPI.UpdateByQueryParams{
 				WaitForCompletion: conversions.ToPointer(true),
+				Refresh:           conversions.ToPointer(true),
 			},
 		},
 		osu.NewBoolQuery().

--- a/tests/acceptance/features/apiSearch1/favoriteSearch.feature
+++ b/tests/acceptance/features/apiSearch1/favoriteSearch.feature
@@ -114,7 +114,7 @@ Feature: search for favorites
     Then the HTTP status code should be "207"
     And the search result should contain "0" entries
 
-
+  @issue-3309
   Scenario: search for favorite files after deleting a file
     Given user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile.txt"
     And user "Alice" has marked file "textfile.txt" as favorite from space "Personal"

--- a/tests/acceptance/features/apiSearch1/favoriteSearch.feature
+++ b/tests/acceptance/features/apiSearch1/favoriteSearch.feature
@@ -114,7 +114,7 @@ Feature: search for favorites
     Then the HTTP status code should be "207"
     And the search result should contain "0" entries
 
-  @issue-3309
+
   Scenario: search for favorite files after deleting a file
     Given user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile.txt"
     And user "Alice" has marked file "textfile.txt" as favorite from space "Personal"


### PR DESCRIPTION
## Description

An update reads the record right before modifying it, so without a refresh, deleting a file immediately after uploading failed with "document not found".

## Related Issue
- Fixes https://github.com/opencloud-eu/opencloud/issues/3309

## How Has This Been Tested?
- tests

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [X] Code changes
- [X] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added
