### PR TITLE
fix(proxy): restrict JWT signed urls to the allowed HTTP methods

### DIFF
--- a/services/proxy/pkg/middleware/signed_url_auth.go
+++ b/services/proxy/pkg/middleware/signed_url_auth.go
@@ -236,6 +236,16 @@ func (m SignedURLAuthenticator) Authenticate(r *http.Request) (*http.Request, bo
 }
 
 func (m SignedURLAuthenticator) authenticate(r *http.Request) (*http.Request, bool) {
+	if err := m.requestMethodIsAllowed(r.Method); err != nil {
+		m.Logger.Error().
+			Err(err).
+			Str("authenticator", "signed_url_jwt").
+			Str("path", r.URL.Path).
+			Str("method", r.Method).
+			Msg("Request method not allowed for signed urls")
+		return nil, false
+	}
+
 	u := r.URL.String()
 	if !r.URL.IsAbs() {
 		u = "https://" + r.Host + u

--- a/services/proxy/pkg/middleware/signed_url_auth_test.go
+++ b/services/proxy/pkg/middleware/signed_url_auth_test.go
@@ -2,11 +2,13 @@ package middleware
 
 import (
 	"context"
+	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
+	"github.com/opencloud-eu/opencloud/pkg/log"
 	"github.com/opencloud-eu/opencloud/services/proxy/pkg/config"
 	revactx "github.com/opencloud-eu/reva/v2/pkg/ctx"
 	"github.com/opencloud-eu/reva/v2/pkg/signedurl"
@@ -67,6 +69,27 @@ func TestSignedURLAuth_shouldServe(t *testing.T) {
 
 		if result != tt.expected {
 			t.Errorf("with %s expected %t got %t", tt.url, tt.expected, result)
+		}
+	}
+}
+
+func TestSignedURLAuth_authenticateRejectsDisallowedMethods(t *testing.T) {
+	signer, err := signedurl.NewJWTSignedURL(signedurl.WithSecret("secret"))
+	if err != nil {
+		t.Fatalf("failed to create signer: %v", err)
+	}
+	signed, err := signer.Sign("https://example.com/dav/spaces/file.txt", "userid", time.Minute)
+	if err != nil {
+		t.Fatalf("failed to sign url: %v", err)
+	}
+
+	pua := SignedURLAuthenticator{Logger: log.NewLogger(), URLVerifier: signer}
+	pua.PreSignedURLConfig.AllowedHTTPMethods = []string{"GET"}
+
+	for _, method := range []string{http.MethodPost, http.MethodPut, http.MethodDelete, "PROPFIND", "MOVE"} {
+		r := httptest.NewRequest(method, signed, nil)
+		if _, ok := pua.authenticate(r); ok {
+			t.Errorf("expected %s with a signed url to be rejected", method)
 		}
 	}
 }


### PR DESCRIPTION
The proxy verifies JWT signed URLs (`oc-jwt-sig`) without checking the request method, while the legacy `OC-Signature` path enforces `PRE_SIGNED_URL_ALLOWED_HTTP_METHODS` (default `GET`). A signed download URL handed out via `oc:downloadURL` or, with #3248, `@microsoft.graph.downloadUrl` therefore also authenticates PUT, DELETE, MOVE and PROPFIND as the signing user until it expires.

Applies the same allowed-methods check to the JWT path.