### PR TITLE
feat: support $expand=children on the driveItem endpoint

### DIFF
--- a/services/graph/pkg/service/v0/driveitems.go
+++ b/services/graph/pkg/service/v0/driveitems.go
@@ -38,7 +38,6 @@ const _selectAllowedValues = "@libre.graph.permissions.actions.allowedValues"
 // opt-in driveItem relations, returned only when requested via $expand
 const _expandChildren = "children"
 
-// odataListContains reports whether the given comma separated odata query parameter contains value
 func odataListContains(r *http.Request, parameter, value string) bool {
 	for _, values := range r.URL.Query()[parameter] {
 		for _, v := range strings.Split(values, ",") {
@@ -55,7 +54,7 @@ func driveItemPropertySelected(r *http.Request, property string) bool {
 	return odataListContains(r, "$select", property)
 }
 
-// driveItemRelationExpanded reports whether the given opt-in relation was requested via $expand
+// driveItemRelationExpanded reports whether the relation was requested via $expand
 func driveItemRelationExpanded(r *http.Request, relation string) bool {
 	return odataListContains(r, "$expand", relation)
 }
@@ -315,7 +314,7 @@ func (g Graph) GetDriveItem(w http.ResponseWriter, r *http.Request) {
 		driveItem.LibreGraphPermissionsActionsAllowedValues = unifiedrole.CS3ResourcePermissionsToLibregraphActions(res.GetInfo().GetPermissionSet())
 	}
 
-	// only containers have children, for anything else the relation stays unset
+	// only containers have children
 	if driveItemRelationExpanded(r, _expandChildren) && res.GetInfo().GetType() == storageprovider.ResourceType_RESOURCE_TYPE_CONTAINER {
 		children, ok := g.listDriveItemChildren(w, r, &driveItemID)
 		if !ok {
@@ -365,8 +364,7 @@ func (g Graph) GetDriveItemChildren(w http.ResponseWriter, r *http.Request) {
 	render.JSON(w, r, &ListResponse{Value: files})
 }
 
-// listDriveItemChildren lists the children of the given container. Shared by
-// the children endpoint and by $expand=children so both return the same items.
+// listDriveItemChildren backs both the children endpoint and $expand=children.
 // It renders the error response itself and reports whether it succeeded.
 func (g Graph) listDriveItemChildren(w http.ResponseWriter, r *http.Request, driveItemID *storageprovider.ResourceId) ([]libregraph.DriveItem, bool) {
 	gatewayClient, err := g.gatewaySelector.Next()

--- a/services/graph/pkg/service/v0/driveitems.go
+++ b/services/graph/pkg/service/v0/driveitems.go
@@ -35,16 +35,29 @@ import (
 // opt-in driveItem instance annotations, returned only when requested via $select
 const _selectAllowedValues = "@libre.graph.permissions.actions.allowedValues"
 
-// driveItemPropertySelected reports whether the given opt-in property was requested via $select
-func driveItemPropertySelected(r *http.Request, property string) bool {
-	for _, values := range r.URL.Query()["$select"] {
+// opt-in driveItem relations, returned only when requested via $expand
+const _expandChildren = "children"
+
+// odataListContains reports whether the given comma separated odata query parameter contains value
+func odataListContains(r *http.Request, parameter, value string) bool {
+	for _, values := range r.URL.Query()[parameter] {
 		for _, v := range strings.Split(values, ",") {
-			if v == property {
+			if v == value {
 				return true
 			}
 		}
 	}
 	return false
+}
+
+// driveItemPropertySelected reports whether the given opt-in property was requested via $select
+func driveItemPropertySelected(r *http.Request, property string) bool {
+	return odataListContains(r, "$select", property)
+}
+
+// driveItemRelationExpanded reports whether the given opt-in relation was requested via $expand
+func driveItemRelationExpanded(r *http.Request, relation string) bool {
+	return odataListContains(r, "$expand", relation)
 }
 
 // CreateUploadSession create an upload session to allow your app to upload files up to the maximum file size.
@@ -302,6 +315,18 @@ func (g Graph) GetDriveItem(w http.ResponseWriter, r *http.Request) {
 		driveItem.LibreGraphPermissionsActionsAllowedValues = unifiedrole.CS3ResourcePermissionsToLibregraphActions(res.GetInfo().GetPermissionSet())
 	}
 
+	// only containers have children, for anything else the relation stays unset
+	if driveItemRelationExpanded(r, _expandChildren) && res.GetInfo().GetType() == storageprovider.ResourceType_RESOURCE_TYPE_CONTAINER {
+		children, ok := g.listDriveItemChildren(w, r, &driveItemID)
+		if !ok {
+			return
+		}
+		driveItem.Children = make([]libregraph.DriveItem, 0, len(children))
+		for _, child := range children {
+			driveItem.Children = append(driveItem.Children, *child)
+		}
+	}
+
 	render.Status(r, http.StatusOK)
 	render.JSON(w, r, &driveItem)
 }
@@ -309,7 +334,6 @@ func (g Graph) GetDriveItem(w http.ResponseWriter, r *http.Request) {
 // GetDriveItemChildren lists the children of a driveItem
 func (g Graph) GetDriveItemChildren(w http.ResponseWriter, r *http.Request) {
 	g.logger.Info().Msg("Calling GetDriveItemChildren")
-	ctx := r.Context()
 
 	driveID, err := parseIDParam(r, "driveID")
 	if err != nil {
@@ -335,43 +359,55 @@ func (g Graph) GetDriveItemChildren(w http.ResponseWriter, r *http.Request) {
 		}
 	*/
 
-	gatewayClient, err := g.gatewaySelector.Next()
-	if err != nil {
-		errorcode.GeneralException.Render(w, r, http.StatusInternalServerError, err.Error())
-		return
-	}
-
-	res, err := gatewayClient.ListContainer(ctx, &storageprovider.ListContainerRequest{
-		Ref: &storageprovider.Reference{ResourceId: &driveItemID},
-	})
-	switch {
-	case err != nil:
-		errorcode.GeneralException.Render(w, r, http.StatusInternalServerError, err.Error())
-		return
-	case res.GetStatus().GetCode() == cs3rpc.Code_CODE_OK:
-		// ok
-	case res.GetStatus().GetCode() == cs3rpc.Code_CODE_NOT_FOUND:
-		errorcode.ItemNotFound.Render(w, r, http.StatusNotFound, res.GetStatus().GetMessage())
-		return
-	case res.GetStatus().GetCode() == cs3rpc.Code_CODE_PERMISSION_DENIED:
-		errorcode.ItemNotFound.Render(w, r, http.StatusNotFound, res.GetStatus().GetMessage()) // do not leak existence? check what graph does
-		return
-	case res.GetStatus().GetCode() == cs3rpc.Code_CODE_UNAUTHENTICATED:
-		errorcode.Unauthenticated.Render(w, r, http.StatusUnauthorized, res.GetStatus().GetMessage()) // do not leak existence? check what graph does
-		return
-	default:
-		errorcode.GeneralException.Render(w, r, http.StatusInternalServerError, res.GetStatus().GetMessage())
-		return
-	}
-
-	files, err := formatDriveItems(g.logger, g.publicBaseURL, res.GetInfos())
-	if err != nil {
-		errorcode.GeneralException.Render(w, r, http.StatusInternalServerError, err.Error())
+	files, ok := g.listDriveItemChildren(w, r, &driveItemID)
+	if !ok {
 		return
 	}
 
 	render.Status(r, http.StatusOK)
 	render.JSON(w, r, &ListResponse{Value: files})
+}
+
+// listDriveItemChildren lists the children of the given container. Shared by
+// the children endpoint and by $expand=children so both return the same items.
+// It renders the error response itself and reports whether it succeeded.
+func (g Graph) listDriveItemChildren(w http.ResponseWriter, r *http.Request, driveItemID *storageprovider.ResourceId) ([]*libregraph.DriveItem, bool) {
+	gatewayClient, err := g.gatewaySelector.Next()
+	if err != nil {
+		errorcode.GeneralException.Render(w, r, http.StatusInternalServerError, err.Error())
+		return nil, false
+	}
+
+	res, err := gatewayClient.ListContainer(r.Context(), &storageprovider.ListContainerRequest{
+		Ref: &storageprovider.Reference{ResourceId: driveItemID},
+	})
+	switch {
+	case err != nil:
+		errorcode.GeneralException.Render(w, r, http.StatusInternalServerError, err.Error())
+		return nil, false
+	case res.GetStatus().GetCode() == cs3rpc.Code_CODE_OK:
+		// ok
+	case res.GetStatus().GetCode() == cs3rpc.Code_CODE_NOT_FOUND:
+		errorcode.ItemNotFound.Render(w, r, http.StatusNotFound, res.GetStatus().GetMessage())
+		return nil, false
+	case res.GetStatus().GetCode() == cs3rpc.Code_CODE_PERMISSION_DENIED:
+		errorcode.ItemNotFound.Render(w, r, http.StatusNotFound, res.GetStatus().GetMessage()) // do not leak existence? check what graph does
+		return nil, false
+	case res.GetStatus().GetCode() == cs3rpc.Code_CODE_UNAUTHENTICATED:
+		errorcode.Unauthenticated.Render(w, r, http.StatusUnauthorized, res.GetStatus().GetMessage()) // do not leak existence? check what graph does
+		return nil, false
+	default:
+		errorcode.GeneralException.Render(w, r, http.StatusInternalServerError, res.GetStatus().GetMessage())
+		return nil, false
+	}
+
+	files, err := formatDriveItems(g.logger, g.publicBaseURL, res.GetInfos())
+	if err != nil {
+		errorcode.GeneralException.Render(w, r, http.StatusInternalServerError, err.Error())
+		return nil, false
+	}
+
+	return files, true
 }
 
 func (g Graph) getRemoteItem(ctx context.Context, root *storageprovider.ResourceId, baseURL *url.URL) (*libregraph.RemoteItem, error) {

--- a/services/graph/pkg/service/v0/driveitems.go
+++ b/services/graph/pkg/service/v0/driveitems.go
@@ -364,8 +364,6 @@ func (g Graph) GetDriveItemChildren(w http.ResponseWriter, r *http.Request) {
 	render.JSON(w, r, &ListResponse{Value: files})
 }
 
-// listDriveItemChildren backs both the children endpoint and $expand=children.
-// It renders the error response itself and reports whether it succeeded.
 func (g Graph) listDriveItemChildren(w http.ResponseWriter, r *http.Request, driveItemID *storageprovider.ResourceId) ([]libregraph.DriveItem, bool) {
 	gatewayClient, err := g.gatewaySelector.Next()
 	if err != nil {

--- a/services/graph/pkg/service/v0/driveitems.go
+++ b/services/graph/pkg/service/v0/driveitems.go
@@ -321,10 +321,7 @@ func (g Graph) GetDriveItem(w http.ResponseWriter, r *http.Request) {
 		if !ok {
 			return
 		}
-		driveItem.Children = make([]libregraph.DriveItem, 0, len(children))
-		for _, child := range children {
-			driveItem.Children = append(driveItem.Children, *child)
-		}
+		driveItem.Children = children
 	}
 
 	render.Status(r, http.StatusOK)
@@ -371,7 +368,7 @@ func (g Graph) GetDriveItemChildren(w http.ResponseWriter, r *http.Request) {
 // listDriveItemChildren lists the children of the given container. Shared by
 // the children endpoint and by $expand=children so both return the same items.
 // It renders the error response itself and reports whether it succeeded.
-func (g Graph) listDriveItemChildren(w http.ResponseWriter, r *http.Request, driveItemID *storageprovider.ResourceId) ([]*libregraph.DriveItem, bool) {
+func (g Graph) listDriveItemChildren(w http.ResponseWriter, r *http.Request, driveItemID *storageprovider.ResourceId) ([]libregraph.DriveItem, bool) {
 	gatewayClient, err := g.gatewaySelector.Next()
 	if err != nil {
 		errorcode.GeneralException.Render(w, r, http.StatusInternalServerError, err.Error())
@@ -448,14 +445,14 @@ func (g Graph) getRemoteItem(ctx context.Context, root *storageprovider.Resource
 	return item, nil
 }
 
-func formatDriveItems(logger *log.Logger, publicBaseURL *url.URL, mds []*storageprovider.ResourceInfo) ([]*libregraph.DriveItem, error) {
-	responses := make([]*libregraph.DriveItem, 0, len(mds))
+func formatDriveItems(logger *log.Logger, publicBaseURL *url.URL, mds []*storageprovider.ResourceInfo) ([]libregraph.DriveItem, error) {
+	responses := make([]libregraph.DriveItem, 0, len(mds))
 	for i := range mds {
 		res, err := cs3ResourceToDriveItem(logger, publicBaseURL, mds[i])
 		if err != nil {
 			return nil, err
 		}
-		responses = append(responses, res)
+		responses = append(responses, *res)
 	}
 
 	return responses, nil

--- a/services/graph/pkg/service/v0/driveitems.go
+++ b/services/graph/pkg/service/v0/driveitems.go
@@ -315,7 +315,7 @@ func (g Graph) GetDriveItem(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// only containers have children
-	if driveItemRelationExpanded(r, _expandChildren) && res.GetInfo().GetType() == storageprovider.ResourceType_RESOURCE_TYPE_CONTAINER {
+	if res.GetInfo().GetType() == storageprovider.ResourceType_RESOURCE_TYPE_CONTAINER && driveItemRelationExpanded(r, _expandChildren) {
 		children, ok := g.listDriveItemChildren(w, r, &driveItemID)
 		if !ok {
 			return

--- a/services/graph/pkg/service/v0/driveitems_test.go
+++ b/services/graph/pkg/service/v0/driveitems_test.go
@@ -243,6 +243,100 @@ var _ = Describe("Driveitems", func() {
 		})
 	})
 
+	Describe("GetDriveItem", func() {
+		var (
+			folderInfo *provider.ResourceInfo
+			mtime      = time.Now()
+		)
+
+		newRequest := func(query string) *http.Request {
+			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/drives/storageid$spaceid/items/storageid$spaceid!nodeid"+query, nil)
+			rctx := chi.NewRouteContext()
+			rctx.URLParams.Add("driveID", "storageid$spaceid")
+			rctx.URLParams.Add("driveItemID", "storageid$spaceid!nodeid")
+			return r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
+		}
+
+		getItem := func(r *http.Request) libregraph.DriveItem {
+			svc.GetDriveItem(rr, r)
+			Expect(rr.Code).To(Equal(http.StatusOK))
+			data, err := io.ReadAll(rr.Body)
+			Expect(err).ToNot(HaveOccurred())
+
+			item := libregraph.DriveItem{}
+			Expect(json.Unmarshal(data, &item)).To(Succeed())
+			return item
+		}
+
+		BeforeEach(func() {
+			folderInfo = &provider.ResourceInfo{
+				Type:  provider.ResourceType_RESOURCE_TYPE_CONTAINER,
+				Id:    &provider.ResourceId{StorageId: "storageid", SpaceId: "spaceid", OpaqueId: "nodeid"},
+				Etag:  "etag",
+				Mtime: utils.TimeToTS(mtime),
+			}
+			gatewayClient.On("Stat", mock.Anything, mock.Anything).Return(&provider.StatResponse{
+				Status: status.NewOK(ctx),
+				Info:   folderInfo,
+			}, nil)
+			gatewayClient.On("ListContainer", mock.Anything, mock.Anything).Return(&provider.ListContainerResponse{
+				Status: status.NewOK(ctx),
+				Infos: []*provider.ResourceInfo{
+					{
+						Type:  provider.ResourceType_RESOURCE_TYPE_FILE,
+						Id:    &provider.ResourceId{StorageId: "storageid", SpaceId: "spaceid", OpaqueId: "opaqueid"},
+						Etag:  "etag",
+						Mtime: utils.TimeToTS(mtime),
+					},
+				},
+			}, nil)
+		})
+
+		It("leaves children unset without $expand", func() {
+			Expect(getItem(newRequest("")).Children).To(BeNil())
+			gatewayClient.AssertNotCalled(GinkgoT(), "ListContainer", mock.Anything, mock.Anything)
+		})
+
+		It("returns the children when requested via $expand", func() {
+			item := getItem(newRequest("?$expand=children"))
+			Expect(item.Children).To(HaveLen(1))
+			Expect(item.Children[0].GetId()).To(Equal("storageid$spaceid!opaqueid"))
+			Expect(item.Children[0].GetETag()).To(Equal("etag"))
+		})
+
+		It("leaves children unset for a file", func() {
+			folderInfo.Type = provider.ResourceType_RESOURCE_TYPE_FILE
+
+			Expect(getItem(newRequest("?$expand=children")).Children).To(BeNil())
+			gatewayClient.AssertNotCalled(GinkgoT(), "ListContainer", mock.Anything, mock.Anything)
+		})
+	})
+
+	Describe("GetDriveItem $expand=children error", func() {
+		It("propagates a failing child listing", func() {
+			gatewayClient.On("Stat", mock.Anything, mock.Anything).Return(&provider.StatResponse{
+				Status: status.NewOK(ctx),
+				Info: &provider.ResourceInfo{
+					Type:  provider.ResourceType_RESOURCE_TYPE_CONTAINER,
+					Id:    &provider.ResourceId{StorageId: "storageid", SpaceId: "spaceid", OpaqueId: "nodeid"},
+					Mtime: utils.TimeToTS(time.Now()),
+				},
+			}, nil)
+			gatewayClient.On("ListContainer", mock.Anything, mock.Anything).Return(&provider.ListContainerResponse{
+				Status: status.NewNotFound(ctx, "not found"),
+			}, nil)
+
+			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/drives/storageid$spaceid/items/storageid$spaceid!nodeid?$expand=children", nil)
+			rctx := chi.NewRouteContext()
+			rctx.URLParams.Add("driveID", "storageid$spaceid")
+			rctx.URLParams.Add("driveItemID", "storageid$spaceid!nodeid")
+			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
+
+			svc.GetDriveItem(rr, r)
+			Expect(rr.Code).To(Equal(http.StatusNotFound))
+		})
+	})
+
 	Describe("GetDriveItemChildren", func() {
 		It("handles ListContainer not found", func() {
 			gatewayClient.On("ListContainer", mock.Anything, mock.Anything).Return(&provider.ListContainerResponse{


### PR DESCRIPTION
Implements `$expand=children` on `GET /v1.0|v1beta1/drives/{drive-id}/items/{item-id}`, the server side of opencloud-eu/libre-graph-api#68.

A folder listing currently needs two requests against graph (stat the folder, then list its children), where a single WebDAV `PROPFIND` with `Depth: 1` returns both at once. With `$expand=children` clients get back to one request.

The children come from the same code path as the `/children` endpoint: the listing was moved into `listDriveItemChildren` and both callers share it, so the items and the error responses are identical. `$expand` is parsed by a helper mirroring the existing `$select` one. The relation stays unset for anything that is not a container.

No SDK bump needed, `children` is already part of the vendored `driveItem` model.
