### PR TITLE
api-test: retry token refresh on transient IDP failures

### DIFF
--- a/tests/acceptance/TestHelpers/TokenHelper.php
+++ b/tests/acceptance/TestHelpers/TokenHelper.php
@@ -32,9 +32,35 @@ class TokenHelper {
 	private const LOGON_URL = '/signin/v1/identifier/_/logon';
 	private const REDIRECT_URL = '/oidc-callback.html';
 	private const TOKEN_URL = '/konnect/v1/token';
+	private const TRANSPORT_RETRY_LIMIT = 3;
 
 	// Static cache [username => token_data]
 	private static array $tokenCache = [];
+
+	/**
+	 * Run a token exchange and retry it a few times if it fails with a transport error
+	 *
+	 * @param callable $exchange returns the token data array
+	 *
+	 * @return array
+	 * @throws GuzzleException the last error if every attempt fails
+	 */
+	private static function retryOnTransportError(callable $exchange): array {
+		$attempt = 0;
+		while (true) {
+			try {
+				return $exchange();
+			} catch (GuzzleException $e) {
+				if ($attempt >= self::TRANSPORT_RETRY_LIMIT) {
+					throw $e;
+				}
+				$attempt++;
+				echo "[INFO] token exchange failed with '" . $e->getMessage() .
+					"', retrying ($attempt)...\n";
+				\sleep(1);
+			}
+		}
+	}
 
 	/**
 	 * @return bool
@@ -80,24 +106,35 @@ class TokenHelper {
 				return $cachedToken;
 			}
 
-			$refreshedToken = self::refreshToken($cachedToken['refresh_token'], $baseUrl);
-			$tokenData = [
-				'access_token' => $refreshedToken['access_token'],
-				'refresh_token' => $refreshedToken['refresh_token'],
-				// set expiry to 240 (4 minutes) seconds to allow for some buffer
-				// token actually expires in 300 seconds (5 minutes)
-				'expires_at' => time() + 240
-			];
-			self::$tokenCache[$cacheKey] = $tokenData;
-			return $tokenData;
+			try {
+				$refreshedToken = self::retryOnTransportError(
+					fn () => self::refreshToken($cachedToken['refresh_token'], $baseUrl)
+				);
+				$tokenData = [
+					'access_token' => $refreshedToken['access_token'],
+					'refresh_token' => $refreshedToken['refresh_token'],
+					// set expiry to 240 (4 minutes) seconds to allow for some buffer
+					// token actually expires in 300 seconds (5 minutes)
+					'expires_at' => time() + 240
+				];
+				self::$tokenCache[$cacheKey] = $tokenData;
+				return $tokenData;
+			} catch (\Throwable $e) {
+				echo "[INFO] token refresh failed with '" . $e->getMessage() .
+					"', falling back to a full login...\n";
+				unset(self::$tokenCache[$cacheKey]);
+			}
 		}
 
 		// Get new tokens
-		$cookieJar = new CookieJar();
-
-		$continueUrl = self::getAuthorizedEndPoint($username, $password, $baseUrl, $cookieJar);
-		$code = self::getCode($continueUrl, $baseUrl, $cookieJar);
-		$tokens = self::getToken($code, $baseUrl, $cookieJar);
+		$tokens = self::retryOnTransportError(
+			function () use ($username, $password, $baseUrl) {
+				$cookieJar = new CookieJar();
+				$continueUrl = self::getAuthorizedEndPoint($username, $password, $baseUrl, $cookieJar);
+				$code = self::getCode($continueUrl, $baseUrl, $cookieJar);
+				return self::getToken($code, $baseUrl, $cookieJar);
+			}
+		);
 
 		$tokenData = [
 			'access_token' => $tokens['access_token'],

--- a/tests/acceptance/TestHelpers/TokenHelper.php
+++ b/tests/acceptance/TestHelpers/TokenHelper.php
@@ -38,7 +38,8 @@ class TokenHelper {
 	private static array $tokenCache = [];
 
 	/**
-	 * Run a token exchange and retry it a few times if it fails with a transport error
+	 * Run a token exchange and retry it if it fails with a transport error. The
+	 * limit counts retries, the exchange runs at most one time more than that.
 	 *
 	 * @param callable $exchange returns the token data array
 	 *
@@ -51,7 +52,7 @@ class TokenHelper {
 			try {
 				return $exchange();
 			} catch (GuzzleException $e) {
-				if ($attempt == self::TRANSPORT_RETRY_LIMIT) {
+				if ($attempt >= self::TRANSPORT_RETRY_LIMIT) {
 					throw $e;
 				}
 				$attempt++;
@@ -119,7 +120,7 @@ class TokenHelper {
 				];
 				self::$tokenCache[$cacheKey] = $tokenData;
 				return $tokenData;
-			} catch (\Throwable $e) {
+			} catch (\Exception $e) {
 				echo "[INFO] token refresh failed with '" . $e->getMessage() .
 					"', falling back to a full login...\n";
 				unset(self::$tokenCache[$cacheKey]);

--- a/tests/acceptance/TestHelpers/TokenHelper.php
+++ b/tests/acceptance/TestHelpers/TokenHelper.php
@@ -51,7 +51,7 @@ class TokenHelper {
 			try {
 				return $exchange();
 			} catch (GuzzleException $e) {
-				if ($attempt >= self::TRANSPORT_RETRY_LIMIT) {
+				if ($attempt == self::TRANSPORT_RETRY_LIMIT) {
 					throw $e;
 				}
 				$attempt++;


### PR DESCRIPTION
problem: 

```
Failed step: Given these users have been created with default attributes:
        cURL error 18: SSL certificate OpenSSL verify result: self-signed certificate (18) (see https://curl.se/libcurl/c/libcurl-errors.html) for https://opencloud-server:9200/konnect/v1/token (GuzzleHttp\Exception\ResponseTransferException)
      | folder/ | /           |
```

log: 
```
{"level":"error","service":"auth-basic","host.name":"6265023e23a4","pkg":"rgrpc","error":"LDAP Result Code 200 \"Network Error\": dial tcp [::1]:9236: connect: connection refused","time":"2026-09-10T10:18:22Z","message":"could not get ldap Connection"}
{"level":"error","service":"proxy","error":"could not authenticate with username and password user: admin, got code: 15","authenticator":"basic","path":"/graph/v1.0/users/admin","time":"2026-09-10T10:18:22Z","message":"failed to authenticate request"}
```

Solution: 
The admin token is cached ~4 min, so it gets refreshed mid-suite against `konnect/v1/token`. A brief idm/LDAP (:9236) blip in that window kills the refresh (cURL 18 / non-200) and fails the scenario setup.

Fix in TokenHelper: retry token exchange on transport errors (3x, 1s backoff), and on any refresh failure drop the cache and fall back to a full login.