### PR TITLE
chore: set introduction version to 7.5.0 for new env vars

### DIFF
--- a/services/eventhistory/pkg/config/config.go
+++ b/services/eventhistory/pkg/config/config.go
@@ -32,7 +32,7 @@ type GRPCConfig struct {
 	Addr      string                 `yaml:"addr" env:"EVENTHISTORY_GRPC_ADDR" desc:"The bind address of the GRPC service." introductionVersion:"1.0.0"`
 	Namespace string                 `yaml:"-"`
 	TLS       *shared.GRPCServiceTLS `yaml:"tls"`
-	Disabled  bool                   `yaml:"disabled" env:"EVENTHISTORY_GRPC_DISABLED" desc:"Disables the GRPC service. Set this to true if the service should only handle events." introductionVersion:"%NEXT%"`
+	Disabled  bool                   `yaml:"disabled" env:"EVENTHISTORY_GRPC_DISABLED" desc:"Disables the GRPC service. Set this to true if the service should only handle events." introductionVersion:"7.5.0"`
 }
 
 // Store configures the store to use
@@ -58,5 +58,5 @@ type Events struct {
 	EnableTLS            bool   `yaml:"enable_tls" env:"OC_EVENTS_ENABLE_TLS;EVENTHISTORY_EVENTS_ENABLE_TLS" desc:"Enable TLS for the connection to the events broker. The events broker is the OpenCloud service which receives and delivers events between the services." introductionVersion:"1.0.0"`
 	AuthUsername         string `yaml:"username" env:"OC_EVENTS_AUTH_USERNAME;EVENTHISTORY_EVENTS_AUTH_USERNAME" desc:"The username to authenticate with the events broker. The events broker is the OpenCloud service which receives and delivers events between the services." introductionVersion:"1.0.0"`
 	AuthPassword         string `yaml:"password" env:"OC_EVENTS_AUTH_PASSWORD;EVENTHISTORY_EVENTS_AUTH_PASSWORD" desc:"The password to authenticate with the events broker. The events broker is the OpenCloud service which receives and delivers events between the services." introductionVersion:"1.0.0"`
-	Disabled             bool   `yaml:"disabled" env:"EVENTHISTORY_EVENTS_DISABLED" desc:"Disables listening for events. Set this to true if the service should only handle GRPC requests." introductionVersion:"%NEXT%"`
+	Disabled             bool   `yaml:"disabled" env:"EVENTHISTORY_EVENTS_DISABLED" desc:"Disables listening for events. Set this to true if the service should only handle GRPC requests." introductionVersion:"7.5.0"`
 }

--- a/services/nats/pkg/config/config.go
+++ b/services/nats/pkg/config/config.go
@@ -19,10 +19,10 @@ type Config struct {
 }
 
 type Monitoring struct {
-	Enabled   bool   `yaml:"enabled" env:"NATS_MONITORING_ENABLED" desc:"Whether to enable the NATS server monitoring HTTP endpoint" introductionVersion:"%NEXT%"`
-	Host      string `yaml:"host" env:"NATS_MONITORING_HTTP_HOST" desc:"The address the NATS server monitoring HTTP endpoint should be bound to" introductionVersion:"%NEXT%"`
-	Port      int    `yaml:"port" env:"NATS_MONITORING_HTTP_PORT" desc:"The port the NATS server monitoring HTTP endpoint should be bound to" introductionVersion:"%NEXT%"`
-	EnableTLS bool   `yaml:"enable_tls" env:"NATS_MONITORING_ENABLE_TLS" desc:"Enable TLS for NATS server monitoring HTTP endpoint. Note that it will use the same TLS configuration as the streaming API." introductionVersion:"%NEXT%"`
+	Enabled   bool   `yaml:"enabled" env:"NATS_MONITORING_ENABLED" desc:"Whether to enable the NATS server monitoring HTTP endpoint" introductionVersion:"7.5.0"`
+	Host      string `yaml:"host" env:"NATS_MONITORING_HTTP_HOST" desc:"The address the NATS server monitoring HTTP endpoint should be bound to" introductionVersion:"7.5.0"`
+	Port      int    `yaml:"port" env:"NATS_MONITORING_HTTP_PORT" desc:"The port the NATS server monitoring HTTP endpoint should be bound to" introductionVersion:"7.5.0"`
+	EnableTLS bool   `yaml:"enable_tls" env:"NATS_MONITORING_ENABLE_TLS" desc:"Enable TLS for NATS server monitoring HTTP endpoint. Note that it will use the same TLS configuration as the streaming API." introductionVersion:"7.5.0"`
 }
 
 // Nats is the nats config

--- a/services/postprocessing/pkg/config/config.go
+++ b/services/postprocessing/pkg/config/config.go
@@ -32,7 +32,7 @@ type Postprocessing struct {
 
 	RetryBackoffDuration time.Duration `yaml:"retry_backoff_duration" env:"POSTPROCESSING_RETRY_BACKOFF_DURATION" desc:"The base for the exponential backoff duration before retrying a failed postprocessing step. See the Environment Variable Types description for more details." introductionVersion:"1.0.0"`
 	MaxRetries           int           `yaml:"max_retries" env:"POSTPROCESSING_MAX_RETRIES" desc:"The maximum number of retries for a failed postprocessing step." introductionVersion:"1.0.0"`
-	PublishMaxRetries    int           `yaml:"publish_max_retries" env:"POSTPROCESSING_PUBLISH_MAX_RETRIES" desc:"The maximum number of retries when publishing an event to the event system fails. The same exponential backoff as for failed postprocessing steps is used, based on POSTPROCESSING_RETRY_BACKOFF_DURATION. Set to 0 to not retry at all." introductionVersion:"%NEXT%"`
+	PublishMaxRetries    int           `yaml:"publish_max_retries" env:"POSTPROCESSING_PUBLISH_MAX_RETRIES" desc:"The maximum number of retries when publishing an event to the event system fails. The same exponential backoff as for failed postprocessing steps is used, based on POSTPROCESSING_RETRY_BACKOFF_DURATION. Set to 0 to not retry at all." introductionVersion:"7.5.0"`
 }
 
 // Events combines the configuration options for the event bus.

--- a/services/proxy/pkg/config/config.go
+++ b/services/proxy/pkg/config/config.go
@@ -31,8 +31,8 @@ type Config struct {
 	RoleAssignment                RoleAssignment      `yaml:"role_assignment"`
 	PolicySelector                *PolicySelector     `yaml:"policy_selector"`
 	PreSignedURL                  PreSignedURL        `yaml:"pre_signed_url"`
-	TransferSecret                string              `yaml:"transfer_secret" env:"OC_TRANSFER_SECRET" desc:"The storage transfer secret." introductionVersion:"%NEXT%"`
-	TransferTimeout               time.Duration       `yaml:"transfer_timeout" env:"PROXY_TRANSFER_TIMEOUT" desc:"The storage transfer timeout." introductionVersion:"%NEXT%"`
+	TransferSecret                string              `yaml:"transfer_secret" env:"OC_TRANSFER_SECRET" desc:"The storage transfer secret." introductionVersion:"7.5.0"`
+	TransferTimeout               time.Duration       `yaml:"transfer_timeout" env:"PROXY_TRANSFER_TIMEOUT" desc:"The storage transfer timeout." introductionVersion:"7.5.0"`
 	AccountBackend                string              `yaml:"account_backend" env:"PROXY_ACCOUNT_BACKEND_TYPE" desc:"Account backend the PROXY service should use. Currently only 'cs3' is possible here." introductionVersion:"1.0.0"`
 	UserOIDCClaim                 string              `yaml:"user_oidc_claim" env:"PROXY_USER_OIDC_CLAIM" desc:"The name of an OpenID Connect claim that is used for resolving users with the account backend. The value of the claim must hold a per user unique, stable and non re-assignable identifier. The availability of claims depends on your Identity Provider. There are common claims available for most Identity providers like 'email' or 'preferred_username' but you can also add your own claim." introductionVersion:"1.0.0"`
 	UserCS3Claim                  string              `yaml:"user_cs3_claim" env:"PROXY_USER_CS3_CLAIM" desc:"The name of a CS3 user attribute (claim) that should be mapped to the 'user_oidc_claim'. Supported values are 'username', 'mail' and 'userid'." introductionVersion:"1.0.0"`

--- a/services/proxy/pkg/config/http.go
+++ b/services/proxy/pkg/config/http.go
@@ -14,12 +14,12 @@ type HTTP struct {
 }
 
 type Client struct {
-	DialTimeout           time.Duration `yaml:"dial_timeout" env:"PROXY_TRANSPORT_CLIENT_DIAL_TIMEOUT" desc:"Dial timeout for the HTTP client." introductionVersion:"%NEXT%"`
-	DialKeepAlive         time.Duration `yaml:"dial_keep_alive" env:"PROXY_TRANSPORT_CLIENT_DIAL_KEEP_ALIVE" desc:"Dial keep alive for the HTTP client." introductionVersion:"%NEXT%"`
-	ForceAttemptHTTP2     bool          `yaml:"force_attempt_http2" env:"PROXY_TRANSPORT_CLIENT_FORCE_ATTEMPT_HTTP2" desc:"Force attempt HTTP/2 for the HTTP client. Set to true if backend communication is encrypted and HTTP/2 is desired." introductionVersion:"%NEXT%"`
-	MaxIdleConns          int           `yaml:"max_idle_conns" env:"PROXY_TRANSPORT_CLIENT_MAX_IDLE_CONNS" desc:"Maximum idle connections for the HTTP client." introductionVersion:"%NEXT%"`
-	MaxIdleConnsPerHost   int           `yaml:"max_idle_conns_per_host" env:"PROXY_TRANSPORT_CLIENT_MAX_IDLE_CONNS_PER_HOST" desc:"Maximum idle connections per host for the HTTP client." introductionVersion:"%NEXT%"`
-	IdleConnTimeout       time.Duration `yaml:"idle_conn_timeout" env:"PROXY_TRANSPORT_CLIENT_IDLE_CONN_TIMEOUT" desc:"Idle connection timeout for the HTTP client." introductionVersion:"%NEXT%"`
-	TLSHandshakeTimeout   time.Duration `yaml:"tls_handshake_timeout" env:"PROXY_TRANSPORT_CLIENT_TLS_HANDSHAKE_TIMEOUT" desc:"TLS handshake timeout for the HTTP client." introductionVersion:"%NEXT%"`
-	ExpectContinueTimeout time.Duration `yaml:"expect_continue_timeout" env:"PROXY_TRANSPORT_CLIENT_EXPECT_CONTINUE_TIMEOUT" desc:"Expect continue timeout for the HTTP client." introductionVersion:"%NEXT%"`
+	DialTimeout           time.Duration `yaml:"dial_timeout" env:"PROXY_TRANSPORT_CLIENT_DIAL_TIMEOUT" desc:"Dial timeout for the HTTP client." introductionVersion:"7.5.0"`
+	DialKeepAlive         time.Duration `yaml:"dial_keep_alive" env:"PROXY_TRANSPORT_CLIENT_DIAL_KEEP_ALIVE" desc:"Dial keep alive for the HTTP client." introductionVersion:"7.5.0"`
+	ForceAttemptHTTP2     bool          `yaml:"force_attempt_http2" env:"PROXY_TRANSPORT_CLIENT_FORCE_ATTEMPT_HTTP2" desc:"Force attempt HTTP/2 for the HTTP client. Set to true if backend communication is encrypted and HTTP/2 is desired." introductionVersion:"7.5.0"`
+	MaxIdleConns          int           `yaml:"max_idle_conns" env:"PROXY_TRANSPORT_CLIENT_MAX_IDLE_CONNS" desc:"Maximum idle connections for the HTTP client." introductionVersion:"7.5.0"`
+	MaxIdleConnsPerHost   int           `yaml:"max_idle_conns_per_host" env:"PROXY_TRANSPORT_CLIENT_MAX_IDLE_CONNS_PER_HOST" desc:"Maximum idle connections per host for the HTTP client." introductionVersion:"7.5.0"`
+	IdleConnTimeout       time.Duration `yaml:"idle_conn_timeout" env:"PROXY_TRANSPORT_CLIENT_IDLE_CONN_TIMEOUT" desc:"Idle connection timeout for the HTTP client." introductionVersion:"7.5.0"`
+	TLSHandshakeTimeout   time.Duration `yaml:"tls_handshake_timeout" env:"PROXY_TRANSPORT_CLIENT_TLS_HANDSHAKE_TIMEOUT" desc:"TLS handshake timeout for the HTTP client." introductionVersion:"7.5.0"`
+	ExpectContinueTimeout time.Duration `yaml:"expect_continue_timeout" env:"PROXY_TRANSPORT_CLIENT_EXPECT_CONTINUE_TIMEOUT" desc:"Expect continue timeout for the HTTP client." introductionVersion:"7.5.0"`
 }


### PR DESCRIPTION
## Description

Sets the introduction version to 7.5.0 for all new env vars for the upcoming rolling release.

## Related Issue

- refs https://github.com/opencloud-eu/opencloud/issues/3391

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)
- [x] Maintenance

## Checklist:
<!-- Tick the checkboxes when done. -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added
