### PR TITLE
fix(proxy): suppress auth challenges for failed signed URLs

### DIFF
--- a/services/proxy/pkg/middleware/authentication.go
+++ b/services/proxy/pkg/middleware/authentication.go
@@ -50,6 +50,10 @@ type Authenticator interface {
 	Authenticate(*http.Request) (*http.Request, bool)
 }
 
+type authenticationChallengeSuppressor interface {
+	SuppressAuthenticationChallenge(*http.Request) bool
+}
+
 // Authentication is a higher order authentication middleware.
 func Authentication(auths []Authenticator, opts ...Option) func(next http.Handler) http.Handler {
 	options := newOptions(opts...)
@@ -76,15 +80,19 @@ func Authentication(auths []Authenticator, opts ...Option) func(next http.Handle
 				return
 			}
 
+			suppressAuthenticationChallenge := false
 			for _, a := range auths {
 				if req, ok := a.Authenticate(r); ok {
 					span.End()
 					next.ServeHTTP(w, req)
 					return
 				}
+				if suppressor, ok := a.(authenticationChallengeSuppressor); ok && suppressor.SuppressAuthenticationChallenge(r) {
+					suppressAuthenticationChallenge = true
+				}
 			}
 
-			if !isPublicPath(r.URL.Path) {
+			if !suppressAuthenticationChallenge && !isPublicPath(r.URL.Path) {
 				// Failed basic authentication attempts receive the Www-Authenticate header in the response
 				var touch bool
 				caser := cases.Title(language.Und)
@@ -103,8 +111,10 @@ func Authentication(auths []Authenticator, opts ...Option) func(next http.Handle
 				}
 			}
 
-			for _, s := range SupportedAuthStrategies {
-				userAgentAuthenticateLockIn(w, r, options.CredentialsByUserAgent, s)
+			if !suppressAuthenticationChallenge {
+				for _, s := range SupportedAuthStrategies {
+					userAgentAuthenticateLockIn(w, r, options.CredentialsByUserAgent, s)
+				}
 			}
 			w.WriteHeader(http.StatusUnauthorized)
 			// if the request is a PROPFIND return a WebDAV error code.

--- a/services/proxy/pkg/middleware/signed_url_auth.go
+++ b/services/proxy/pkg/middleware/signed_url_auth.go
@@ -65,6 +65,16 @@ func (m SignedURLAuthenticator) shouldServe(req *http.Request) bool {
 	return req.URL.Query().Get(_paramOCJWTSig) != ""
 }
 
+// SuppressAuthenticationChallenge prevents other authentication mechanisms from challenging signed URL clients.
+// Requests that carry an Authorization header are not suppressed, so clients that additionally sent
+// (possibly stale) credentials still receive a challenge and can re-authenticate.
+func (m SignedURLAuthenticator) SuppressAuthenticationChallenge(req *http.Request) bool {
+	if req.Header.Get("Authorization") != "" {
+		return false
+	}
+	return m.shouldServeLegacy(req) || m.shouldServe(req)
+}
+
 func (m SignedURLAuthenticator) validate(req *http.Request) (err error) {
 	query := req.URL.Query()
 

--- a/services/proxy/pkg/middleware/signed_url_auth_test.go
+++ b/services/proxy/pkg/middleware/signed_url_auth_test.go
@@ -10,9 +10,13 @@ import (
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	"github.com/opencloud-eu/opencloud/pkg/log"
 	"github.com/opencloud-eu/opencloud/services/proxy/pkg/config"
+	"github.com/opencloud-eu/opencloud/services/proxy/pkg/router"
+	"github.com/opencloud-eu/opencloud/services/proxy/pkg/user/backend"
+	backendmocks "github.com/opencloud-eu/opencloud/services/proxy/pkg/user/backend/mocks"
 	revactx "github.com/opencloud-eu/reva/v2/pkg/ctx"
 	"github.com/opencloud-eu/reva/v2/pkg/signedurl"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"go-micro.dev/v4/store"
 )
 
@@ -91,6 +95,88 @@ func TestSignedURLAuth_authenticateRejectsDisallowedMethods(t *testing.T) {
 		if _, ok := pua.authenticate(r); ok {
 			t.Errorf("expected %s with a signed url to be rejected", method)
 		}
+	}
+}
+
+func TestSignedURLAuthFailureSuppressesAuthenticationChallenge(t *testing.T) {
+	oldStrategies := SupportedAuthStrategies
+	SupportedAuthStrategies = nil
+	t.Cleanup(func() { SupportedAuthStrategies = oldStrategies })
+
+	verifier, err := signedurl.NewJWTSignedURL(signedurl.WithSecret("secret"))
+	if err != nil {
+		t.Fatalf("failed to create signed URL verifier: %v", err)
+	}
+	userProvider := &backendmocks.UserBackend{}
+	userProvider.On("GetUserByClaims", mock.Anything, "username", "").Return(nil, "", backend.ErrAccountNotFound)
+
+	tests := []struct {
+		name              string
+		url               string
+		authenticator     SignedURLAuthenticator
+		expectedChallenge bool
+	}{
+		{
+			name: "invalid signed URL",
+			url:  "https://example.com/file?oc-jwt-sig=invalid",
+			authenticator: SignedURLAuthenticator{
+				Logger:             log.NewLogger(),
+				PreSignedURLConfig: config.PreSignedURL{AllowedHTTPMethods: []string{http.MethodGet}},
+				URLVerifier:        verifier,
+			},
+			expectedChallenge: false,
+		},
+		{
+			name: "invalid legacy signed URL",
+			url:  "https://example.com/file?OC-Signature=invalid",
+			authenticator: SignedURLAuthenticator{
+				Logger:             log.NewLogger(),
+				PreSignedURLConfig: config.PreSignedURL{Enabled: true},
+				UserProvider:       userProvider,
+			},
+			expectedChallenge: false,
+		},
+		{
+			name:              "legacy signed URLs disabled",
+			url:               "https://example.com/file?OC-Signature=invalid",
+			authenticator:     SignedURLAuthenticator{},
+			expectedChallenge: true,
+		},
+		{
+			name:              "signed URL verifier disabled",
+			url:               "https://example.com/file?oc-jwt-sig=invalid",
+			authenticator:     SignedURLAuthenticator{},
+			expectedChallenge: true,
+		},
+		{
+			name:              "unsigned URL",
+			url:               "https://example.com/file",
+			authenticator:     SignedURLAuthenticator{URLVerifier: verifier},
+			expectedChallenge: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			SupportedAuthStrategies = nil
+			req := httptest.NewRequest(http.MethodGet, tt.url, nil)
+			req = req.WithContext(router.SetRoutingInfo(req.Context(), router.RoutingInfo{}))
+			rr := httptest.NewRecorder()
+			nextCalled := false
+			handler := Authentication([]Authenticator{tt.authenticator}, EnableBasicAuth(true))(
+				http.HandlerFunc(func(http.ResponseWriter, *http.Request) { nextCalled = true }),
+			)
+
+			handler.ServeHTTP(rr, req)
+
+			assert.Equal(t, http.StatusUnauthorized, rr.Code)
+			assert.False(t, nextCalled)
+			if tt.expectedChallenge {
+				assert.NotEmpty(t, rr.Header().Values(WwwAuthenticate))
+			} else {
+				assert.Empty(t, rr.Header().Values(WwwAuthenticate))
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Do not set WWW-Authenticate headers when an active signed URL authentication attempt fails. Signed URL clients cannot respond to Basic or Bearer challenges, and advertising them may trigger unintended authentication prompts.

Keep returning 401 Unauthorized while preserving the existing challenge behavior for unsigned requests and disabled signed URL mechanisms.

Related issue: https://github.com/opencloud-eu/web/issues/3282