### PR TITLE
fix(search): normalize KQL path once

### DIFF
--- a/services/search/pkg/opensearch/internal/convert/kql_transpile.go
+++ b/services/search/pkg/opensearch/internal/convert/kql_transpile.go
@@ -119,9 +119,6 @@ func (t kqlOpensearchTranspiler) toBuilder(node ast.Node) (osu.Builder, error) {
 		}
 
 		field, value := node.Key, node.Value
-		if query.FieldIsPath(node.Key) {
-			value = strings.TrimSuffix(value, "/")
-		}
 		if node.CaseInsensitive {
 			field += mapping.LowercaseSuffix
 			value = strings.ToLower(value)

--- a/services/search/pkg/parity/README.md
+++ b/services/search/pkg/parity/README.md
@@ -250,6 +250,8 @@ Fixtures:
 | PATH-06 | `path:"./DOCUMENTS"` | docs-upper | docs-upper | docs-upper | ✅ |
 | PATH-07 | `path:"./Documents"` | docs-mixed | docs-mixed | docs-mixed | ✅ |
 | PATH-08 | `path:"./parent/"` | child.jpg, parent | child.jpg, parent | child.jpg, parent | ✅ |
+| PATH-09 | `path:"/"` | child.jpg, docs-lower, docs-mixed, docs-upper, parent | child.jpg, docs-lower, docs-mixed, docs-upper, parent | child.jpg, docs-lower, docs-mixed, docs-upper, parent | ✅ |
+| PATH-10 | `path:""` | child.jpg, docs-lower, docs-mixed, docs-upper, parent | child.jpg, docs-lower, docs-mixed, docs-upper, parent | child.jpg, docs-lower, docs-mixed, docs-upper, parent | ✅ |
 
 ### fields
 

--- a/services/search/pkg/parity/query_path_test.go
+++ b/services/search/pkg/parity/query_path_test.go
@@ -23,6 +23,8 @@ func pathGroup() queryGroup {
 			{id: 6, query: `path:"./DOCUMENTS"`, want: []string{"docs-upper"}},
 			{id: 7, query: `path:"./Documents"`, want: []string{"docs-mixed"}},
 			{id: 8, query: `path:"./parent/"`, want: []string{"parent", "child.jpg"}},
+			{id: 9, query: `path:"/"`, want: []string{"parent", "child.jpg", "docs-lower", "docs-upper", "docs-mixed"}},
+			{id: 10, query: `path:""`, want: []string{"parent", "child.jpg", "docs-lower", "docs-upper", "docs-mixed"}},
 		},
 	}
 }

--- a/services/search/pkg/query/bleve/compiler.go
+++ b/services/search/pkg/query/bleve/compiler.go
@@ -95,9 +95,6 @@ func walk(offset int, nodes []ast.Node) (bleveQuery.Query, int, error) {
 			// bleve treats `/` and `+` as literals mid-term, so a literal MIME like
 			// image/svg+xml still matches exactly.
 			val := n.Value
-			if searchQuery.FieldIsPath(n.Key) {
-				val = strings.TrimSuffix(val, "/")
-			}
 			k := n.Key
 			v := val
 			if k != "ID" && k != "Size" && k != "MimeType" {

--- a/services/search/pkg/query/normalize.go
+++ b/services/search/pkg/query/normalize.go
@@ -36,6 +36,12 @@ func normalizeNodes(nodes []ast.Node, resolve func(string) string, defaultKey st
 		switch node := n.(type) {
 		case *ast.StringNode:
 			node.Key = resolveKey(node.Key)
+			if FieldIsPath(node.Key) {
+				node.Value = strings.TrimSuffix(node.Value, "/")
+				if node.Value == "" {
+					node.Value = "."
+				}
+			}
 			if FieldValueIsNormalized(node.Key) {
 				node.Value = strings.ToLower(node.Value)
 			}


### PR DESCRIPTION
## Description

The trailing slash of a KQL `path:` value was trimmed in the bleve compiler and again in the OpenSearch transpiler. The normalizer now trims it once for both engines. An empty value, `path:"/"`, was a term query on the empty string and matched nothing; it now means the space root, consistent with the scope handling.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)