### PR TITLE
fix: log jwt expired on debug level instead of error

### DIFF
--- a/services/proxy/pkg/middleware/oidc_auth.go
+++ b/services/proxy/pkg/middleware/oidc_auth.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/pkg/errors"
 	"github.com/vmihailenco/msgpack/v5"
 	"go-micro.dev/v4/store"
@@ -186,6 +187,13 @@ func verifyExpiresAt(claims map[string]any, cmp time.Time) bool {
 	return cmp.Before(expiry)
 }
 
+// isExpectedTokenTimeError reports whether the error is caused by a token that
+// failed its expiry (or not-before) validation. These are expected as part of
+// the normal token renewal cycle and should not be logged at error level.
+func isExpectedTokenTimeError(err error) bool {
+	return errors.Is(err, jwt.ErrTokenExpired) || errors.Is(err, jwt.ErrTokenNotValidYet)
+}
+
 func (m OIDCAuthenticator) shouldServe(req *http.Request) bool {
 	if m.OIDCIss == "" {
 		return false
@@ -212,7 +220,17 @@ func (m *OIDCAuthenticator) Authenticate(r *http.Request) (*http.Request, bool) 
 	claims, newSession, err := m.getClaims(token, r)
 	if err != nil {
 		host, port, _ := net.SplitHostPort(r.RemoteAddr)
-		m.Logger.Error().
+
+		// Expired (or not yet valid) tokens are a normal part of the token
+		// renewal cycle: the client hits the proxy with a token that is just
+		// past its expiry, receives a 401 challenge and refreshes. This is not
+		// a failure of the proxy, so we log it at debug level to avoid noise.
+		logEvent := m.Logger.Debug()
+		if !isExpectedTokenTimeError(err) {
+			logEvent = m.Logger.Error()
+		}
+
+		logEvent.
 			Err(err).
 			Str("authenticator", "oidc").
 			Str("path", r.URL.Path).

--- a/services/proxy/pkg/middleware/oidc_auth_test.go
+++ b/services/proxy/pkg/middleware/oidc_auth_test.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"bytes"
 	"net/http"
 	"net/http/httptest"
 	"time"
@@ -11,6 +12,7 @@ import (
 	"github.com/opencloud-eu/opencloud/pkg/log"
 	"github.com/opencloud-eu/opencloud/pkg/oidc"
 	oidcmocks "github.com/opencloud-eu/opencloud/pkg/oidc/mocks"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/mock"
 	"go-micro.dev/v4/store"
 )
@@ -108,20 +110,22 @@ var _ = Describe("Authenticating requests", Label("OIDCAuthenticator"), func() {
 	})
 
 	When("the request contains an expired token", func() {
-		It("should reject the request", func() {
-			ocExpired := oidcmocks.OIDCClient{}
-			ocExpired.On("VerifyAccessToken", mock.Anything, mock.Anything).Return(
+		var buf bytes.Buffer
+		expiredAuthenticator := &OIDCAuthenticator{
+			OIDCIss:       "http://idp.example.com",
+			Logger:        log.Logger{zerolog.New(&buf).Level(zerolog.DebugLevel)},
+			oidcClient: &oidcmocks.OIDCClient{},
+			userInfoCache: store.NewMemoryStore(),
+			skipUserInfo:  true,
+		}
+
+		BeforeEach(func() {
+			expiredAuthenticator.oidcClient.(*oidcmocks.OIDCClient).On("VerifyAccessToken", mock.Anything, mock.Anything).Return(
 				oidc.RegClaimsWithSID{}, jwt.MapClaims{}, jwt.ErrTokenExpired,
 			)
+		})
 
-			expiredAuthenticator := &OIDCAuthenticator{
-				OIDCIss:       "http://idp.example.com",
-				Logger:        log.NewLogger(),
-				oidcClient:    &ocExpired,
-				userInfoCache: store.NewMemoryStore(),
-				skipUserInfo:  true,
-			}
-
+		It("should reject the request", func() {
 			req := httptest.NewRequest(http.MethodGet, "http://example.com/example/path", http.NoBody)
 			req.Header.Set(_headerAuthorization, "Bearer jwt.token.sig")
 
@@ -129,6 +133,44 @@ var _ = Describe("Authenticating requests", Label("OIDCAuthenticator"), func() {
 
 			Expect(valid).To(Equal(false))
 			Expect(req2).To(BeNil())
+		})
+
+		It("should log the authentication failure at debug level", func() {
+			req := httptest.NewRequest(http.MethodGet, "http://example.com/example/path", http.NoBody)
+			req.Header.Set(_headerAuthorization, "Bearer jwt.token.sig")
+
+			expiredAuthenticator.Authenticate(req)
+
+			Expect(buf.String()).To(ContainSubstring("failed to authenticate the request"))
+			Expect(buf.String()).To(ContainSubstring(`"level":"debug"`))
+			Expect(buf.String()).ToNot(ContainSubstring(`"level":"error"`))
+		})
+	})
+
+	When("the request contains a token that cannot be verified", func() {
+		var buf bytes.Buffer
+		failingAuthenticator := &OIDCAuthenticator{
+			OIDCIss:       "http://idp.example.com",
+			Logger:        log.Logger{zerolog.New(&buf).Level(zerolog.DebugLevel)},
+			oidcClient: &oidcmocks.OIDCClient{},
+			userInfoCache: store.NewMemoryStore(),
+			skipUserInfo:  true,
+		}
+
+		BeforeEach(func() {
+			failingAuthenticator.oidcClient.(*oidcmocks.OIDCClient).On("VerifyAccessToken", mock.Anything, mock.Anything).Return(
+				oidc.RegClaimsWithSID{}, jwt.MapClaims{}, jwt.ErrTokenMalformed,
+			)
+		})
+
+		It("should log the authentication failure at error level", func() {
+			req := httptest.NewRequest(http.MethodGet, "http://example.com/example/path", http.NoBody)
+			req.Header.Set(_headerAuthorization, "Bearer jwt.token.sig")
+
+			failingAuthenticator.Authenticate(req)
+
+			Expect(buf.String()).To(ContainSubstring("failed to authenticate the request"))
+			Expect(buf.String()).To(ContainSubstring(`"level":"error"`))
 		})
 	})
 })

--- a/services/proxy/pkg/middleware/oidc_auth_test.go
+++ b/services/proxy/pkg/middleware/oidc_auth_test.go
@@ -106,4 +106,29 @@ var _ = Describe("Authenticating requests", Label("OIDCAuthenticator"), func() {
 			Expect(req2).ToNot(BeNil())
 		})
 	})
+
+	When("the request contains an expired token", func() {
+		It("should reject the request", func() {
+			ocExpired := oidcmocks.OIDCClient{}
+			ocExpired.On("VerifyAccessToken", mock.Anything, mock.Anything).Return(
+				oidc.RegClaimsWithSID{}, jwt.MapClaims{}, jwt.ErrTokenExpired,
+			)
+
+			expiredAuthenticator := &OIDCAuthenticator{
+				OIDCIss:       "http://idp.example.com",
+				Logger:        log.NewLogger(),
+				oidcClient:    &ocExpired,
+				userInfoCache: store.NewMemoryStore(),
+				skipUserInfo:  true,
+			}
+
+			req := httptest.NewRequest(http.MethodGet, "http://example.com/example/path", http.NoBody)
+			req.Header.Set(_headerAuthorization, "Bearer jwt.token.sig")
+
+			req2, valid := expiredAuthenticator.Authenticate(req)
+
+			Expect(valid).To(Equal(false))
+			Expect(req2).To(BeNil())
+		})
+	})
 })


### PR DESCRIPTION
log jwt expired on debug level instead of error

closes #https://github.com/opencloud-eu/opencloud/issues/919