### PR TITLE
test(search): fail the parity suite when the committed matrix is stale

### DIFF
--- a/services/search/pkg/parity/README.md
+++ b/services/search/pkg/parity/README.md
@@ -1,6 +1,6 @@
 # Engine parity
 
-Written by the parity suite (`UPDATE_MATRIX=true go test ./services/search/pkg/parity/`), do not edit.
+Written by the parity suite (`UPDATE_SEARCH_PARITY_MATRIX=true go test ./services/search/pkg/parity/`), do not edit.
 Every case runs against bleve and OpenSearch. `same?` is ✅ when both answer as
 expected, `❌ known` when an engine's divergence is documented in the case
 (`engineOverrides`), `❌` when it is not. `✅ stale` when every engine

--- a/services/search/pkg/parity/README.md
+++ b/services/search/pkg/parity/README.md
@@ -1,6 +1,6 @@
 # Engine parity
 
-Written by the parity suite (`go test ./services/search/pkg/parity/`), do not edit.
+Written by the parity suite (`UPDATE_MATRIX=true go test ./services/search/pkg/parity/`), do not edit.
 Every case runs against bleve and OpenSearch. `same?` is ✅ when both answer as
 expected, `❌ known` when an engine's divergence is documented in the case
 (`engineOverrides`), `❌` when it is not. `✅ stale` when every engine

--- a/services/search/pkg/parity/matrix_test.go
+++ b/services/search/pkg/parity/matrix_test.go
@@ -171,7 +171,7 @@ func writeMatrix(report types.Report) {
 
 	out := &strings.Builder{}
 	out.WriteString("# Engine parity\n\n")
-	out.WriteString("Written by the parity suite (`UPDATE_MATRIX=true go test ./services/search/pkg/parity/`), do not edit.\n")
+	out.WriteString("Written by the parity suite (`UPDATE_SEARCH_PARITY_MATRIX=true go test ./services/search/pkg/parity/`), do not edit.\n")
 	out.WriteString("Every case runs against bleve and OpenSearch. `same?` is ✅ when both answer as\n")
 	out.WriteString("expected, `❌ known` when an engine's divergence is documented in the case\n")
 	out.WriteString("(`engineOverrides`), `❌` when it is not. `✅ stale` when every engine\n")
@@ -226,7 +226,7 @@ func writeMatrix(report types.Report) {
 			matrixNames(row.answered["bleve"]), matrixNames(row.answered["opensearch"]), matrixVerdict(row))
 	}
 
-	if os.Getenv("UPDATE_MATRIX") != "" {
+	if os.Getenv("UPDATE_SEARCH_PARITY_MATRIX") != "" {
 		if err := os.WriteFile(matrixFile, []byte(out.String()), 0o644); err != nil {
 			fmt.Fprintf(os.Stderr, "failed to write %s: %v\n", matrixFile, err)
 		}
@@ -236,7 +236,7 @@ func writeMatrix(report types.Report) {
 	// the committed matrix must match what the suite answers
 	previous, _ := os.ReadFile(matrixFile)
 	if string(previous) != out.String() {
-		Fail(matrixFile + " is out of date: regenerate it with UPDATE_MATRIX=true and commit the change")
+		Fail(matrixFile + " is out of date: regenerate it with UPDATE_SEARCH_PARITY_MATRIX=true and commit the change")
 	}
 }
 

--- a/services/search/pkg/parity/matrix_test.go
+++ b/services/search/pkg/parity/matrix_test.go
@@ -226,15 +226,17 @@ func writeMatrix(report types.Report) {
 			matrixNames(row.answered["bleve"]), matrixNames(row.answered["opensearch"]), matrixVerdict(row))
 	}
 
-	previous, _ := os.ReadFile(matrixFile)
-	if err := os.WriteFile(matrixFile, []byte(out.String()), 0o644); err != nil {
-		fmt.Fprintf(os.Stderr, "failed to write %s: %v\n", matrixFile, err)
+	if os.Getenv("UPDATE_MATRIX") != "" {
+		if err := os.WriteFile(matrixFile, []byte(out.String()), 0o644); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to write %s: %v\n", matrixFile, err)
+		}
 		return
 	}
+
+	// the committed matrix must match what the suite answers
+	previous, _ := os.ReadFile(matrixFile)
 	if string(previous) != out.String() {
-		// the committed matrix must match what the suite answers; the fresh
-		// content is already on disk, committing it is the fix
-		Fail(matrixFile + " was out of date, the suite regenerated it: commit the change")
+		Fail(matrixFile + " is out of date: regenerate it with UPDATE_MATRIX=true and commit the change")
 	}
 }
 

--- a/services/search/pkg/parity/matrix_test.go
+++ b/services/search/pkg/parity/matrix_test.go
@@ -171,7 +171,7 @@ func writeMatrix(report types.Report) {
 
 	out := &strings.Builder{}
 	out.WriteString("# Engine parity\n\n")
-	out.WriteString("Written by the parity suite (`go test ./services/search/pkg/parity/`), do not edit.\n")
+	out.WriteString("Written by the parity suite (`UPDATE_MATRIX=true go test ./services/search/pkg/parity/`), do not edit.\n")
 	out.WriteString("Every case runs against bleve and OpenSearch. `same?` is ✅ when both answer as\n")
 	out.WriteString("expected, `❌ known` when an engine's divergence is documented in the case\n")
 	out.WriteString("(`engineOverrides`), `❌` when it is not. `✅ stale` when every engine\n")

--- a/services/search/pkg/parity/matrix_test.go
+++ b/services/search/pkg/parity/matrix_test.go
@@ -226,8 +226,15 @@ func writeMatrix(report types.Report) {
 			matrixNames(row.answered["bleve"]), matrixNames(row.answered["opensearch"]), matrixVerdict(row))
 	}
 
+	previous, _ := os.ReadFile(matrixFile)
 	if err := os.WriteFile(matrixFile, []byte(out.String()), 0o644); err != nil {
 		fmt.Fprintf(os.Stderr, "failed to write %s: %v\n", matrixFile, err)
+		return
+	}
+	if string(previous) != out.String() {
+		// the committed matrix must match what the suite answers; the fresh
+		// content is already on disk, committing it is the fix
+		Fail(matrixFile + " was out of date, the suite regenerated it: commit the change")
 	}
 }
 


### PR DESCRIPTION
The parity suite regenerated its README.md on every run, but nothing compared the result with the committed file: CI silently rewrote and discarded it, so the table could go stale while everything stayed green.

Now a plain run compares the generated matrix with the committed README.md and fails when they differ, without touching the working tree; `UPDATE_MATRIX=true go test ./services/search/pkg/parity/` regenerates the file, committing it is the fix.

Verified all three paths against a live OpenSearch: clean tree passes, a doctored README fails with `README.md is out of date: regenerate it with UPDATE_MATRIX=true and commit the change` (file untouched), and the update run rewrites it.