### PR TITLE
fix: make `oidcHTTPClient' in 'proxy' service using proxy env settings

### DIFF
--- a/services/proxy/pkg/command/server.go
+++ b/services/proxy/pkg/command/server.go
@@ -198,7 +198,7 @@ func Server(cfg *config.Config) *cobra.Command {
 
 			gr := runner.NewGroup()
 			{
-				middlewares := loadMiddlewares(logger, cfg, userInfoCache, signingKeyStore, traceProvider, *m, userProvider, publisher, gatewaySelector, serviceSelector)
+				middlewares := loadMiddlewares(logger, cfg, userInfoCache, signingKeyStore, traceProvider, *m, userProvider, publisher, gatewaySelector, serviceSelector, oidcClient, oidcHTTPClient)
 
 				server, err := proxyHTTP.Server(
 					proxyHTTP.Handler(lh.Handler()),
@@ -251,7 +251,8 @@ func loadMiddlewares(logger log.Logger, cfg *config.Config,
 	userInfoCache, signingKeyStore microstore.Store,
 	traceProvider trace.TracerProvider, metrics metrics.Metrics,
 	userProvider backend.UserBackend, publisher events.Publisher,
-	gatewaySelector pool.Selectable[gateway.GatewayAPIClient], serviceSelector selector.Selector) alice.Chain {
+	gatewaySelector pool.Selectable[gateway.GatewayAPIClient], serviceSelector selector.Selector,
+	oidcClient oidc.OIDCClient, oidcHTTPClient *http.Client) alice.Chain {
 
 	rolesClient := settingssvc.NewRoleService("eu.opencloud.api.settings", cfg.GrpcClient)
 	policiesProviderClient := policiessvc.NewPoliciesProviderService("eu.opencloud.api.policies", cfg.GrpcClient)
@@ -274,21 +275,6 @@ func loadMiddlewares(logger log.Logger, cfg *config.Config,
 		)
 	default:
 		logger.Fatal().Msgf("Invalid role assignment driver '%s'", cfg.RoleAssignment.Driver)
-	}
-
-	// Clone the default transport so that the proxy configuration from the
-	// environment (HTTP_PROXY, HTTPS_PROXY, NO_PROXY) is honored when talking
-	// to the IDP. A bare &http.Transport{} leaves Proxy nil and never proxies.
-	oidcTransport := http.DefaultTransport.(*http.Transport).Clone()
-	oidcTransport.TLSClientConfig = &tls.Config{
-		MinVersion:         tls.VersionTLS12,
-		InsecureSkipVerify: cfg.OIDC.Insecure, //nolint:gosec
-	}
-	oidcTransport.DisableKeepAlives = true
-
-	oidcHTTPClient := &http.Client{
-		Transport: oidcTransport,
-		Timeout:   time.Second * 10,
 	}
 
 	var authenticators []middleware.Authenticator
@@ -314,13 +300,7 @@ func loadMiddlewares(logger log.Logger, cfg *config.Config,
 		middleware.HTTPClient(oidcHTTPClient),
 		middleware.OIDCIss(cfg.OIDC.Issuer),
 		middleware.AccessTokenVerifyMethod(cfg.OIDC.AccessTokenVerifyMethod),
-		middleware.OIDCClient(oidc.NewOIDCClient(
-			oidc.WithAccessTokenVerifyMethod(cfg.OIDC.AccessTokenVerifyMethod),
-			oidc.WithLogger(logger),
-			oidc.WithHTTPClient(oidcHTTPClient),
-			oidc.WithOidcIssuer(cfg.OIDC.Issuer),
-			oidc.WithJWKSOptions(cfg.OIDC.JWKS),
-		)),
+		middleware.OIDCClient(oidcClient),
 		middleware.SkipUserInfo(cfg.OIDC.SkipUserInfo),
 	))
 	authenticators = append(authenticators, middleware.PublicShareAuthenticator{

--- a/services/proxy/pkg/command/server.go
+++ b/services/proxy/pkg/command/server.go
@@ -97,15 +97,19 @@ func Server(cfg *config.Config) *cobra.Command {
 				return err
 			}
 
+			// Clone the default transport so that the proxy configuration from the
+			// environment (HTTP_PROXY, HTTPS_PROXY, NO_PROXY) is honored when talking
+			// to the IDP. A bare &http.Transport{} leaves Proxy nil and never proxies.
+			oidcTransport := http.DefaultTransport.(*http.Transport).Clone()
+			oidcTransport.TLSClientConfig = &tls.Config{
+				MinVersion:         tls.VersionTLS12,
+				InsecureSkipVerify: cfg.OIDC.Insecure, //nolint:gosec
+			}
+			oidcTransport.DisableKeepAlives = true
+
 			oidcHTTPClient := &http.Client{
-				Transport: &http.Transport{
-					TLSClientConfig: &tls.Config{
-						MinVersion:         tls.VersionTLS12,
-						InsecureSkipVerify: cfg.OIDC.Insecure, //nolint:gosec
-					},
-					DisableKeepAlives: true,
-				},
-				Timeout: time.Second * 10,
+				Transport: oidcTransport,
+				Timeout:   time.Second * 10,
 			}
 
 			oidcClient := oidc.NewOIDCClient(
@@ -272,15 +276,19 @@ func loadMiddlewares(logger log.Logger, cfg *config.Config,
 		logger.Fatal().Msgf("Invalid role assignment driver '%s'", cfg.RoleAssignment.Driver)
 	}
 
+	// Clone the default transport so that the proxy configuration from the
+	// environment (HTTP_PROXY, HTTPS_PROXY, NO_PROXY) is honored when talking
+	// to the IDP. A bare &http.Transport{} leaves Proxy nil and never proxies.
+	oidcTransport := http.DefaultTransport.(*http.Transport).Clone()
+	oidcTransport.TLSClientConfig = &tls.Config{
+		MinVersion:         tls.VersionTLS12,
+		InsecureSkipVerify: cfg.OIDC.Insecure, //nolint:gosec
+	}
+	oidcTransport.DisableKeepAlives = true
+
 	oidcHTTPClient := &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{
-				MinVersion:         tls.VersionTLS12,
-				InsecureSkipVerify: cfg.OIDC.Insecure, //nolint:gosec
-			},
-			DisableKeepAlives: true,
-		},
-		Timeout: time.Second * 10,
+		Transport: oidcTransport,
+		Timeout:   time.Second * 10,
 	}
 
 	var authenticators []middleware.Authenticator

--- a/services/webfinger/pkg/server/http/server.go
+++ b/services/webfinger/pkg/server/http/server.go
@@ -72,15 +72,19 @@ func Server(opts ...Option) (ohttp.Service, error) {
 		),
 	)
 
+	// Clone the default transport so that the proxy configuration from the
+	// environment (HTTP_PROXY, HTTPS_PROXY, NO_PROXY) is honored when talking
+	// to the IDP. A bare &http.Transport{} leaves Proxy nil and never proxies.
+	oidcTransport := http.DefaultTransport.(*http.Transport).Clone()
+	oidcTransport.TLSClientConfig = &tls.Config{
+		MinVersion:         tls.VersionTLS12,
+		InsecureSkipVerify: options.Config.Insecure, //nolint:gosec
+	}
+	oidcTransport.DisableKeepAlives = true
+
 	var oidcHTTPClient = &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{
-				MinVersion:         tls.VersionTLS12,
-				InsecureSkipVerify: options.Config.Insecure, //nolint:gosec
-			},
-			DisableKeepAlives: true,
-		},
-		Timeout: time.Second * 10,
+		Transport: oidcTransport,
+		Timeout:   time.Second * 10,
 	}
 
 	mux.Use(middleware.OidcAuth(


### PR DESCRIPTION
## Description
This issue is an attempt to fix #3508 by telling the 'oidcHTTPClient` to hour the configured `*_PROXY` environment settings within the `opencloud` container.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/opencloud-eu/opencloud/issues/3508

## Motivation and Context
To have OpenCloud working in case it requires a authenticated forward proxy to reach the internet (or OC's public IP address)

## How Has This Been Tested?
I have built a test container based on the provided fix to check whether the proxy env settings are used.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added
