### PR TITLE
fix(search): ignore invalid photo exposure times

### DIFF
--- a/services/search/pkg/content/tika_photo.go
+++ b/services/search/pkg/content/tika_photo.go
@@ -63,10 +63,12 @@ func (t Tika) getPhoto(meta map[string][]string) *libregraph.Photo {
 	}
 
 	if v, err := getFirstValue(meta, "exif:ExposureTime"); err == nil {
-		if i, err := strconv.ParseFloat(v, 64); err == nil && i > 0 {
-			initPhoto()
-			photo.SetExposureNumerator(1)
-			photo.SetExposureDenominator(math.Round(1 / i))
+		if i, err := strconv.ParseFloat(v, 64); err == nil {
+			if d := math.Round(1 / i); !math.IsNaN(d) && !math.IsInf(d, 0) && d > 0 {
+				initPhoto()
+				photo.SetExposureNumerator(1)
+				photo.SetExposureDenominator(d)
+			}
 		}
 	}
 

--- a/services/search/pkg/content/tika_test.go
+++ b/services/search/pkg/content/tika_test.go
@@ -146,14 +146,16 @@ var _ = Describe("Tika", func() {
 		})
 
 		It("ignores zero exposure time", func() {
-			fullResponse = `[{"exif:ExposureTime": "0.0"}]`
+			fullResponse = `[{"exif:ExposureTime": "0.0", "exif:FNumber": "2.0"}]`
 
 			doc, err := tika.Extract(context.TODO(), &provider.ResourceInfo{
 				Type: provider.ResourceType_RESOURCE_TYPE_FILE,
 				Size: 1,
 			})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(doc.Photo).To(BeNil())
+			Expect(doc.Photo).ToNot(BeNil())
+			Expect(doc.Photo.FNumber).To(Equal(libregraph.PtrFloat64(2)))
+			Expect(doc.Photo.ExposureDenominator).To(BeNil())
 		})
 
 		It("removes stop words", func() {

--- a/services/search/pkg/content/tika_test.go
+++ b/services/search/pkg/content/tika_test.go
@@ -145,6 +145,17 @@ var _ = Describe("Tika", func() {
 			Expect(doc.Content).To(Equal("body test stop words!!!"))
 		})
 
+		It("ignores zero exposure time", func() {
+			fullResponse = `[{"exif:ExposureTime": "0.0"}]`
+
+			doc, err := tika.Extract(context.TODO(), &provider.ResourceInfo{
+				Type: provider.ResourceType_RESOURCE_TYPE_FILE,
+				Size: 1,
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(doc.Photo).To(BeNil())
+		})
+
 		It("removes stop words", func() {
 			body = "body to test stop words!!! against almost everyone"
 			language = "en"


### PR DESCRIPTION
## Summary

Apache Tika can report `exif:ExposureTime` as `0.0` for embedded placeholder images. Dividing by that value creates `+Inf`, which later makes the Graph photo JSON impossible to marshal and prevents the containing file from being indexed.

Ignore non-positive and non-finite exposure values while preserving valid photo metadata.

## Testing

- `gofmt -w services/search/pkg/content/tika.go services/search/pkg/content/tika_test.go`
- `go test ./services/search/pkg/content`
- `git diff --check`

Fixes #3267