### PR TITLE
add insecure to search reindex

### DIFF
--- a/services/search/MIGRATION.md
+++ b/services/search/MIGRATION.md
@@ -13,7 +13,7 @@ Fill the new index by indexing all spaces again:
 
 ```shell
 # the service keeps running while it happens
-opencloud search index --all-spaces
+opencloud search index --all-spaces --insecure
 ```
 
 Once the new index is filled, every index but the one with the highest
@@ -31,7 +31,7 @@ The new index is a directory next to the old `bleve` one, both in
 bleve index cannot be copied, index all spaces again:
 
 ```shell
-opencloud search index --all-spaces
+opencloud search index --all-spaces --insecure
 ```
 
 Once the new index is filled, every directory but the one with the highest

--- a/services/search/README.md
+++ b/services/search/README.md
@@ -124,14 +124,14 @@ opencloud search index --space $SPACE_ID
 It can also be used to re-index all spaces:
 
 ```shell
-opencloud search index --all-spaces
+opencloud search index --all-spaces --insecure
 ```
 
 Please note that a reindex only picks up new or changed files. Files that have already been indexed are not scanned again, even if the configuration or the whole extractor has been changed. To force a full rescan (re-running the extractor on every file) you need to use the `force-rescan` flag:
 
 
 ```shell
-opencloud search index --all-spaces --force-rescan
+opencloud search index --all-spaces --force-rescan --insecure
 ```
 
 ## Metrics

--- a/services/search/pkg/mapping/reconcile.go
+++ b/services/search/pkg/mapping/reconcile.go
@@ -27,7 +27,7 @@ func Reconcile(index string, r SchemaReconciler, logger log.Logger) (Classificat
 	case VerdictAdditive:
 		persisted, err := r.ApplyAdditive()
 		if persisted {
-			logger.Warn().Strs("fields", classification.NewFields).Str("index", index).Msg("extended the search index mapping with new fields; documents indexed before the upgrade do not contain them and queries on these fields will miss those documents until they are re-indexed; to re-index everything run: opencloud search index --all-spaces --force-rescan")
+			logger.Warn().Strs("fields", classification.NewFields).Str("index", index).Msg("extended the search index mapping with new fields; documents indexed before the upgrade do not contain them and queries on these fields will miss those documents until they are re-indexed; to re-index everything run: opencloud search index --all-spaces --force-rescan --insecure")
 		}
 		if err != nil {
 			return classification, err
@@ -40,5 +40,5 @@ func Reconcile(index string, r SchemaReconciler, logger log.Logger) (Classificat
 // LogNewIndexCreated logs that a fresh, empty index was created and how to
 // backfill it. The create path does not run through Reconcile.
 func LogNewIndexCreated(logger log.Logger, index string) {
-	logger.Info().Str("index", index).Msg("created a new empty search index; if this OpenCloud instance already held files, they are not in it yet, index them by running: opencloud search index --all-spaces --force-rescan")
+	logger.Info().Str("index", index).Msg("created a new empty search index; if this OpenCloud instance already held files, they are not in it yet, index them by running: opencloud search index --all-spaces --force-rescan --insecure")
 }


### PR DESCRIPTION
during the testing https://github.com/opencloud-eu/opencloud/pull/3197 I noticed that
```
$ opencloud search index --all-spaces --force-rescan
rpc error: code = Unavailable desc = connection error: desc = "transport: authentication handshake failed: tls: first record does not look like a TLS handshake"
```

after added `--insecure` works fine:

```
~ $ opencloud search index --all-spaces --force-rescan --insecure
[1/7] indexed space 7230b71a-5362-486c-8f35-414d443b638b$dc67b41d-fbb3-4c52-b4d7-59a0774d0ce5!dc67b41d-fbb3-4c52-b4d7-59a0774d0ce5 in 10.579733921s
[2/7] indexed space 7230b71a-5362-486c-8f35-414d443b638b$c3919acb-aa79-4d1e-aa56-2d48cb36c891!c3919acb-aa79-4d1e-aa56-2d48cb36c891 in 10.668783838s
[3/7] indexed space 7230b71a-5362-486c-8f35-414d443b638b$b5a2d63c-5223-4263-bb2f-b1efbe500f13!b5a2d63c-5223-4263-bb2f-b1efbe500f13 in 9.702030129s
[4/7] indexed space 7230b71a-5362-486c-8f35-414d443b638b$e8ca4dda-cf6c-437f-b6a8-1e31033b0a0a!e8ca4dda-cf6c-437f-b6a8-1e31033b0a0a in 9.751792088s
[5/7] indexed space 7230b71a-5362-486c-8f35-414d443b638b$9ef27369-04f4-4b34-97fc-ccff31a9985d!9ef27369-04f4-4b34-97fc-ccff31a9985d in 8.726422712s
[6/7] indexed space 7230b71a-5362-486c-8f35-414d443b638b$4702248d-7570-4b77-bedc-0364af8a45b4!4702248d-7570-4b77-bedc-0364af8a45b4 in 9.808745254s
[7/7] indexed space 7230b71a-5362-486c-8f35-414d443b638b$cae518d9-869b-4cd1-8847-2591ab7a4a70!cae518d9-869b-4cd1-8847-2591ab7a4a70 in 1m41.059535047s
```

also added to log: 
`{"level":"info","service":"search","index":"/var/lib/opencloud/search/bleve-v4","time":"2026-09-10T09:08:19Z","line":"github.com/opencloud-eu/opencloud/services/search/pkg/mapping/reconcile.go:43","message":"created a new empty search index; if this OpenCloud instance already held files, they are not in it yet, index them by running: opencloud search index --all-spaces --force-rescan --insecure"}`
