### PR TITLE
fix(middleware): reject empty OIDC providers safely

### DIFF
--- a/pkg/middleware/oidc.go
+++ b/pkg/middleware/oidc.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"strings"
 	"sync"
@@ -61,7 +62,10 @@ func OidcAuth(opts ...Option) func(http.Handler) http.Handler {
 						provider, err = providerFunc()
 					}
 					initializeProviderLock.Unlock()
-					if err != nil {
+					if err != nil || provider == nil {
+						if err == nil {
+							err = errors.New("OIDC provider initialization returned nil")
+						}
 						opt.Logger.Error().Err(err).Msg("could not initialize OIDC provider")
 						w.WriteHeader(http.StatusInternalServerError)
 						return
@@ -78,6 +82,12 @@ func OidcAuth(opts ...Option) func(http.Handler) http.Handler {
 					oauth2.StaticTokenSource(oauth2Token),
 				)
 				if err != nil {
+					w.Header().Add("WWW-Authenticate", `Bearer`)
+					w.WriteHeader(http.StatusUnauthorized)
+					return
+				}
+				if userInfo == nil {
+					opt.Logger.Error().Msg("OIDC provider returned empty user info")
 					w.Header().Add("WWW-Authenticate", `Bearer`)
 					w.WriteHeader(http.StatusUnauthorized)
 					return


### PR DESCRIPTION
## Summary

A bearer-authenticated request can panic when OIDC provider initialization yields a nil provider, and a provider returning empty user info is not handled defensively. This is especially visible on the webfinger endpoint as a 500/502 instead of an authentication response.

Validate both initialization results before invoking the provider and treat empty user info as unauthorized.

## Testing

- `gofmt -w pkg/middleware/oidc.go`
- `go test ./pkg/middleware`
- `git diff --check`

Fixes #3413