### PR TITLE
align the handler verifier, update docs

### DIFF
--- a/services/activitylog/pkg/config/parser/parse.go
+++ b/services/activitylog/pkg/config/parser/parse.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	occfg "github.com/opencloud-eu/opencloud/pkg/config"
+	"github.com/opencloud-eu/opencloud/pkg/shared"
 	"github.com/opencloud-eu/opencloud/services/activitylog/pkg/config"
 	"github.com/opencloud-eu/opencloud/services/activitylog/pkg/config/defaults"
 
@@ -34,5 +35,8 @@ func ParseConfig(cfg *config.Config) error {
 
 // Validate validates the config
 func Validate(cfg *config.Config) error {
+	if cfg.Events.Disabled && cfg.HTTP.Disabled {
+		return shared.AllComponentsDisabledError(cfg.Service.Name)
+	}
 	return nil
 }

--- a/services/frontend/README.md
+++ b/services/frontend/README.md
@@ -63,10 +63,6 @@ Store specific notes:
   -   When using `nats-js-kv` it is recommended to set `OC_CACHE_STORE_NODES` to the same value as `OC_EVENTS_ENDPOINT`. That way the cache uses the same nats instance as the event bus.
   -   When using the `nats-js-kv` store, it is possible to set `OC_CACHE_DISABLE_PERSISTENCE` to instruct nats to not persist cache data on disc.
 
-### Auto-Accept Shares
-
-When setting the `SHARING_AUTO_ACCEPT_SHARES` to `true` (sharing service), all incoming shares will be accepted automatically. Users can overwrite this setting individually in their profile. The deprecated `FRONTEND_AUTO_ACCEPT_SHARES` is still supported for backwards compatibility.
-
 ## Passwords
 
 ### The Password Policy

--- a/services/graph/pkg/config/parser/parse.go
+++ b/services/graph/pkg/config/parser/parse.go
@@ -40,11 +40,7 @@ func ParseConfig(cfg *config.Config) error {
 
 func Validate(cfg *config.Config) error {
 	if cfg.HTTP.Disabled && cfg.Events.DisabledConsumer {
-		// might be debatable, but this situation should be treated as an error,
-		// as the process wouldn't be able to serve either API and would thus be
-		// completely useless -- in that case, just don't start this service
-		// in the first place (especially since it's optional)
-		return shared.AllComponentsDisabledError("graph")
+		return shared.AllComponentsDisabledError(cfg.Service.Name)
 	}
 
 	if cfg.TokenManager.JWTSecret == "" {

--- a/services/policies/pkg/config/parser/parse.go
+++ b/services/policies/pkg/config/parser/parse.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	occfg "github.com/opencloud-eu/opencloud/pkg/config"
+	"github.com/opencloud-eu/opencloud/pkg/shared"
 	"github.com/opencloud-eu/opencloud/services/policies/pkg/config"
 	"github.com/opencloud-eu/opencloud/services/policies/pkg/config/defaults"
 
@@ -33,12 +34,8 @@ func ParseConfig(cfg *config.Config) error {
 }
 
 func Validate(cfg *config.Config) error {
-	if cfg.GRPC.Disabled && cfg.Events.Disabled {
-		// might be debatable, but this situation should be treated as an error,
-		// as the process wouldn't be able to serve either API and would thus be
-		// completely useless -- in that case, just don't start this service
-		// in the first place (especially since it's optional)
-		return errors.New("both gRPC and events APIs are disabled by configuration; at least one must be enabled")
+	if cfg.Events.Disabled && cfg.GRPC.Disabled {
+		return shared.AllComponentsDisabledError(cfg.Service.Name)
 	}
 	return nil
 }

--- a/services/search/pkg/config/parser/parse.go
+++ b/services/search/pkg/config/parser/parse.go
@@ -34,6 +34,10 @@ func ParseConfig(cfg *config.Config) error {
 }
 
 func Validate(cfg *config.Config) error {
+	if cfg.Events.Disabled && cfg.GRPC.Disabled {
+		return shared.AllComponentsDisabledError(cfg.Service.Name)
+	}
+
 	if cfg.TokenManager.JWTSecret == "" {
 		return shared.MissingJWTTokenError(cfg.Service.Name)
 	}

--- a/services/sharing/README.md
+++ b/services/sharing/README.md
@@ -35,7 +35,12 @@ Share behavior can be configured via environment variables:
 - Auto-acceptance of shares
 - Share permissions and restrictions
 
-See the `frontend` service README for more details on share-related configuration options.
+### Auto-Accept Shares
+
+When setting the `SHARING_AUTO_ACCEPT_SHARES` to `true` (sharing service), all
+incoming shares will be accepted automatically. Users can overwrite this
+setting individually in their profile. The deprecated
+`FRONTEND_AUTO_ACCEPT_SHARES` is still supported for backwards compatibility.
 
 ## Scalability
 


### PR DESCRIPTION
I aligned the validator in the sevices that allow disabling the event and request handlers individually. Also updated the docs after https://github.com/opencloud-eu/opencloud/pull/3389

part of https://github.com/opencloud-eu/opencloud/issues/1312