### PR TITLE
chore(mise): determine go version in mise.toml by parsing go.mod

### DIFF
--- a/.mise-go-version.sh
+++ b/.mise-go-version.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -euo pipefail
+
+# Purpose of this script is to parse the go.mod file to retrieve the version of
+# Go that we are using, either from a "toolchain" directive (preferred), or from
+# a "go" directive as a fallback.
+#
+# The script then outputs that version, where it will be picked up as an environment
+# variable in mise.
+
+F="./go.mod"
+
+AWK=awk
+# prefer 'gawk' over 'awk' to make sure we get GNU awk
+command -v gawk &>/dev/null && AWK=gawk
+
+[[ -e $F ]] || { echo "ERROR: failed to find $F" >&2; exit 1;}
+
+GO_VERSION=$("$AWK" '/^toolchain/ {print $2; exit} /^go / {print $2}' "$F")
+GO_VERSION=${GO_VERSION#go} # strip the potential 'go' prefix:
+echo "${GO_VERSION}"

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,8 @@
+[env]
+GO_VERSION = "{{ exec(command='./.mise-go-version.sh') }}"
+
 [tools]
-go = "1.25.9"
+go = "{{ env.GO_VERSION }}"
 node = "24"
 pnpm = "11.1.3"
 "go:github.com/go-delve/delve/cmd/dlv" = "1.27.1"


### PR DESCRIPTION
## Description
Instead of statically defining the version of Go in `mise.toml` as well as in its native file (`go.mod`), use a small shell script to parse go.mod and determine the version dynamically from there.

That version is then available as an env variable in the `mise.toml` file and can be referenced for go, in order to avoid having to keep those versions in sync, especially since `dependabot` will update go in the `go.mod` file, but not in `mise.toml`.

Note that this only impacts developers who use [`mise`](https://mise.jdx.dev/), and has no effect on building, or the CI, nor on the runtime or users.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added
