### PR TITLE
test(search): cover chinese search in the parity suite

### DIFF
--- a/services/search/pkg/parity/README.md
+++ b/services/search/pkg/parity/README.md
@@ -149,6 +149,50 @@ Fixtures:
 | CONTENT-09 | `Content:"alan@example.org"` | links.txt | links.txt | links.txt | ✅ |
 | CONTENT-10 | `Content:opencloud` | links.txt | links.txt | links.txt | ✅ |
 
+### cjk
+
+Fixtures:
+
+- `报告.txt`, Content = "这是一个关于年度销售的中文文档"
+- `说明书.pdf`, MimeType = application/pdf, Content = "产品说明与安装步骤"
+- `手册.txt`, Content = "学生手册"
+- `图片`, folder
+- `english.txt`, Content = "annual sales report"
+
+| Case | Query | expected | bleve | OpenSearch | same? |
+|---|---|---|---|---|---|
+| CJK-01 | `Content:中文` | 报告.txt | 报告.txt | 报告.txt | ✅ |
+| CJK-02 | `Content:中文文档` | 报告.txt | 报告.txt | 报告.txt | ✅ |
+| CJK-03 | `Content:"中文文档"` | 报告.txt | 报告.txt | 报告.txt | ✅ |
+| CJK-04 | `Content:销售` | 报告.txt | 报告.txt | 报告.txt | ✅ |
+| CJK-05 | `Content:说明` | 说明书.pdf | 说明书.pdf | 说明书.pdf | ✅ |
+| CJK-06 | `name:报告` | 报告.txt | 报告.txt | 报告.txt | ✅ |
+| CJK-07 | `name:"*报告*"` | 报告.txt | 报告.txt | 报告.txt | ✅ |
+| CJK-08 | `name:"报告.txt"` | 报告.txt | 报告.txt | 报告.txt | ✅ |
+| CJK-09 | `报告` | 报告.txt | 报告.txt | 报告.txt | ✅ |
+| CJK-10 | `说明书` | 说明书.pdf | 说明书.pdf | 说明书.pdf | ✅ |
+| CJK-11 | `name:图片` | 图片 | 图片 | 图片 | ✅ |
+| CJK-12 | `name:"*图片*"` | 图片 | 图片 | 图片 | ✅ |
+| CJK-13 | `图片` | 图片 | 图片 | 图片 | ✅ |
+| CJK-14 | `Content:学生` | 手册.txt | 手册.txt | 手册.txt | ✅ |
+| CJK-15 | `Content:手册` | 手册.txt | 手册.txt | 手册.txt | ✅ |
+| CJK-16 | `Content:生手` | 手册.txt | 手册.txt | 手册.txt | ✅ |
+| CJK-17 | `name:"报*"` | 报告.txt | 报告.txt | 报告.txt | ✅ |
+| CJK-18 | `name:"*告*"` | 报告.txt | 报告.txt | 报告.txt | ✅ |
+| CJK-19 | `name:"*册*"` | 手册.txt | 手册.txt | 手册.txt | ✅ |
+| CJK-20 | `name:"图?"` | 图片 | 图片 | 图片 | ✅ |
+| CJK-21 | `name:"报?.txt"` | 报告.txt | 报告.txt | 报告.txt | ✅ |
+| CJK-22 | `name:"*报?*"` | 报告.txt | 报告.txt | 报告.txt | ✅ |
+| CJK-23 | `Content:中文*` | no match | no match | no match | ✅ |
+| CJK-24 | `Content:*销售*` | no match | no match | no match | ✅ |
+| CJK-25 | `Content:*文档` | no match | no match | no match | ✅ |
+| CJK-26 | `Content:文*` | 报告.txt | 报告.txt | 报告.txt | ✅ |
+| CJK-27 | `Content:*文*` | 报告.txt | 报告.txt | 报告.txt | ✅ |
+| CJK-28 | `Content:*文` | 报告.txt | 报告.txt | 报告.txt | ✅ |
+| CJK-29 | `Content:销*` | 报告.txt | 报告.txt | 报告.txt | ✅ |
+| CJK-30 | `Content:说*` | 说明书.pdf | 说明书.pdf | 说明书.pdf | ✅ |
+| CJK-31 | `Content:*明` | 说明书.pdf | 说明书.pdf | 说明书.pdf | ✅ |
+
 ### favorites
 
 Fixtures:

--- a/services/search/pkg/parity/parity_test.go
+++ b/services/search/pkg/parity/parity_test.go
@@ -97,6 +97,7 @@ func queryGroups() []queryGroup {
 		tagsGroup(),
 		titleGroup(),
 		contentGroup(),
+		cjkGroup(),
 		favoritesGroup(),
 		mediatypeGroup(),
 		pathGroup(),

--- a/services/search/pkg/parity/query_cjk_test.go
+++ b/services/search/pkg/parity/query_cjk_test.go
@@ -1,0 +1,51 @@
+package parity
+
+import (
+	"github.com/opencloud-eu/opencloud/services/search/pkg/search"
+)
+
+func cjkGroup() queryGroup {
+	return queryGroup{
+		name: "cjk",
+		fixtures: []search.Resource{
+			fixtureDoc("报告.txt", withContent("这是一个关于年度销售的中文文档")),
+			fixtureDoc("说明书.pdf", withContent("产品说明与安装步骤"), withMime("application/pdf")),
+			fixtureDoc("手册.txt", withContent("学生手册")),
+			fixtureFolder("图片"),
+			fixtureDoc("english.txt", withContent("annual sales report")),
+		},
+		cases: []queryCase{
+			{id: 1, query: `Content:中文`, want: []string{"报告.txt"}},
+			{id: 2, query: `Content:中文文档`, want: []string{"报告.txt"}},
+			{id: 3, query: `Content:"中文文档"`, want: []string{"报告.txt"}},
+			{id: 4, query: `Content:销售`, want: []string{"报告.txt"}},
+			{id: 5, query: `Content:说明`, want: []string{"说明书.pdf"}},
+			{id: 6, query: `name:报告`, want: []string{"报告.txt"}},
+			{id: 7, query: `name:"*报告*"`, want: []string{"报告.txt"}},
+			{id: 8, query: `name:"报告.txt"`, want: []string{"报告.txt"}},
+			{id: 9, query: `报告`, want: []string{"报告.txt"}},
+			{id: 10, query: `说明书`, want: []string{"说明书.pdf"}},
+			{id: 11, query: `name:图片`, want: []string{"图片"}},
+			{id: 12, query: `name:"*图片*"`, want: []string{"图片"}},
+			{id: 13, query: `图片`, want: []string{"图片"}},
+			{id: 14, query: `Content:学生`, want: []string{"手册.txt"}},
+			{id: 15, query: `Content:手册`, want: []string{"手册.txt"}},
+			{id: 16, query: `Content:生手`, want: []string{"手册.txt"}},
+			{id: 17, query: `name:"报*"`, want: []string{"报告.txt"}},
+			{id: 18, query: `name:"*告*"`, want: []string{"报告.txt"}},
+			{id: 19, query: `name:"*册*"`, want: []string{"手册.txt"}},
+			{id: 20, query: `name:"图?"`, want: []string{"图片"}},
+			{id: 21, query: `name:"报?.txt"`, want: []string{"报告.txt"}},
+			{id: 22, query: `name:"*报?*"`, want: []string{"报告.txt"}},
+			{id: 23, query: `Content:中文*`},
+			{id: 24, query: `Content:*销售*`},
+			{id: 25, query: `Content:*文档`},
+			{id: 26, query: `Content:文*`, want: []string{"报告.txt"}},
+			{id: 27, query: `Content:*文*`, want: []string{"报告.txt"}},
+			{id: 28, query: `Content:*文`, want: []string{"报告.txt"}},
+			{id: 29, query: `Content:销*`, want: []string{"报告.txt"}},
+			{id: 30, query: `Content:说*`, want: []string{"说明书.pdf"}},
+			{id: 31, query: `Content:*明`, want: []string{"说明书.pdf"}},
+		},
+	}
+}


### PR DESCRIPTION
## Description
the old search implementation (bleve & openSearch) had problems finding cjk strings, this was solved but never proven, the pr just extends the parity search suite and proves that it works.

## Related Issue
- https://github.com/opencloud-eu/opencloud/issues/3430

## How Has This Been Tested?
- parity test suite

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [X] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [X] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added
