### PR TITLE
chore(mise): upgrade go in mise to 1.25.9 after 578861b4737

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,8 +1,8 @@
 [tools]
-go = "1.25"
+go = "1.25.9"
 node = "24"
 pnpm = "11.1.3"
-"go:github.com/go-delve/delve/cmd/dlv" = "1.27.0"
+"go:github.com/go-delve/delve/cmd/dlv" = "1.27.1"
 "aqua:nats-io/natscli" = "0.4.0"
 
 [tasks.build]


### PR DESCRIPTION
## Description
* upgrade the go version in `mise.toml` to 1.25.9 because dependabot upgraded go to 1.25.9 in `go.mod` in commit [578861b4737](https://github.com/opencloud-eu/opencloud/commit/578861b4737)
* `mise.toml`: upgrade dlv from 1.27.0 to [1.27.1](https://github.com/go-delve/delve/releases/tag/v1.27.1)

## Motivation and Context
Aligns the required Go version for developers that use [`mise`](https://mise.jdx.dev/) to manage their tool chain.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added
